### PR TITLE
Formatting code with new code standard

### DIFF
--- a/examples/heat-eqn/include/ConvectiveHeatFluxConstBC.h
+++ b/examples/heat-eqn/include/ConvectiveHeatFluxConstBC.h
@@ -8,12 +8,12 @@ class ConvectiveHeatFluxConstBC : public NaturalBC {
 public:
     ConvectiveHeatFluxConstBC(const InputParameters & params);
 
-    virtual PetscInt getFieldId() const;
-    virtual PetscInt getNumComponents() const;
-    virtual std::vector<PetscInt> getComponents() const;
+    virtual PetscInt get_field_id() const;
+    virtual PetscInt get_num_components() const;
+    virtual std::vector<PetscInt> get_components() const;
 
 protected:
-    virtual void onSetWeakForm();
+    virtual void on_set_weak_form();
 
     /// Convective heat transfer coefficient
     const PetscReal & htc;
@@ -22,7 +22,7 @@ protected:
     const PetscReal & T_infinity;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/examples/heat-eqn/include/HeatEquationProblem.h
+++ b/examples/heat-eqn/include/HeatEquationProblem.h
@@ -12,12 +12,12 @@ public:
     virtual ~HeatEquationProblem();
 
 protected:
-    virtual void onSetFields() override;
-    virtual void onSetWeakForm() override;
+    virtual void on_set_fields() override;
+    virtual void on_set_weak_form() override;
 
     /// ID for the 'temperature' field
     const PetscInt itemp;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };

--- a/examples/heat-eqn/src/ConvectiveHeatFluxConstBC.cpp
+++ b/examples/heat-eqn/src/ConvectiveHeatFluxConstBC.cpp
@@ -59,47 +59,51 @@ __g0_convective_heat_flux_const_bc(PetscInt dim,
 }
 
 InputParameters
-ConvectiveHeatFluxConstBC::validParams()
+ConvectiveHeatFluxConstBC::valid_params()
 {
-    InputParameters params = NaturalBC::validParams();
-    params.addRequiredParam<PetscReal>("htc", "Convective heat transfer coefficient");
-    params.addRequiredParam<PetscReal>("T_infinity", "Ambient temperature");
+    InputParameters params = NaturalBC::valid_params();
+    params.add_required_param<PetscReal>("htc", "Convective heat transfer coefficient");
+    params.add_required_param<PetscReal>("T_infinity", "Ambient temperature");
     return params;
 }
 
 ConvectiveHeatFluxConstBC::ConvectiveHeatFluxConstBC(const InputParameters & params) :
     NaturalBC(params),
-    htc(getParam<PetscReal>("htc")),
-    T_infinity(getParam<PetscReal>("T_infinity"))
+    htc(get_param<PetscReal>("htc")),
+    T_infinity(get_param<PetscReal>("T_infinity"))
 {
     _F_;
 }
 
 PetscInt
-ConvectiveHeatFluxConstBC::getFieldId() const
+ConvectiveHeatFluxConstBC::get_field_id() const
 {
     return 0;
 }
 
 PetscInt
-ConvectiveHeatFluxConstBC::getNumComponents() const
+ConvectiveHeatFluxConstBC::get_num_components() const
 {
     return 1;
 }
 
 std::vector<PetscInt>
-ConvectiveHeatFluxConstBC::getComponents() const
+ConvectiveHeatFluxConstBC::get_components() const
 {
     std::vector<PetscInt> comps = { 0 };
     return comps;
 }
 
 void
-ConvectiveHeatFluxConstBC::onSetWeakForm()
+ConvectiveHeatFluxConstBC::on_set_weak_form()
 {
     _F_;
-    setResidualBlock(__f0_convective_heat_flux_const_bc, nullptr);
-    setJacobianBlock(getFieldId(), __g0_convective_heat_flux_const_bc, nullptr, nullptr, nullptr);
+    set_residual_block(__f0_convective_heat_flux_const_bc, nullptr);
+    set_jacobian_block(get_field_id(),
+                       __g0_convective_heat_flux_const_bc,
+                       nullptr,
+                       nullptr,
+                       nullptr);
 }
 
 } // namespace godzilla

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -104,9 +104,9 @@ g0_temp(PetscInt dim,
 }
 
 InputParameters
-HeatEquationProblem::validParams()
+HeatEquationProblem::valid_params()
 {
-    InputParameters params = ImplicitFENonlinearProblem::validParams();
+    InputParameters params = ImplicitFENonlinearProblem::valid_params();
     return params;
 }
 
@@ -120,17 +120,17 @@ HeatEquationProblem::HeatEquationProblem(const InputParameters & parameters) :
 HeatEquationProblem::~HeatEquationProblem() {}
 
 void
-HeatEquationProblem::onSetFields()
+HeatEquationProblem::on_set_fields()
 {
     _F_;
     PetscInt order = 1;
-    addFE(this->itemp, "temp", 1, order);
+    add_fe(this->itemp, "temp", 1, order);
 }
 
 void
-HeatEquationProblem::onSetWeakForm()
+HeatEquationProblem::on_set_weak_form()
 {
     _F_;
-    setResidualBlock(this->itemp, f0_temp, f1_temp);
-    setJacobianBlock(this->itemp, this->itemp, g0_temp, NULL, NULL, g3_temp);
+    set_residual_block(this->itemp, f0_temp, f1_temp);
+    set_jacobian_block(this->itemp, this->itemp, g0_temp, NULL, NULL, g3_temp);
 }

--- a/examples/heat-eqn/src/main.cpp
+++ b/examples/heat-eqn/src/main.cpp
@@ -8,7 +8,7 @@ main(int argc, char * argv[])
     godzilla::Init init(argc, argv, comm);
 
     godzilla::App app("heat-eqn", comm);
-    app.parseCommandLine(argc, argv);
+    app.parse_command_line(argc, argv);
     app.run();
 
     return 0;

--- a/examples/poisson/include/PoissonEquation.h
+++ b/examples/poisson/include/PoissonEquation.h
@@ -12,8 +12,8 @@ public:
     virtual ~PoissonEquation();
 
 protected:
-    virtual void onSetFields() override;
-    virtual void onSetWeakForm() override;
+    virtual void on_set_fields() override;
+    virtual void on_set_weak_form() override;
 
     /// Polynomial order of the FE space
     PetscInt p_order;
@@ -25,5 +25,5 @@ protected:
     const PetscInt affn;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };

--- a/examples/poisson/src/PoissonEquation.cpp
+++ b/examples/poisson/src/PoissonEquation.cpp
@@ -86,16 +86,16 @@ g3_uu(PetscInt dim,
 ///
 
 InputParameters
-PoissonEquation::validParams()
+PoissonEquation::valid_params()
 {
-    InputParameters params = FENonlinearProblem::validParams();
-    params.addParam<PetscInt>("p_order", 1., "Polynomial order of the FE space.");
+    InputParameters params = FENonlinearProblem::valid_params();
+    params.add_param<PetscInt>("p_order", 1., "Polynomial order of the FE space.");
     return params;
 }
 
 PoissonEquation::PoissonEquation(const InputParameters & parameters) :
     FENonlinearProblem(parameters),
-    p_order(getParam<PetscInt>("p_order")),
+    p_order(get_param<PetscInt>("p_order")),
     iu(0),
     affn(0)
 {
@@ -105,17 +105,17 @@ PoissonEquation::PoissonEquation(const InputParameters & parameters) :
 PoissonEquation::~PoissonEquation() {}
 
 void
-PoissonEquation::onSetFields()
+PoissonEquation::on_set_fields()
 {
     _F_;
-    addFE(this->iu, "u", 1, this->p_order);
-    addAuxFE(this->affn, "forcing_fn", 1, this->p_order);
+    add_fe(this->iu, "u", 1, this->p_order);
+    add_aux_fe(this->affn, "forcing_fn", 1, this->p_order);
 }
 
 void
-PoissonEquation::onSetWeakForm()
+PoissonEquation::on_set_weak_form()
 {
     _F_;
-    setResidualBlock(this->iu, f0_u, f1_u);
-    setJacobianBlock(this->iu, this->iu, NULL, NULL, NULL, g3_uu);
+    set_residual_block(this->iu, f0_u, f1_u);
+    set_jacobian_block(this->iu, this->iu, NULL, NULL, NULL, g3_uu);
 }

--- a/examples/poisson/src/main.cpp
+++ b/examples/poisson/src/main.cpp
@@ -8,7 +8,7 @@ main(int argc, char * argv[])
     godzilla::Init init(argc, argv, comm);
 
     godzilla::App app("poisson", comm);
-    app.parseCommandLine(argc, argv);
+    app.parse_command_line(argc, argv);
     app.run();
 
     return 0;

--- a/include/App.h
+++ b/include/App.h
@@ -21,16 +21,16 @@ public:
     App(const std::string & app_name, MPI_Comm comm);
     virtual ~App();
 
-    const Logger & getLogger() const;
+    const Logger & get_logger() const;
 
     /// @return Get problem this application is representing
-    virtual Problem * getProblem() const;
+    virtual Problem * get_problem() const;
 
     /// Parse command line arguments
     ///
     /// @param argc Number of command line arguments
     /// @param argv Command line argumnts
-    virtual void parseCommandLine(int argc, char * argv[]);
+    virtual void parse_command_line(int argc, char * argv[]);
 
     /// Run the application
     ///
@@ -40,22 +40,22 @@ public:
     /// Get level of verbosity
     ///
     /// @return The verbosity level
-    virtual const unsigned int & getVerbosityLevel() const;
+    virtual const unsigned int & get_verbosity_level() const;
 
     /// Get MPI communicator
     ///
     /// @return MPI communicator
-    virtual const MPI_Comm & getComm() const;
+    virtual const MPI_Comm & get_comm() const;
 
     /// Get communicator rank
     ///
     /// @return The rank of the calling process in the application communicator
-    virtual const PetscMPIInt & getCommRank() const;
+    virtual const PetscMPIInt & get_comm_rank() const;
 
     /// Get communicator size
     ///
     /// @return Size of the group associated with the application communicator
-    virtual const PetscMPIInt & getCommSize() const;
+    virtual const PetscMPIInt & get_comm_size() const;
 
     /// Build object using the Factory
     ///
@@ -67,14 +67,14 @@ public:
     /// @param parameters Input parameters
     /// @return The constructed object
     template <typename T>
-    T * buildObject(const std::string & class_name,
-                    const std::string & name,
-                    InputParameters & parameters);
+    T * build_object(const std::string & class_name,
+                     const std::string & name,
+                     InputParameters & parameters);
 
     template <typename T>
-    T * buildObject(const std::string & class_name,
-                    const std::string & name,
-                    InputParameters * parameters);
+    T * build_object(const std::string & class_name,
+                     const std::string & name,
+                     InputParameters * parameters);
 
 protected:
     /// Create method can be used to additional object allocation, etc. needed before the
@@ -84,20 +84,20 @@ protected:
     /// Build application objects from a GYML file
     ///
     /// @param file_name The GYML file name
-    virtual void buildFromGYML(const std::string & file_name);
+    virtual void build_from_gyml(const std::string & file_name);
 
     /// Check integrity of the application
-    virtual void checkIntegrity();
+    virtual void check_integrity();
 
     /// Run the input file
     ///
     /// This is the method that will be called wehn user specify -i command line parameter
     ///
     /// @param file_name The name of the file specified via `-i` parameter
-    virtual void runInputFile(const std::string & file_name);
+    virtual void run_input_file(const std::string & file_name);
 
-    /// Run the problem build via `buildFromGYML`
-    virtual void runProblem();
+    /// Run the problem build via `build_from_gyml`
+    virtual void run_problem();
 
     /// MPI communicators
     MPI_Comm comm;
@@ -132,9 +132,9 @@ protected:
 
 template <typename T>
 T *
-App::buildObject(const std::string & class_name,
-                 const std::string & name,
-                 InputParameters & parameters)
+App::build_object(const std::string & class_name,
+                  const std::string & name,
+                  InputParameters & parameters)
 {
     parameters.set<const App *>("_app") = this;
     return Factory::create<T>(class_name, name, parameters);
@@ -142,9 +142,9 @@ App::buildObject(const std::string & class_name,
 
 template <typename T>
 T *
-App::buildObject(const std::string & class_name,
-                 const std::string & name,
-                 InputParameters * parameters)
+App::build_object(const std::string & class_name,
+                  const std::string & name,
+                  InputParameters * parameters)
 {
     parameters->set<const App *>("_app") = this;
     return Factory::create<T>(class_name, name, parameters);

--- a/include/AuxiliaryField.h
+++ b/include/AuxiliaryField.h
@@ -19,17 +19,17 @@ public:
     ///
     /// @param dm The main DM
     /// @param dm_aux DM for the auxiliary fields
-    virtual void setUp(DM dm, DM dm_aux) = 0;
+    virtual void set_up(DM dm, DM dm_aux) = 0;
 
     /// Get the ID of the field this boundary condition operates on
     ///
     /// @return ID of the field
-    virtual PetscInt getFieldId() const;
+    virtual PetscInt get_field_id() const;
 
     /// Get the number of constrained components
     ///
     /// @return The number of constrained components
-    virtual PetscInt getNumComponents() const = 0;
+    virtual PetscInt get_num_components() const = 0;
 
 protected:
     /// FE problem this object is part of
@@ -42,7 +42,7 @@ protected:
     DMLabel block;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/BoundaryCondition.h
+++ b/include/BoundaryCondition.h
@@ -15,36 +15,36 @@ public:
     /// Get the boundary name this BC is active on
     ///
     /// @return The boundary name
-    virtual const std::string & getBoundary() const;
+    virtual const std::string & get_boundary() const;
 
     /// Get the ID of the field this boundary condition operates on
     ///
     /// @return ID of the field
-    virtual PetscInt getFieldId() const = 0;
+    virtual PetscInt get_field_id() const = 0;
 
     /// Get the number of constrained components
     ///
     /// @return The number of constrained components
-    virtual PetscInt getNumComponents() const = 0;
+    virtual PetscInt get_num_components() const = 0;
 
     /// Get the type of this boundary condition
     ///
     /// @return Type of boundary condition
-    virtual DMBoundaryConditionType getBcType() const = 0;
+    virtual DMBoundaryConditionType get_bc_type() const = 0;
 
     /// Get the component numbers this boundary condition is constraining
     ///
     /// @return Vector of component numbers
-    virtual std::vector<PetscInt> getComponents() const = 0;
+    virtual std::vector<PetscInt> get_components() const = 0;
 
     /// Set up this boundary condition
     ///
     /// @param dm DM of problem (should have PetscDS)
-    virtual void setUp(DM dm);
+    virtual void set_up(DM dm);
 
 protected:
     /// Set up the PETSc callback
-    virtual void setUpCallback() = 0;
+    virtual void set_up_callback() = 0;
 
     /// DM object
     DM dm;
@@ -66,7 +66,7 @@ protected:
 
 public:
     /// Method for building InputParameters for this class
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/BoxMesh.h
+++ b/include/BoxMesh.h
@@ -12,34 +12,34 @@ public:
     BoxMesh(const InputParameters & parameters);
 
     /// Get lower limit in x-direction
-    PetscInt getXMin() const;
+    PetscInt get_x_min() const;
 
     /// Get upper limit in x-direction
-    PetscInt getXMax() const;
+    PetscInt get_x_max() const;
 
     /// Get the number of mesh points in x direction
-    PetscInt getNx() const;
+    PetscInt get_nx() const;
 
     /// Get lower limit in y-direction
-    PetscInt getYMin() const;
+    PetscInt get_y_min() const;
 
     /// Get upper limit in y-direction
-    PetscInt getYMax() const;
+    PetscInt get_y_max() const;
 
     /// Get the number of mesh points in y-direction
-    PetscInt getNy() const;
+    PetscInt get_ny() const;
 
     /// Get lower limit in z-direction
-    PetscInt getZMin() const;
+    PetscInt get_z_min() const;
 
     /// Get upper limit in z-direction
-    PetscInt getZMax() const;
+    PetscInt get_z_max() const;
 
     /// Get the number of mesh points in z direction
-    PetscInt getNz() const;
+    PetscInt get_nz() const;
 
 protected:
-    virtual void createDM() override;
+    virtual void create_dm() override;
 
     /// Minimum in the x direction
     const PetscReal & xmin;
@@ -76,7 +76,7 @@ protected:
 
 public:
     /// Method for building InputParameters for this class
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/CallStack.h
+++ b/include/CallStack.h
@@ -67,7 +67,7 @@ public:
 /// Get the call stack object
 ///
 /// @return Call stack object
-CallStack & getCallstack();
+CallStack & get_callstack();
 
 } // namespace internal
 } // namespace godzilla

--- a/include/ConstantIC.h
+++ b/include/ConstantIC.h
@@ -14,7 +14,7 @@ class ConstantIC : public InitialCondition {
 public:
     ConstantIC(const InputParameters & params);
 
-    virtual PetscInt getNumComponents() const override;
+    virtual PetscInt get_num_components() const override;
 
 protected:
     virtual void evaluate(PetscInt dim,
@@ -27,7 +27,7 @@ protected:
     const std::vector<PetscReal> & values;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/DirichletBC.h
+++ b/include/DirichletBC.h
@@ -13,14 +13,14 @@ public:
     DirichletBC(const InputParameters & params);
 
     virtual void create();
-    virtual PetscInt getFieldId() const;
-    virtual PetscInt getNumComponents() const;
-    virtual std::vector<PetscInt> getComponents() const;
+    virtual PetscInt get_field_id() const;
+    virtual PetscInt get_num_components() const;
+    virtual std::vector<PetscInt> get_components() const;
     virtual void
     evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nc, PetscScalar u[]);
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/Error.h
+++ b/include/Error.h
@@ -11,27 +11,27 @@ namespace internal {
 
 /// All of the following are not meant to be called directly - they are called by the normal macros
 /// (godzillaError(), etc.) down below
-void godzillaStreamAll(std::ostringstream & ss);
+void godzilla_stream_all(std::ostringstream & ss);
 
 template <typename T, typename... Args>
 void
-godzillaStreamAll(std::ostringstream & ss, T && val, Args &&... args)
+godzilla_stream_all(std::ostringstream & ss, T && val, Args &&... args)
 {
     ss << val;
-    godzillaStreamAll(ss, std::forward<Args>(args)...);
+    godzilla_stream_all(ss, std::forward<Args>(args)...);
 }
 
-void godzillaMsgRaw(const std::string & msg);
+void godzilla_msg_raw(const std::string & msg);
 
 std::string
-godzillaMsgFmt(const std::string & msg, const std::string & title, const std::string & color);
+godzilla_msg_fmt(const std::string & msg, const std::string & title, const std::string & color);
 
-void godzillaErrorRaw(std::string msg, bool call_stack = false);
+void godzilla_error_raw(std::string msg, bool call_stack = false);
 
 /// Terminate the run
 [[noreturn]] void terminate(int status = 1);
 
-void memCheck(int line, const char * func, const char * file, void * var);
+void mem_check(int line, const char * func, const char * file, void * var);
 
 } // namespace internal
 
@@ -40,18 +40,18 @@ template <typename... Args>
 error(Args &&... args)
 {
     std::ostringstream oss;
-    internal::godzillaStreamAll(oss, std::forward<Args>(args)...);
-    internal::godzillaErrorRaw(oss.str());
+    internal::godzilla_stream_all(oss, std::forward<Args>(args)...);
+    internal::godzilla_error_raw(oss.str());
     internal::terminate();
 }
 
 /// Check PETSc error
 ///
 /// @param ierr Error code returned by PETSc
-void checkPetscError(PetscErrorCode ierr);
+void check_petsc_error(PetscErrorCode ierr);
 
 /// Check that memory allocation was ok. If not, report an error (also dump call stack) and
 /// terminate
-#define MEM_CHECK(var) godzilla::internal::memCheck(__LINE__, __PRETTY_FUNCTION__, __FILE__, var)
+#define MEM_CHECK(var) godzilla::internal::mem_check(__LINE__, __PRETTY_FUNCTION__, __FILE__, var)
 
 } // namespace godzilla

--- a/include/EssentialBC.h
+++ b/include/EssentialBC.h
@@ -10,7 +10,7 @@ class EssentialBC : public BoundaryCondition {
 public:
     EssentialBC(const InputParameters & params);
 
-    virtual DMBoundaryConditionType getBcType() const override;
+    virtual DMBoundaryConditionType get_bc_type() const override;
 
     /// Evaluate the boundary condition
     ///
@@ -23,10 +23,10 @@ public:
     evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nc, PetscScalar u[]) = 0;
 
 protected:
-    virtual void setUpCallback() override;
+    virtual void set_up_callback() override;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/ExodusIIMesh.h
+++ b/include/ExodusIIMesh.h
@@ -10,10 +10,10 @@ class ExodusIIMesh : public UnstructuredMesh {
 public:
     ExodusIIMesh(const InputParameters & parameters);
 
-    const std::string getFileName() const;
+    const std::string get_file_name() const;
 
 protected:
-    virtual void createDM() override;
+    virtual void create_dm() override;
 
     /// File name with the ExodusII mesh
     const std::string & file_name;
@@ -21,7 +21,7 @@ protected:
     const PetscBool interpolate;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/ExodusIIOutput.h
+++ b/include/ExodusIIOutput.h
@@ -23,17 +23,17 @@ class ExodusIIOutput : public FileOutput {
 public:
     ExodusIIOutput(const InputParameters & params);
 
-    virtual std::string getFileExt() const override;
+    virtual std::string get_file_ext() const override;
     virtual void create() override;
     virtual void check() override;
-    virtual void outputStep(PetscInt stepi, DM dm, Vec vec) override;
+    virtual void output_step(PetscInt stepi, DM dm, Vec vec) override;
 
 protected:
     /// Create "Cell Sets" label if it does not exist
-    void createCellSets();
+    void create_cell_sets();
 
     /// Write variable info into the ExodusII file
-    void writeVariableInfo(int exoid, Vec vec);
+    void write_variable_info(int exoid, Vec vec);
 
     /// FE problem interface (convenience pointer)
     const FEProblemInterface * fepi;
@@ -43,7 +43,7 @@ protected:
     int file_seq_no;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/FENonlinearProblem.h
+++ b/include/FENonlinearProblem.h
@@ -17,13 +17,13 @@ public:
 
 protected:
     virtual void init() override;
-    virtual void setUpCallbacks() override;
-    virtual void setUpInitialGuess() override;
-    virtual PetscErrorCode computeResidualCallback(Vec x, Vec f) override;
-    virtual PetscErrorCode computeJacobianCallback(Vec x, Mat J, Mat Jp) override;
+    virtual void set_up_callbacks() override;
+    virtual void set_up_initial_guess() override;
+    virtual PetscErrorCode compute_residual_callback(Vec x, Vec f) override;
+    virtual PetscErrorCode compute_jacobian_callback(Vec x, Mat J, Mat Jp) override;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -26,49 +26,49 @@ public:
     /// Get field name
     ///
     /// @param fid Field ID
-    virtual const std::string & getFieldName(PetscInt fid) const;
+    virtual const std::string & get_field_name(PetscInt fid) const;
 
     /// Get field ID
     ///
     /// @param name Field name
     /// @param Field ID
-    virtual PetscInt getFieldId(const std::string & name) const;
+    virtual PetscInt get_field_id(const std::string & name) const;
 
     /// Do we have field with specified ID
     ///
     /// @param fid The ID of the field
     /// @return True if the field exists, otherwise False
-    virtual bool hasFieldById(PetscInt fid) const;
+    virtual bool has_field_by_id(PetscInt fid) const;
 
     /// Do we have field with specified name
     ///
     /// @param name The name of the field
     /// @return True if the field exists, otherwise False
-    virtual bool hasFieldByName(const std::string & name) const;
+    virtual bool has_field_by_name(const std::string & name) const;
 
     /// Get auxiliary field name
     ///
     /// @param fid Auxiliary field ID
     /// @return Auxiliary field name
-    virtual const std::string & getAuxFieldName(PetscInt fid) const;
+    virtual const std::string & get_aux_field_name(PetscInt fid) const;
 
     /// Get auxiliary field ID
     ///
     /// @param name Auxiliary field name
     /// @param Auxiliary field ID
-    virtual PetscInt getAuxFieldId(const std::string & name) const;
+    virtual PetscInt get_aux_field_id(const std::string & name) const;
 
     /// Do we have auxiliary field with specified ID
     ///
     /// @param fid The ID of the auxiliary field
     /// @return True if the auxiliary field exists, otherwise False
-    virtual bool hasAuxFieldById(PetscInt fid) const;
+    virtual bool has_aux_field_by_id(PetscInt fid) const;
 
     /// Do we have auxiliary field with specified name
     ///
     /// @param name The name of the auxiliary field
     /// @return True if the auxiliary field exists, otherwise False
-    virtual bool hasAuxFieldByName(const std::string & name) const;
+    virtual bool has_aux_field_by_name(const std::string & name) const;
 
     /// Adds a volumetric field
     ///
@@ -76,7 +76,7 @@ public:
     /// @param name The name of the field
     /// @param nc The number of components
     /// @param k The degree k of the space
-    virtual void addFE(PetscInt id, const std::string & name, PetscInt nc, PetscInt k);
+    virtual void add_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k);
 
     /// Adds a volumetric auxiliary field
     ///
@@ -84,33 +84,33 @@ public:
     /// @param name The name of the field
     /// @param nc The number of components
     /// @param k The degree k of the space
-    virtual void addAuxFE(PetscInt id, const std::string & name, PetscInt nc, PetscInt k);
+    virtual void add_aux_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k);
 
     /// Set problem constants
     ///
     /// These constants will be available in the weak form via `constants` parameter.
     /// @param consts Constants to add to the problem
-    virtual void setConstants(const std::vector<PetscReal> & consts);
+    virtual void set_constants(const std::vector<PetscReal> & consts);
 
     /// Add initial condition
     ///
     /// @param ic Initial condition object to add
-    virtual void addInitialCondition(InitialCondition * ic);
+    virtual void add_initial_condition(InitialCondition * ic);
 
     /// Add essential boundary condition
     ///
     /// @param bc Boundary condition object to add
-    virtual void addBoundaryCondition(BoundaryCondition * bc);
+    virtual void add_boundary_condition(BoundaryCondition * bc);
 
     /// Add auxiliary field
     ///
     /// @param aux Auxiliary field object to add
-    virtual void addAuxiliaryField(AuxiliaryField * aux);
+    virtual void add_auxiliary_field(AuxiliaryField * aux);
 
     /// Get the simulation time (the time is pulled from the linked Problem class)
     ///
     /// @return The simulation time
-    virtual const PetscReal & getTime() const;
+    virtual const PetscReal & get_time() const;
 
 protected:
     /// Initialize the FE system
@@ -118,7 +118,7 @@ protected:
 
     virtual void create(DM dm);
 
-    virtual void setUpInitialGuess(DM dm, Vec x);
+    virtual void set_up_initial_guess(DM dm, Vec x);
 
     typedef void PetscFEResidualFunc(PetscInt dim,
                                      PetscInt Nf,
@@ -160,17 +160,17 @@ protected:
                                      PetscScalar g3[]);
 
     /// Set up finite element objects
-    void setUpFEs(DM dm);
+    void set_up_fes(DM dm);
 
     /// Inform PETSc to about all fields in this problem
-    void setUpProblem(DM dm);
+    void set_up_problem(DM dm);
 
     /// Set up residual statement for a field variable
     ///
     /// @param fid Field ID
     /// @param f0 Integrand for the test function term
     /// @param f1 Integrand for the test function gradient term
-    void setResidualBlock(PetscInt fid, PetscFEResidualFunc * f0, PetscFEResidualFunc * f1);
+    void set_residual_block(PetscInt fid, PetscFEResidualFunc * f0, PetscFEResidualFunc * f1);
 
     /// Set up residual statement for a field variable
     ///
@@ -180,28 +180,28 @@ protected:
     /// @param g1 Integrand for the test function and basis function gradient term
     /// @param g2 Integrand for the test function gradient and basis function term
     /// @param g3 Integrand for the test function gradient and basis function gradient term
-    void setJacobianBlock(PetscInt fid,
-                          PetscInt gid,
-                          PetscFEJacobianFunc * g0,
-                          PetscFEJacobianFunc * g1,
-                          PetscFEJacobianFunc * g2,
-                          PetscFEJacobianFunc * g3);
+    void set_jacobian_block(PetscInt fid,
+                            PetscInt gid,
+                            PetscFEJacobianFunc * g0,
+                            PetscFEJacobianFunc * g1,
+                            PetscFEJacobianFunc * g2,
+                            PetscFEJacobianFunc * g3);
 
     /// Set up boundary conditions
-    virtual void setUpBoundaryConditions(DM dm);
+    virtual void set_up_boundary_conditions(DM dm);
 
     /// Set up auxiliary DM
-    virtual void setUpAuxiliaryDM(DM dm);
+    virtual void set_up_auxiliary_dm(DM dm);
 
     /// Set up constants
-    void setUpConstants();
+    void set_up_constants();
 
     /// Set up field variables
-    virtual void onSetFields() = 0;
+    virtual void on_set_fields() = 0;
 
     /// Setup volumetric weak form terms
     /// FIXME: This needs a better name
-    virtual void onSetWeakForm() = 0;
+    virtual void on_set_weak_form() = 0;
 
     /// Reference to the the problem this interface is part of
     Problem & problem;

--- a/include/Factory.h
+++ b/include/Factory.h
@@ -34,7 +34,7 @@ build_obj(const InputParameters & parameters)
 
 template <typename T>
 auto
-call_valid_params() -> decltype(T::valid_params(), emptyInputParameters())
+call_valid_params() -> decltype(T::valid_params(), InputParameters())
 {
     return T::valid_params();
 }

--- a/include/Factory.h
+++ b/include/Factory.h
@@ -27,16 +27,16 @@ using BuildPtr = ObjectPtr (*)(const InputParameters & parameters);
 
 template <typename T>
 ObjectPtr
-buildObj(const InputParameters & parameters)
+build_obj(const InputParameters & parameters)
 {
     return new T(parameters);
 }
 
 template <typename T>
 auto
-callValidParams() -> decltype(T::validParams(), emptyInputParameters())
+call_valid_params() -> decltype(T::valid_params(), emptyInputParameters())
 {
-    return T::validParams();
+    return T::valid_params();
 }
 
 class InputParameters;
@@ -57,8 +57,8 @@ public:
     reg(const std::string & class_name)
     {
         Entry entry;
-        entry.build_ptr = &buildObj<T>;
-        entry.params_ptr = &callValidParams<T>;
+        entry.build_ptr = &build_obj<T>;
+        entry.params_ptr = &call_valid_params<T>;
         classes[class_name] = entry;
         return '\0';
     }
@@ -67,11 +67,11 @@ public:
     /// @param class_name Name of the object whose parameter we are requesting
     /// @return Parameters of the object
     static InputParameters *
-    getValidParams(const std::string & class_name)
+    get_valid_params(const std::string & class_name)
     {
         auto it = classes.find(class_name);
         if (it == classes.end())
-            error("Getting validParams for object '",
+            error("Getting valid_params for object '",
                   class_name,
                   "' failed.  Object is not registred.");
 
@@ -114,7 +114,7 @@ public:
     }
 
     static bool
-    isRegistered(const std::string & class_name)
+    is_registered(const std::string & class_name)
     {
         auto it = classes.find(class_name);
         return it != classes.end();

--- a/include/FileOutput.h
+++ b/include/FileOutput.h
@@ -15,24 +15,24 @@ public:
     /// Get the file name with the output file produced by this outputter
     ///
     /// @return The file name with the output
-    virtual const std::string & getFileName() const;
+    virtual const std::string & get_file_name() const;
 
     /// Set the file name for single output
-    virtual void setFileName();
+    virtual void set_file_name();
 
     /// Set the file name for a sequence of outputs
     ///
     /// @param stepi Step number
-    virtual void setSequenceFileName(unsigned int stepi);
+    virtual void set_sequence_file_name(unsigned int stepi);
 
     /// Get file extension
     ///
     /// @return File extension
-    virtual std::string getFileExt() const = 0;
+    virtual std::string get_file_ext() const = 0;
 
-    virtual void outputMesh(DM dm) override;
-    virtual void outputSolution(Vec vec) override;
-    virtual void outputStep(PetscInt stepi, DM dm, Vec vec) override;
+    virtual void output_mesh(DM dm) override;
+    virtual void output_solution(Vec vec) override;
+    virtual void output_step(PetscInt stepi, DM dm, Vec vec) override;
 
 protected:
     /// The file base of the output file
@@ -45,7 +45,7 @@ protected:
     PetscViewer viewer;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/Function.h
+++ b/include/Function.h
@@ -14,10 +14,10 @@ public:
     /// Register this function with the function parser
     ///
     /// @param parser The mu::Parser object we register this function with
-    virtual void registerCallback(mu::Parser & parser) = 0;
+    virtual void register_callback(mu::Parser & parser) = 0;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/FunctionAuxiliaryField.h
+++ b/include/FunctionAuxiliaryField.h
@@ -12,13 +12,13 @@ public:
     FunctionAuxiliaryField(const InputParameters & params);
 
     virtual void create();
-    virtual void setUp(DM dm, DM dm_aux);
-    virtual PetscInt getNumComponents() const;
+    virtual void set_up(DM dm, DM dm_aux);
+    virtual PetscInt get_num_components() const;
     virtual void
     evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc, PetscScalar u[]);
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/FunctionEvaluator.h
+++ b/include/FunctionEvaluator.h
@@ -21,7 +21,7 @@ public:
     /// Register user function with function evaluator
     ///
     /// @param fn Fuction to register
-    void registerFunction(Function * fn);
+    void register_function(Function * fn);
 
     /// Evaluate the function expression at time `time` and spatial position `x`
     ///

--- a/include/FunctionIC.h
+++ b/include/FunctionIC.h
@@ -12,7 +12,7 @@ public:
     FunctionIC(const InputParameters & params);
 
     virtual void create() override;
-    virtual PetscInt getNumComponents() const override;
+    virtual PetscInt get_num_components() const override;
 
 protected:
     virtual void evaluate(PetscInt dim,
@@ -22,7 +22,7 @@ protected:
                           PetscScalar u[]) override;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/FunctionInterface.h
+++ b/include/FunctionInterface.h
@@ -24,7 +24,8 @@ public:
     /// @param dim Spatial dimension of the evaluated function
     /// @param time Time of the time-dependent function
     /// @param x Spatial coordinate where we evaluate the function (has size of `dim`)
-    PetscReal evaluateFunction(unsigned int idx, PetscInt dim, PetscReal time, const PetscReal x[]);
+    PetscReal
+    evaluate_function(unsigned int idx, PetscInt dim, PetscReal time, const PetscReal x[]);
 
 protected:
     /// Reference to the application
@@ -37,7 +38,7 @@ protected:
     std::vector<FunctionEvaluator> evalr;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 /// This is the API that we hand to PETSc for fields.

--- a/include/FunctionInterface.h
+++ b/include/FunctionInterface.h
@@ -24,8 +24,7 @@ public:
     /// @param dim Spatial dimension of the evaluated function
     /// @param time Time of the time-dependent function
     /// @param x Spatial coordinate where we evaluate the function (has size of `dim`)
-    PetscReal
-    evaluate_function(unsigned int idx, PetscInt dim, PetscReal time, const PetscReal x[]);
+    PetscReal evaluate(unsigned int idx, PetscInt dim, PetscReal time, const PetscReal x[]);
 
 protected:
     /// Reference to the application

--- a/include/GYMLFile.h
+++ b/include/GYMLFile.h
@@ -29,35 +29,35 @@ public:
     /// build the simulation
     virtual void build();
 
-    virtual Mesh * getMesh();
-    virtual Problem * getProblem();
+    virtual Mesh * get_mesh();
+    virtual Problem * get_problem();
 
-    virtual const YAML::Node & getYml();
+    virtual const YAML::Node & get_yml();
 
 protected:
-    void addObject(Object * obj);
-    void buildFunctions();
-    void buildMesh();
-    void buildProblem();
-    void buildPartitioner();
-    void buildAuxiliaryFields();
-    void buildInitialConditions();
-    void buildBoundaryConditions();
-    void buildPostprocessors();
-    void buildOutputs();
-    InputParameters * buildParams(const YAML::Node & root, const std::string & name);
-    void setParameterFromYML(InputParameters * params,
-                             const YAML::Node & node,
-                             const std::string & param_name);
+    void add_object(Object * obj);
+    void build_functions();
+    void build_mesh();
+    void build_problem();
+    void build_partitioner();
+    void build_auxiliary_fields();
+    void build_initial_conditions();
+    void build_boundary_conditions();
+    void build_postprocessors();
+    void build_outputs();
+    InputParameters * build_params(const YAML::Node & root, const std::string & name);
+    void set_parameter_from_yml(InputParameters * params,
+                                const YAML::Node & node,
+                                const std::string & param_name);
 
     /// Read a vector-valued parameter from a YAML file
     ///
     /// If users specify a vector-valued parameter as a single value, we read in the single value
     /// but convert it into a vector with one element.
     template <typename T>
-    std::vector<T> readVectorValue(const std::string & param_name, const YAML::Node & val_node);
+    std::vector<T> read_vector_value(const std::string & param_name, const YAML::Node & val_node);
 
-    void checkParams(const InputParameters * params, const std::string & name);
+    void check_params(const InputParameters * params, const std::string & name);
 
     /// Application object
     const godzilla::App & app;

--- a/include/HDF5Output.h
+++ b/include/HDF5Output.h
@@ -29,12 +29,12 @@ class HDF5Output : public FileOutput {
 public:
     HDF5Output(const InputParameters & params);
 
-    virtual std::string getFileExt() const override;
+    virtual std::string get_file_ext() const override;
     virtual void create() override;
     virtual void check() override;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/ImplicitFENonlinearProblem.h
+++ b/include/ImplicitFENonlinearProblem.h
@@ -16,22 +16,22 @@ public:
 
 protected:
     virtual void init() override;
-    virtual void setUpCallbacks() override;
+    virtual void set_up_callbacks() override;
     /// Called before the time step solve
-    virtual PetscErrorCode onPreStep();
+    virtual PetscErrorCode on_pre_step();
     /// Called after the time step is done solving
-    virtual PetscErrorCode onPostStep();
+    virtual PetscErrorCode on_post_step();
     /// TS monitor callback
-    virtual PetscErrorCode tsMonitorCallback(PetscInt stepi, PetscReal time, Vec X);
+    virtual PetscErrorCode ts_monitor_callback(PetscInt stepi, PetscReal time, Vec X);
     /// Setup monitors
-    virtual void setUpMonitors() override;
+    virtual void set_up_monitors() override;
     /// Output
     virtual void output() override;
     /// Output time step
-    virtual void outputStep(Vec vec);
+    virtual void output_step(Vec vec);
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 
     friend PetscErrorCode __transient_pre_step(TS ts);
     friend PetscErrorCode __transient_post_step(TS ts);

--- a/include/InitialCondition.h
+++ b/include/InitialCondition.h
@@ -11,8 +11,8 @@ class InitialCondition : public Object, public PrintInterface {
 public:
     InitialCondition(const InputParameters & params);
 
-    virtual PetscInt getFieldId() const;
-    virtual PetscInt getNumComponents() const = 0;
+    virtual PetscInt get_field_id() const;
+    virtual PetscInt get_num_components() const = 0;
 
 protected:
     /// Evaluate the initial condition
@@ -26,7 +26,7 @@ protected:
     evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nc, PetscScalar u[]) = 0;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 
     friend PetscErrorCode __initial_condition_function(PetscInt dim,
                                                        PetscReal time,

--- a/include/InputParameters.h
+++ b/include/InputParameters.h
@@ -124,17 +124,17 @@ public:
     /// object that will be extracted from the input file.  If the parameter is
     /// missing in the input file, and error will be thrown
     template <typename T>
-    void addRequiredParam(const std::string & name, const std::string & doc_string);
+    void add_required_param(const std::string & name, const std::string & doc_string);
 
     ///@{
     /// These methods add an option parameter and a documentation string to the InputParameters
     /// object. The first version of this function takes a default value which is used if the
     /// parameter is not found in the input file. The second method will leave the parameter
-    /// uninitialized but can be checked with "isParamValid" before use.
+    /// uninitialized but can be checked with "is_param_valid" before use.
     template <typename T, typename S>
-    void addParam(const std::string & name, const S & value, const std::string & doc_string);
+    void add_param(const std::string & name, const S & value, const std::string & doc_string);
     template <typename T>
-    void addParam(const std::string & name, const std::string & doc_string);
+    void add_param(const std::string & name, const std::string & doc_string);
     ///@}
 
     ///@{
@@ -143,14 +143,14 @@ public:
     /// page dump so does not take a documentation string.  The first version of this function takes
     /// an optional default value.
     template <typename T>
-    void addPrivateParam(const std::string & name, const T & value);
+    void add_private_param(const std::string & name, const T & value);
     template <typename T>
-    void addPrivateParam(const std::string & name);
+    void add_private_param(const std::string & name);
     ///@}
 
     /// Returns a boolean indicating whether the specified parameter is required or not
     bool
-    isParamRequired(const std::string & name) const
+    is_param_required(const std::string & name) const
     {
         return this->params.count(name) > 0 && this->params.at(name)->required;
     }
@@ -159,13 +159,13 @@ public:
     /// i.e. The value was supplied as a default argument or read and properly converted from
     /// the input file
     bool
-    isParamValid(const std::string & name) const
+    is_param_valid(const std::string & name) const
     {
         return this->params.count(name) > 0 && this->params.at(name)->valid;
     }
 
     bool
-    isPrivate(const std::string & name) const
+    is_private(const std::string & name) const
     {
         return this->params.count(name) > 0 && this->params.at(name)->is_private;
     }
@@ -179,7 +179,7 @@ public:
 
     ///
     std::string
-    getDocString(const std::string & name) const
+    get_doc_string(const std::string & name) const
     {
         auto it = this->params.find(name);
         if (it != this->params.end())
@@ -250,7 +250,7 @@ private:
     /// This method is called when adding a Parameter with a default value, can be specialized for
     /// non-matching types.
     template <typename T, typename S>
-    void setParamHelper(const std::string & name, T & l_value, const S & r_value);
+    void set_param_helper(const std::string & name, T & l_value, const S & r_value);
 
     /// The actual parameter data. Each Metadata object contains attributes for the corresponding
     /// parameter.
@@ -259,7 +259,7 @@ private:
 
 template <typename T>
 void
-InputParameters::addRequiredParam(const std::string & name, const std::string & doc_string)
+InputParameters::add_required_param(const std::string & name, const std::string & doc_string)
 {
     if (!this->has<T>(name)) {
         Parameter<T> * param = new Parameter<T>;
@@ -274,7 +274,7 @@ InputParameters::addRequiredParam(const std::string & name, const std::string & 
 
 template <typename T>
 void
-InputParameters::addParam(const std::string & name, const std::string & doc_string)
+InputParameters::add_param(const std::string & name, const std::string & doc_string)
 {
     if (!this->has<T>(name)) {
         Parameter<T> * param = new Parameter<T>;
@@ -289,7 +289,9 @@ InputParameters::addParam(const std::string & name, const std::string & doc_stri
 
 template <typename T, typename S>
 void
-InputParameters::addParam(const std::string & name, const S & value, const std::string & doc_string)
+InputParameters::add_param(const std::string & name,
+                           const S & value,
+                           const std::string & doc_string)
 {
     if (!this->has<T>(name)) {
         Parameter<T> * param = new Parameter<T>;
@@ -305,7 +307,7 @@ InputParameters::addParam(const std::string & name, const S & value, const std::
 
 template <typename T>
 void
-InputParameters::addPrivateParam(const std::string & name)
+InputParameters::add_private_param(const std::string & name)
 {
     if (!this->has<T>(name)) {
         Parameter<T> * param = new Parameter<T>;
@@ -319,7 +321,7 @@ InputParameters::addPrivateParam(const std::string & name)
 
 template <typename T>
 void
-InputParameters::addPrivateParam(const std::string & name, const T & value)
+InputParameters::add_private_param(const std::string & name, const T & value)
 {
     Parameter<T> * param = new Parameter<T>;
     param->value = value;

--- a/include/InputParameters.h
+++ b/include/InputParameters.h
@@ -332,6 +332,4 @@ InputParameters::add_private_param(const std::string & name, const T & value)
     this->params[name] = param;
 }
 
-InputParameters emptyInputParameters();
-
 } // namespace godzilla

--- a/include/L2Diff.h
+++ b/include/L2Diff.h
@@ -13,7 +13,7 @@ public:
 
     virtual void create() override;
     virtual void compute() override;
-    virtual PetscReal getValue() override;
+    virtual PetscReal get_value() override;
 
     /// Evaluate the function 'u'
     ///
@@ -30,7 +30,7 @@ protected:
     PetscReal l2_diff;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/LineMesh.h
+++ b/include/LineMesh.h
@@ -13,20 +13,20 @@ public:
     /// Get the lower bound in x-direction
     ///
     /// @return Lower bound in x-direction
-    PetscReal getXMin();
+    PetscReal get_x_min();
 
     /// Get the upper bound in x-direction
     ///
     /// @return Upper bound in x-direction
-    PetscReal getXMax();
+    PetscReal get_x_max();
 
     /// Get the number of divisions in the x-direction
     ///
     /// @return Number of divisions in the x-direction
-    PetscInt getNx();
+    PetscInt get_nx();
 
 protected:
-    virtual void createDM() override;
+    virtual void create_dm() override;
 
     /// Minimum in the x direction
     const PetscReal & xmin;
@@ -40,7 +40,7 @@ protected:
     PetscBool interpolate;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/LinearProblem.h
+++ b/include/LinearProblem.h
@@ -16,32 +16,32 @@ public:
     virtual void solve() override;
     virtual void run() override;
     virtual bool converged() override;
-    virtual Vec getSolutionVector() const override;
+    virtual Vec get_solution_vector() const override;
 
 protected:
     /// provide DM for the underlying KSP object
-    virtual DM getDM() const override;
+    virtual DM get_dm() const override;
     /// Initialize the problem
     virtual void init();
     /// Allocate Jacobian/residual objects
-    virtual void allocateObjects();
+    virtual void allocate_objects();
     /// Setup computation of residual and Jacobian callbacks
-    virtual void setUpCallbacks();
+    virtual void set_up_callbacks();
     /// Setup monitors
-    virtual void setUpMonitors();
+    virtual void set_up_monitors();
     /// Setup solver parameters
-    virtual void setUpSolverParameters();
+    virtual void set_up_solver_parameters();
     /// Method to compute right-hand side. Called from the PETsc callback
-    virtual PetscErrorCode computeRhsCallback(Vec b) = 0;
+    virtual PetscErrorCode compute_rhs_callback(Vec b) = 0;
     /// Method to compute operators. Called from the PETsc callback
-    virtual PetscErrorCode computeOperatorsCallback(Mat A, Mat B) = 0;
+    virtual PetscErrorCode compute_operators_callback(Mat A, Mat B) = 0;
     /// KSP monitor
-    PetscErrorCode kspMonitorCallback(PetscInt it, PetscReal rnorm);
+    PetscErrorCode ksp_monitor_callback(PetscInt it, PetscReal rnorm);
     /// Output
     virtual void output();
 
     /// Method for setting matrix properties
-    virtual void onSetMatrixProperties();
+    virtual void on_set_matrix_properties();
 
     /// KSP object
     KSP ksp;
@@ -64,7 +64,7 @@ protected:
     PetscInt lin_max_iter;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 
     friend PetscErrorCode __compute_rhs(KSP ksp, Vec b, void * ctx);
     friend PetscErrorCode __compute_operators(KSP ksp, Mat A, Mat B, void * ctx);

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -19,11 +19,11 @@ public:
     error(Args &&... args)
     {
         std::ostringstream oss;
-        streamAll(oss,
-                  Terminal::Color::red,
-                  "error: ",
-                  Terminal::Color::normal,
-                  std::forward<Args>(args)...);
+        stream_all(oss,
+                   Terminal::Color::red,
+                   "error: ",
+                   Terminal::Color::normal,
+                   std::forward<Args>(args)...);
         this->entries.push_back(oss.str());
         this->num_errors++;
     }
@@ -34,11 +34,11 @@ public:
     warning(Args &&... args)
     {
         std::ostringstream oss;
-        streamAll(oss,
-                  Terminal::Color::magenta,
-                  "warning: ",
-                  Terminal::Color::normal,
-                  std::forward<Args>(args)...);
+        stream_all(oss,
+                   Terminal::Color::magenta,
+                   "warning: ",
+                   Terminal::Color::normal,
+                   std::forward<Args>(args)...);
         this->entries.push_back(oss.str());
         this->num_warnings++;
     }
@@ -46,33 +46,33 @@ public:
     /// Get the number of logged errors/warnings
     ///
     /// @return Number of logger errors/warnings
-    std::size_t getNumEntries() const;
+    std::size_t get_num_entries() const;
 
     /// Get the number of errors
     ///
     /// @return Number of errors
-    std::size_t getNumErrors() const;
+    std::size_t get_num_errors() const;
 
     /// Get the number of warnings
     ///
     /// @return Number of warnings
-    std::size_t getNumWarnings() const;
+    std::size_t get_num_warnings() const;
 
     /// Print logged errors and warnings
     void print() const;
 
 protected:
     void
-    streamAll(std::ostringstream & ss)
+    stream_all(std::ostringstream & ss)
     {
     }
 
     template <typename T, typename... Args>
     void
-    streamAll(std::ostringstream & ss, T && val, Args &&... args)
+    stream_all(std::ostringstream & ss, T && val, Args &&... args)
     {
         ss << val;
-        streamAll(ss, std::forward<Args>(args)...);
+        stream_all(ss, std::forward<Args>(args)...);
     }
 
     /// List of logged errors/warnings

--- a/include/LoggingInterface.h
+++ b/include/LoggingInterface.h
@@ -17,7 +17,7 @@ public:
     /// Log an error
     template <typename... Args>
     void
-    logError(Args &&... args)
+    log_error(Args &&... args)
     {
         this->logger.error(this->prefix, std::forward<Args>(args)...);
     }
@@ -25,7 +25,7 @@ public:
     /// Log a warning
     template <typename... Args>
     void
-    logWarning(Args &&... args)
+    log_warning(Args &&... args)
     {
         this->logger.warning(this->prefix, std::forward<Args>(args)...);
     }

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -13,19 +13,19 @@ public:
     Mesh(const InputParameters & parameters);
     virtual ~Mesh();
 
-    DM getDM() const;
+    DM get_dm() const;
 
     /// Get the mesh spatial dimension
     ///
     /// @return Mesh spatial dimension
-    PetscInt getDimension() const;
+    PetscInt get_dimension() const;
 
     /// Create the mesh
     virtual void create();
 
 protected:
     /// Method that builds DM for the mesh
-    virtual void createDM() = 0;
+    virtual void create_dm() = 0;
 
     /// Distribute mesh over processes
     virtual void distribute() = 0;
@@ -37,7 +37,7 @@ protected:
     PetscInt dim;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/NaturalBC.h
+++ b/include/NaturalBC.h
@@ -9,7 +9,7 @@ class NaturalBC : public BoundaryCondition {
 public:
     NaturalBC(const InputParameters & params);
 
-    virtual DMBoundaryConditionType getBcType() const override;
+    virtual DMBoundaryConditionType get_bc_type() const override;
 
 protected:
     typedef void PetscFEBndResidualFunc(PetscInt dim,
@@ -57,7 +57,7 @@ protected:
     ///
     /// @param f0 Integrand for the test function term
     /// @param f1 Integrand for the test function gradient term
-    void setResidualBlock(PetscFEBndResidualFunc * f0, PetscFEBndResidualFunc * f1);
+    void set_residual_block(PetscFEBndResidualFunc * f0, PetscFEBndResidualFunc * f1);
 
     /// Set Jacobian statement for the boundary integral
     ///
@@ -66,16 +66,16 @@ protected:
     /// @param g1 Integrand for the test function and basis function gradient term
     /// @param g2 Integrand for the test function gradient and basis function term
     /// @param g3 Integrand for the test function gradient and basis function gradient term
-    void setJacobianBlock(PetscInt gid,
-                          PetscFEBndJacobianFunc * g0,
-                          PetscFEBndJacobianFunc * g1,
-                          PetscFEBndJacobianFunc * g2,
-                          PetscFEBndJacobianFunc * g3);
+    void set_jacobian_block(PetscInt gid,
+                            PetscFEBndJacobianFunc * g0,
+                            PetscFEBndJacobianFunc * g1,
+                            PetscFEBndJacobianFunc * g2,
+                            PetscFEBndJacobianFunc * g3);
 
-    virtual void setUpCallback() override;
+    virtual void set_up_callback() override;
 
     /// Set up the weak form for the boundary integral of this boundary condition
-    virtual void onSetWeakForm() = 0;
+    virtual void on_set_weak_form() = 0;
 
     /// WeakForm object
     PetscWeakForm wf;
@@ -84,7 +84,7 @@ protected:
     PetscInt bd;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/NonlinearProblem.h
+++ b/include/NonlinearProblem.h
@@ -16,38 +16,38 @@ public:
     virtual void run() override;
     virtual void solve() override;
     virtual bool converged() override;
-    Vec getSolutionVector() const override;
+    Vec get_solution_vector() const override;
 
 protected:
     /// provide DM for the underlying SNES object
-    virtual DM getDM() const override;
+    virtual DM get_dm() const override;
     /// Initialize the problem
     virtual void init();
     /// Set up initial guess
-    virtual void setUpInitialGuess();
+    virtual void set_up_initial_guess();
     /// Allocate Jacobian/residual objects
-    virtual void allocateObjects();
+    virtual void allocate_objects();
     /// Set up line search
-    virtual void setUpLineSearch();
+    virtual void set_up_line_search();
     /// Set up computation of residual and Jacobian callbacks
-    virtual void setUpCallbacks();
+    virtual void set_up_callbacks();
     /// Set up monitors
-    virtual void setUpMonitors();
+    virtual void set_up_monitors();
     /// Set up solver parameters
-    virtual void setUpSolverParameters();
+    virtual void set_up_solver_parameters();
     /// Method to compute residual. Called from the PETsc callback
-    virtual PetscErrorCode computeResidualCallback(Vec x, Vec f) = 0;
+    virtual PetscErrorCode compute_residual_callback(Vec x, Vec f) = 0;
     /// Method to compute Jacobian. Called from the PETsc callback
-    virtual PetscErrorCode computeJacobianCallback(Vec x, Mat J, Mat Jp) = 0;
+    virtual PetscErrorCode compute_jacobian_callback(Vec x, Mat J, Mat Jp) = 0;
     /// SNES monitor
-    PetscErrorCode snesMonitorCallback(PetscInt it, PetscReal norm);
+    PetscErrorCode snes_monitor_callback(PetscInt it, PetscReal norm);
     /// KSP monitor
-    PetscErrorCode kspMonitorCallback(PetscInt it, PetscReal rnorm);
+    PetscErrorCode ksp_monitor_callback(PetscInt it, PetscReal rnorm);
     /// Output
     virtual void output();
 
     /// Method for setting matrix properties
-    virtual void onSetMatrixProperties();
+    virtual void on_set_matrix_properties();
 
     /// SNES object
     SNES snes;
@@ -80,7 +80,7 @@ protected:
     PetscInt lin_max_iter;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 
     friend PetscErrorCode __compute_residual(SNES snes, Vec x, Vec f, void * ctx);
     friend PetscErrorCode __compute_jacobian(SNES snes, Vec x, Mat A, Mat B, void * ctx);

--- a/include/Object.h
+++ b/include/Object.h
@@ -46,7 +46,7 @@ public:
     const MPI_Comm & get_comm() const;
 
     /// Get processor ID (aka MPI rank) this object is running at
-    const PetscMPIInt & processor_id() const;
+    const PetscMPIInt & get_processor_id() const;
 
     /// Get communicator size
     const PetscMPIInt & get_comm_size() const;

--- a/include/Object.h
+++ b/include/Object.h
@@ -49,7 +49,7 @@ public:
     const PetscMPIInt & processor_id() const;
 
     /// Get communicator size
-    const PetscMPIInt & comm_size() const;
+    const PetscMPIInt & get_comm_size() const;
 
     /// Called to construct the object
     virtual void create();

--- a/include/Object.h
+++ b/include/Object.h
@@ -19,37 +19,37 @@ public:
 
     /// Get the type of this object.
     /// @return the name of the type of this object
-    const std::string & getType() const;
+    const std::string & get_type() const;
 
     /// Get the name of the object
     /// @return The name of the object
-    virtual const std::string & getName() const;
+    virtual const std::string & get_name() const;
 
     /// Get the parameters of the object
     /// @return The parameters of the object
-    const InputParameters & getParameters() const;
+    const InputParameters & get_parameters() const;
 
     /// Retrieve a parameter for the object
     /// @param name The name of the parameter
     /// @return The value of the parameter
     template <typename T>
-    const T & getParam(const std::string & name) const;
+    const T & get_param(const std::string & name) const;
 
     /// Test if the supplied parameter is valid
     /// @param name The name of the parameter to test
-    bool isParamValid(const std::string & name) const;
+    bool is_param_valid(const std::string & name) const;
 
     /// Get the App this object is associated with
-    const App & getApp() const;
+    const App & get_app() const;
 
     /// Get the MPI comm this object works on
     const MPI_Comm & comm() const;
 
     /// Get processor ID (aka MPI rank) this object is running at
-    const PetscMPIInt & processorId() const;
+    const PetscMPIInt & processor_id() const;
 
     /// Get communicator size
-    const PetscMPIInt & commSize() const;
+    const PetscMPIInt & comm_size() const;
 
     /// Called to construct the object
     virtual void create();
@@ -72,12 +72,12 @@ protected:
 
 public:
     /// Method for building InputParameters for this class
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 template <typename T>
 const T &
-Object::getParam(const std::string & name) const
+Object::get_param(const std::string & name) const
 {
     return this->pars.get<T>(name);
 }

--- a/include/Object.h
+++ b/include/Object.h
@@ -43,7 +43,7 @@ public:
     const App & get_app() const;
 
     /// Get the MPI comm this object works on
-    const MPI_Comm & comm() const;
+    const MPI_Comm & get_comm() const;
 
     /// Get processor ID (aka MPI rank) this object is running at
     const PetscMPIInt & processor_id() const;

--- a/include/Output.h
+++ b/include/Output.h
@@ -17,26 +17,26 @@ public:
     /// Store the mesh
     ///
     /// @param dm DM holding the mesh to store into the file
-    virtual void outputMesh(DM dm) = 0;
+    virtual void output_mesh(DM dm) = 0;
 
     /// Store the solution vector
     ///
     /// @param vec Solution vector to store into the file
-    virtual void outputSolution(Vec vec) = 0;
+    virtual void output_solution(Vec vec) = 0;
 
     /// Output a step of a multi-step simulation
     ///
     /// @param stepi Index of a step, -1 indicates no sequence
     /// @param dm DM with the mesh
     /// @param vec Solution vector
-    virtual void outputStep(PetscInt stepi, DM dm, Vec vec) = 0;
+    virtual void output_step(PetscInt stepi, DM dm, Vec vec) = 0;
 
 protected:
     /// Problem to get data from
     const Problem & problem;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/PiecewiseLinear.h
+++ b/include/PiecewiseLinear.h
@@ -13,7 +13,7 @@ class PiecewiseLinear : public Function {
 public:
     PiecewiseLinear(const InputParameters & params);
 
-    virtual void registerCallback(mu::Parser & parser);
+    virtual void register_callback(mu::Parser & parser);
 
     /// Evaluate this function at point 'x'
     PetscReal evaluate(PetscReal x);
@@ -23,7 +23,7 @@ protected:
     LinearInterpolation linpol;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/Postprocessor.h
+++ b/include/Postprocessor.h
@@ -23,14 +23,14 @@ public:
     /// Get the computed value
     ///
     /// @return The value computed by the postprocessor
-    virtual PetscReal getValue() = 0;
+    virtual PetscReal get_value() = 0;
 
 protected:
     /// Problem this object is part of
     const Problem & problem;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/PrintInterface.h
+++ b/include/PrintInterface.h
@@ -23,12 +23,12 @@ protected:
     /// Print a message on a terminal
     template <typename... Args>
     void
-    godzillaPrint(unsigned int level, Args &&... args) const
+    godzilla_print(unsigned int level, Args &&... args) const
     {
         if (level <= this->verbosity_level) {
             std::ostringstream oss;
-            internal::godzillaStreamAll(oss, this->prefix, std::forward<Args>(args)...);
-            internal::godzillaMsgRaw(oss.str());
+            internal::godzilla_stream_all(oss, this->prefix, std::forward<Args>(args)...);
+            internal::godzilla_msg_raw(oss.str());
         }
     }
 

--- a/include/Problem.h
+++ b/include/Problem.h
@@ -30,46 +30,46 @@ public:
     /// true if solve converged, otherwise false
     virtual bool converged() = 0;
     /// provide DM for the underlying KSP object
-    virtual DM getDM() const = 0;
+    virtual DM get_dm() const = 0;
     /// Return solution vector
-    virtual Vec getSolutionVector() const = 0;
+    virtual Vec get_solution_vector() const = 0;
     /// Get problem spatial dimension
-    virtual PetscInt getDimension() const;
+    virtual PetscInt get_dimension() const;
 
     /// Get simulation time. For steady-state simulations, time is always 0
     ///
     /// @return Simulation time
-    virtual const PetscReal & getTime() const;
+    virtual const PetscReal & get_time() const;
 
     /// Get list of functions
     ///
     /// @return List of functions
-    const std::vector<Function *> & getFunctions() const;
+    const std::vector<Function *> & get_functions() const;
 
     /// Add a function object
     ///
     /// @param fn Function object to add
-    virtual void addFunction(Function * fn);
+    virtual void add_function(Function * fn);
 
     /// Add and output object
     ///
     /// @param output Output object to add
-    virtual void addOutput(Output * output);
+    virtual void add_output(Output * output);
 
     /// Add a postprocessor object
     ///
     /// @param pp Postprocessor object to add
-    virtual void addPostprocessor(Postprocessor * pp);
+    virtual void add_postprocessor(Postprocessor * pp);
 
     /// Get postprocessor by name
     ///
     /// @param name The name of the postprocessor
     /// @return Pointer to the postprocessor with name 'name' if it exists, otherwise `nullptr`
-    virtual Postprocessor * getPostprocessor(const std::string & name) const;
+    virtual Postprocessor * get_postprocessor(const std::string & name) const;
 
 protected:
     /// Compute all postprocessors
-    virtual void computePostprocessors();
+    virtual void compute_postprocessors();
 
     /// Mesh
     const Mesh * mesh;
@@ -87,7 +87,7 @@ protected:
     PetscReal time;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/RectangleMesh.h
+++ b/include/RectangleMesh.h
@@ -11,18 +11,18 @@ public:
     RectangleMesh(const InputParameters & parameters);
 
     ///
-    PetscInt getXMin() const;
-    PetscInt getXMax() const;
+    PetscInt get_x_min() const;
+    PetscInt get_x_max() const;
     /// Get the number of mesh points in x direction
-    PetscInt getNx() const;
+    PetscInt get_nx() const;
     ///
-    PetscInt getYMin() const;
-    PetscInt getYMax() const;
+    PetscInt get_y_min() const;
+    PetscInt get_y_max() const;
     /// Get the number of mesh points in y direction
-    PetscInt getNy() const;
+    PetscInt get_ny() const;
 
 protected:
-    virtual void createDM() override;
+    virtual void create_dm() override;
 
     /// Minimum in the x direction
     const PetscReal & xmin;
@@ -42,7 +42,7 @@ protected:
     PetscBool interpolate;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/Terminal.h
+++ b/include/Terminal.h
@@ -32,7 +32,7 @@ public:
     /// Query if terminal has colors
     ///
     /// @return true if terminal supports colors
-    static bool hasColors();
+    static bool has_colors();
 
     /// Number of colors supported by the terminal
     static unsigned int num_colors;

--- a/include/TransientInterface.h
+++ b/include/TransientInterface.h
@@ -19,7 +19,7 @@ protected:
     /// Create
     virtual void create(DM dm);
     /// Called before the time step solve
-    virtual void setUpTimeScheme();
+    virtual void set_up_time_scheme();
     /// Solve
     virtual void solve(Vec x);
 
@@ -35,7 +35,7 @@ protected:
     PetscInt step_num;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -15,17 +15,17 @@ public:
     /// Set partitioner type
     ///
     /// @param type Type of the partitioner
-    virtual void setPartitionerType(const std::string & type);
+    virtual void set_partitioner_type(const std::string & type);
 
     /// Set partitioner type
     ///
     /// @param type Type of the partitioner
-    virtual void setPartitionOverlap(PetscInt overlap);
+    virtual void set_partition_overlap(PetscInt overlap);
 
     /// Output partitioning
     ///
     /// @param viewer PetscViewer to store the partitioning
-    virtual void outputPartitioning(PetscViewer viewer);
+    virtual void output_partitioning(PetscViewer viewer);
 
 protected:
     virtual void distribute() override;
@@ -37,7 +37,7 @@ protected:
     PetscInt partition_overlap;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -5,19 +5,19 @@
 namespace godzilla {
 namespace utils {
 
-bool pathExists(const std::string & path);
+bool path_exists(const std::string & path);
 
 /**
  * Convert supplied string to upper case.
  * @param name The string to convert upper case.
  */
-std::string toUpper(const std::string & name);
+std::string to_upper(const std::string & name);
 
 /**
  * Convert supplied string to lower case.
  * @param name The string to convert upper case.
  */
-std::string toLower(const std::string & name);
+std::string to_lower(const std::string & name);
 
 } // namespace utils
 } // namespace godzilla

--- a/include/VTKOutput.h
+++ b/include/VTKOutput.h
@@ -19,13 +19,13 @@ class VTKOutput : public FileOutput {
 public:
     VTKOutput(const InputParameters & params);
 
-    virtual std::string getFileExt() const override;
+    virtual std::string get_file_ext() const override;
     virtual void create() override;
     virtual void check() override;
-    // void outputSolution(Vec v) override;
+    // void output_solution(Vec v) override;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };
 
 } // namespace godzilla

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -38,18 +38,18 @@ App::~App()
 }
 
 const Logger &
-App::getLogger() const
+App::get_logger() const
 {
     _F_;
     return this->log;
 }
 
 Problem *
-App::getProblem() const
+App::get_problem() const
 {
     _F_;
     assert(this->gyml != nullptr);
-    return this->gyml->getProblem();
+    return this->gyml->get_problem();
 }
 
 void
@@ -60,35 +60,35 @@ App::create()
 }
 
 void
-App::parseCommandLine(int argc, char * argv[])
+App::parse_command_line(int argc, char * argv[])
 {
     _F_;
     this->args.parse(argc, argv);
 }
 
 const unsigned int &
-App::getVerbosityLevel() const
+App::get_verbosity_level() const
 {
     _F_;
     return this->verbosity_level;
 }
 
 const MPI_Comm &
-App::getComm() const
+App::get_comm() const
 {
     _F_;
     return this->comm;
 }
 
 const PetscMPIInt &
-App::getCommRank() const
+App::get_comm_rank() const
 {
     _F_;
     return this->comm_rank;
 }
 
 const PetscMPIInt &
-App::getCommSize() const
+App::get_comm_size() const
 {
     _F_;
     return this->comm_size;
@@ -107,24 +107,24 @@ App::run()
 
     if (this->input_file_arg.isSet()) {
         std::string file_name = this->input_file_arg.getValue();
-        runInputFile(file_name);
+        run_input_file(file_name);
     }
 }
 
 void
-App::runInputFile(const std::string & file_name)
+App::run_input_file(const std::string & file_name)
 {
     _F_;
-    if (utils::pathExists(file_name)) {
-        godzillaPrint(9, "Reading '", file_name, "'...");
-        buildFromGYML(file_name);
+    if (utils::path_exists(file_name)) {
+        godzilla_print(9, "Reading '", file_name, "'...");
+        build_from_gyml(file_name);
         create();
 
-        godzillaPrint(9, "Checking integrity...");
-        checkIntegrity();
+        godzilla_print(9, "Checking integrity...");
+        check_integrity();
 
-        godzillaPrint(9, "Running '", file_name, "'...");
-        runProblem();
+        godzilla_print(9, "Running '", file_name, "'...");
+        run_problem();
     }
     else
         error("Unable to open '",
@@ -133,7 +133,7 @@ App::runInputFile(const std::string & file_name)
 }
 
 void
-App::buildFromGYML(const std::string & file_name)
+App::build_from_gyml(const std::string & file_name)
 {
     _F_;
     this->gyml->parse(file_name);
@@ -141,21 +141,21 @@ App::buildFromGYML(const std::string & file_name)
 }
 
 void
-App::checkIntegrity()
+App::check_integrity()
 {
     _F_;
     this->gyml->check();
-    if (this->log.getNumEntries() > 0) {
+    if (this->log.get_num_entries() > 0) {
         this->log.print();
         godzilla::internal::terminate();
     }
 }
 
 void
-App::runProblem()
+App::run_problem()
 {
     _F_;
-    Problem * p = this->gyml->getProblem();
+    Problem * p = this->gyml->get_problem();
     assert(p != nullptr);
     p->run();
 }

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -5,17 +5,17 @@
 namespace godzilla {
 
 InputParameters
-AuxiliaryField::validParams()
+AuxiliaryField::valid_params()
 {
-    InputParameters params = Object::validParams();
-    params.addPrivateParam<const FEProblemInterface *>("_fepi", nullptr);
+    InputParameters params = Object::valid_params();
+    params.add_private_param<const FEProblemInterface *>("_fepi", nullptr);
     return params;
 }
 
 AuxiliaryField::AuxiliaryField(const InputParameters & params) :
     Object(params),
     PrintInterface(this),
-    fepi(*getParam<FEProblemInterface *>("_fepi")),
+    fepi(*get_param<FEProblemInterface *>("_fepi")),
     a(nullptr),
     // TODO: set to the block where this aux field lives (nullptr => everywhere)
     block(nullptr)
@@ -30,10 +30,10 @@ AuxiliaryField::~AuxiliaryField()
 }
 
 PetscInt
-AuxiliaryField::getFieldId() const
+AuxiliaryField::get_field_id() const
 {
     _F_;
-    return this->fepi.getAuxFieldId(this->getName());
+    return this->fepi.get_aux_field_id(this->get_name());
 }
 
 } // namespace godzilla

--- a/src/BoundaryCondition.cpp
+++ b/src/BoundaryCondition.cpp
@@ -4,10 +4,10 @@
 namespace godzilla {
 
 InputParameters
-BoundaryCondition::validParams()
+BoundaryCondition::valid_params()
 {
-    InputParameters params = Object::validParams();
-    params.addRequiredParam<std::string>("boundary", "Boundary name");
+    InputParameters params = Object::valid_params();
+    params.add_required_param<std::string>("boundary", "Boundary name");
     return params;
 }
 
@@ -19,19 +19,19 @@ BoundaryCondition::BoundaryCondition(const InputParameters & params) :
     label(nullptr),
     n_ids(0),
     ids(nullptr),
-    boundary(getParam<std::string>("boundary"))
+    boundary(get_param<std::string>("boundary"))
 {
     _F_;
 }
 
 const std::string &
-BoundaryCondition::getBoundary() const
+BoundaryCondition::get_boundary() const
 {
     return this->boundary;
 }
 
 void
-BoundaryCondition::setUp(DM dm)
+BoundaryCondition::set_up(DM dm)
 {
     _F_;
     PetscErrorCode ierr;
@@ -39,29 +39,29 @@ BoundaryCondition::setUp(DM dm)
     this->dm = dm;
 
     ierr = DMGetDS(dm, &this->ds);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     IS is;
     ierr = DMGetLabelIdIS(dm, this->boundary.c_str(), &is);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = DMGetLabel(dm, this->boundary.c_str(), &this->label);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = ISGetSize(is, &this->n_ids);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = ISGetIndices(is, &this->ids);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
-    setUpCallback();
+    set_up_callback();
 
     ierr = ISRestoreIndices(is, &this->ids);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     this->ids = nullptr;
 
     ierr = ISDestroy(&is);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 } // namespace godzilla

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -8,109 +8,109 @@ namespace godzilla {
 registerObject(BoxMesh);
 
 InputParameters
-BoxMesh::validParams()
+BoxMesh::valid_params()
 {
-    InputParameters params = UnstructuredMesh::validParams();
-    params.addParam<PetscReal>("xmin", 0., "Minimum in the x direction");
-    params.addParam<PetscReal>("xmax", 1., "Maximum in the x direction");
-    params.addParam<PetscReal>("ymin", 0., "Minimum in the y direction");
-    params.addParam<PetscReal>("ymax", 1., "Maximum in the y direction");
-    params.addParam<PetscReal>("zmin", 0., "Minimum in the z direction");
-    params.addParam<PetscReal>("zmax", 1., "Maximum in the z direction");
-    params.addRequiredParam<PetscInt>("nx", "Number of mesh points in the x direction");
-    params.addRequiredParam<PetscInt>("ny", "Number of mesh points in the y direction");
-    params.addRequiredParam<PetscInt>("nz", "Number of mesh points in the z direction");
+    InputParameters params = UnstructuredMesh::valid_params();
+    params.add_param<PetscReal>("xmin", 0., "Minimum in the x direction");
+    params.add_param<PetscReal>("xmax", 1., "Maximum in the x direction");
+    params.add_param<PetscReal>("ymin", 0., "Minimum in the y direction");
+    params.add_param<PetscReal>("ymax", 1., "Maximum in the y direction");
+    params.add_param<PetscReal>("zmin", 0., "Minimum in the z direction");
+    params.add_param<PetscReal>("zmax", 1., "Maximum in the z direction");
+    params.add_required_param<PetscInt>("nx", "Number of mesh points in the x direction");
+    params.add_required_param<PetscInt>("ny", "Number of mesh points in the y direction");
+    params.add_required_param<PetscInt>("nz", "Number of mesh points in the z direction");
     return params;
 }
 
 BoxMesh::BoxMesh(const InputParameters & parameters) :
     UnstructuredMesh(parameters),
-    xmin(getParam<PetscReal>("xmin")),
-    xmax(getParam<PetscReal>("xmax")),
-    ymin(getParam<PetscReal>("ymin")),
-    ymax(getParam<PetscReal>("ymax")),
-    zmin(getParam<PetscReal>("zmin")),
-    zmax(getParam<PetscReal>("zmax")),
-    nx(getParam<PetscInt>("nx")),
-    ny(getParam<PetscInt>("ny")),
-    nz(getParam<PetscInt>("nz")),
+    xmin(get_param<PetscReal>("xmin")),
+    xmax(get_param<PetscReal>("xmax")),
+    ymin(get_param<PetscReal>("ymin")),
+    ymax(get_param<PetscReal>("ymax")),
+    zmin(get_param<PetscReal>("zmin")),
+    zmax(get_param<PetscReal>("zmax")),
+    nx(get_param<PetscInt>("nx")),
+    ny(get_param<PetscInt>("ny")),
+    nz(get_param<PetscInt>("nz")),
     simplex(PETSC_FALSE),
     interpolate(PETSC_TRUE)
 {
     _F_;
     if (this->xmax <= this->xmin)
-        logError("Parameter 'xmax' must be larger than 'xmin'.");
+        log_error("Parameter 'xmax' must be larger than 'xmin'.");
     if (this->ymax <= this->ymin)
-        logError("Parameter 'ymax' must be larger than 'ymin'.");
+        log_error("Parameter 'ymax' must be larger than 'ymin'.");
     if (this->zmax <= this->zmin)
-        logError("Parameter 'zmax' must be larger than 'zmin'.");
+        log_error("Parameter 'zmax' must be larger than 'zmin'.");
 }
 
 PetscInt
-BoxMesh::getXMin() const
+BoxMesh::get_x_min() const
 {
     _F_;
     return this->xmin;
 }
 
 PetscInt
-BoxMesh::getXMax() const
+BoxMesh::get_x_max() const
 {
     _F_;
     return this->xmax;
 }
 
 PetscInt
-BoxMesh::getNx() const
+BoxMesh::get_nx() const
 {
     _F_;
     return this->nx;
 }
 
 PetscInt
-BoxMesh::getYMin() const
+BoxMesh::get_y_min() const
 {
     _F_;
     return this->ymin;
 }
 
 PetscInt
-BoxMesh::getYMax() const
+BoxMesh::get_y_max() const
 {
     _F_;
     return this->ymax;
 }
 
 PetscInt
-BoxMesh::getNy() const
+BoxMesh::get_ny() const
 {
     _F_;
     return this->ny;
 }
 
 PetscInt
-BoxMesh::getZMin() const
+BoxMesh::get_z_min() const
 {
     _F_;
     return this->zmin;
 }
 
 PetscInt
-BoxMesh::getZMax() const
+BoxMesh::get_z_max() const
 {
     _F_;
     return this->zmax;
 }
 
 PetscInt
-BoxMesh::getNz() const
+BoxMesh::get_nz() const
 {
     _F_;
     return this->nz;
 }
 
 void
-BoxMesh::createDM()
+BoxMesh::create_dm()
 {
     _F_;
     PetscErrorCode ierr;
@@ -131,7 +131,7 @@ BoxMesh::createDM()
                                periodicity,
                                interpolate,
                                &this->dm);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     // create user-friendly names for sides
     DMLabel face_sets_label;
@@ -141,25 +141,25 @@ BoxMesh::createDM()
     for (unsigned int i = 0; i < 6; i++) {
         IS is;
         ierr = DMLabelGetStratumIS(face_sets_label, i + 1, &is);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         ierr = DMCreateLabel(this->dm, side_name[i]);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         DMLabel label;
         ierr = DMGetLabel(this->dm, side_name[i], &label);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         if (is) {
             ierr = DMLabelSetStratumIS(label, i + 1, is);
-            checkPetscError(ierr);
+            check_petsc_error(ierr);
         }
 
         ierr = ISDestroy(&is);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         ierr = DMPlexLabelComplete(this->dm, label);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
     }
 }
 

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -122,7 +122,7 @@ BoxMesh::create_dm()
                                       DM_BOUNDARY_GHOSTED,
                                       DM_BOUNDARY_GHOSTED };
 
-    ierr = DMPlexCreateBoxMesh(comm(),
+    ierr = DMPlexCreateBoxMesh(get_comm(),
                                3,
                                this->simplex,
                                faces,

--- a/src/CallStack.cpp
+++ b/src/CallStack.cpp
@@ -52,7 +52,7 @@ sighandler(int signo)
 // Call Stack
 
 CallStack &
-getCallstack()
+get_callstack()
 {
     return callstack;
 }

--- a/src/ConstantIC.cpp
+++ b/src/ConstantIC.cpp
@@ -7,23 +7,23 @@ namespace godzilla {
 registerObject(ConstantIC);
 
 InputParameters
-ConstantIC::validParams()
+ConstantIC::valid_params()
 {
-    InputParameters params = InitialCondition::validParams();
-    params.addRequiredParam<std::vector<PetscReal>>("value",
-                                                    "Constant values for each field component");
+    InputParameters params = InitialCondition::valid_params();
+    params.add_required_param<std::vector<PetscReal>>("value",
+                                                      "Constant values for each field component");
     return params;
 }
 
 ConstantIC::ConstantIC(const InputParameters & params) :
     InitialCondition(params),
-    values(getParam<std::vector<PetscReal>>("value"))
+    values(get_param<std::vector<PetscReal>>("value"))
 {
     _F_;
 }
 
 PetscInt
-ConstantIC::getNumComponents() const
+ConstantIC::get_num_components() const
 {
     _F_;
     return this->values.size();

--- a/src/DirichletBC.cpp
+++ b/src/DirichletBC.cpp
@@ -6,10 +6,10 @@ namespace godzilla {
 registerObject(DirichletBC);
 
 InputParameters
-DirichletBC::validParams()
+DirichletBC::valid_params()
 {
-    InputParameters params = EssentialBC::validParams();
-    params += FunctionInterface::validParams();
+    InputParameters params = EssentialBC::valid_params();
+    params += FunctionInterface::valid_params();
     return params;
 }
 
@@ -28,23 +28,23 @@ DirichletBC::create()
 }
 
 PetscInt
-DirichletBC::getFieldId() const
+DirichletBC::get_field_id() const
 {
     _F_;
     return 0;
 }
 
 PetscInt
-DirichletBC::getNumComponents() const
+DirichletBC::get_num_components() const
 {
     _F_;
     return this->num_comps;
 }
 
 std::vector<PetscInt>
-DirichletBC::getComponents() const
+DirichletBC::get_components() const
 {
-    PetscInt nc = getNumComponents();
+    PetscInt nc = get_num_components();
     std::vector<PetscInt> comps(nc);
     for (PetscInt i = 0; i < nc; i++)
         comps[i] = i;
@@ -60,7 +60,7 @@ DirichletBC::evaluate(PetscInt dim,
 {
     _F_;
     for (PetscInt i = 0; i < Nc; i++)
-        u[i] = evaluateFunction(i, dim, time, x);
+        u[i] = evaluate_function(i, dim, time, x);
 }
 
 } // namespace godzilla

--- a/src/DirichletBC.cpp
+++ b/src/DirichletBC.cpp
@@ -60,7 +60,7 @@ DirichletBC::evaluate(PetscInt dim,
 {
     _F_;
     for (PetscInt i = 0; i < Nc; i++)
-        u[i] = evaluate_function(i, dim, time, x);
+        u[i] = FunctionInterface::evaluate(i, dim, time, x);
 }
 
 } // namespace godzilla

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -6,13 +6,13 @@ namespace godzilla {
 namespace internal {
 
 void
-godzillaMsgRaw(const std::string & msg)
+godzilla_msg_raw(const std::string & msg)
 {
     std::cout << msg << std::endl;
 }
 
 std::string
-godzillaMsgFmt(const std::string & msg, const std::string & title, const Terminal::Color & color)
+godzilla_msg_fmt(const std::string & msg, const std::string & title, const Terminal::Color & color)
 {
     std::ostringstream oss;
     oss << color << title << ": " << msg << Terminal::Color::normal << std::endl;
@@ -20,19 +20,19 @@ godzillaMsgFmt(const std::string & msg, const std::string & title, const Termina
 }
 
 void
-godzillaStreamAll(std::ostringstream &)
+godzilla_stream_all(std::ostringstream &)
 {
 }
 
 void
-godzillaErrorRaw(std::string msg, bool call_stack)
+godzilla_error_raw(std::string msg, bool call_stack)
 {
-    msg = godzillaMsgFmt(msg, "error", Terminal::Color::red);
+    msg = godzilla_msg_fmt(msg, "error", Terminal::Color::red);
     std::cerr << msg << std::flush;
 
     if (call_stack) {
         std::cerr << std::endl;
-        getCallstack().dump();
+        get_callstack().dump();
     }
 }
 
@@ -45,14 +45,14 @@ terminate(int status)
 }
 
 void
-memCheck(int line, const char * func, const char * file, void * var)
+mem_check(int line, const char * func, const char * file, void * var)
 {
     if (var == nullptr) {
         std::ostringstream oss;
-        internal::godzillaStreamAll(oss, "Out of memory");
+        internal::godzilla_stream_all(oss, "Out of memory");
         oss << std::endl;
-        internal::godzillaStreamAll(oss, "  Location: ", file, ":", line);
-        internal::godzillaErrorRaw(oss.str(), true);
+        internal::godzilla_stream_all(oss, "  Location: ", file, ":", line);
+        internal::godzilla_error_raw(oss.str(), true);
         terminate();
     }
 }
@@ -60,12 +60,12 @@ memCheck(int line, const char * func, const char * file, void * var)
 } // namespace internal
 
 void
-checkPetscError(PetscErrorCode ierr)
+check_petsc_error(PetscErrorCode ierr)
 {
     if (ierr) {
         std::ostringstream oss;
-        internal::godzillaStreamAll(oss, "PETSc error: ", ierr);
-        internal::godzillaErrorRaw(oss.str(), true);
+        internal::godzilla_stream_all(oss, "PETSc error: ", ierr);
+        internal::godzilla_error_raw(oss.str(), true);
         internal::terminate();
     }
 }

--- a/src/EssentialBC.cpp
+++ b/src/EssentialBC.cpp
@@ -19,9 +19,9 @@ __essential_boundary_condition_function(PetscInt dim,
 }
 
 InputParameters
-EssentialBC::validParams()
+EssentialBC::valid_params()
 {
-    InputParameters params = BoundaryCondition::validParams();
+    InputParameters params = BoundaryCondition::valid_params();
     return params;
 }
 
@@ -31,31 +31,31 @@ EssentialBC::EssentialBC(const InputParameters & params) : BoundaryCondition(par
 }
 
 DMBoundaryConditionType
-EssentialBC::getBcType() const
+EssentialBC::get_bc_type() const
 {
     _F_;
     return DM_BC_ESSENTIAL;
 }
 
 void
-EssentialBC::setUpCallback()
+EssentialBC::set_up_callback()
 {
     _F_;
     PetscErrorCode ierr;
     ierr = PetscDSAddBoundary(this->ds,
-                              getBcType(),
-                              getName().c_str(),
+                              get_bc_type(),
+                              get_name().c_str(),
                               this->label,
                               this->n_ids,
                               this->ids,
-                              getFieldId(),
-                              getNumComponents(),
-                              getNumComponents() == 0 ? NULL : getComponents().data(),
+                              get_field_id(),
+                              get_num_components(),
+                              get_num_components() == 0 ? NULL : get_components().data(),
                               (void (*)(void)) & __essential_boundary_condition_function,
                               NULL,
                               (void *) this,
                               NULL);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 } // namespace godzilla

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -42,8 +42,10 @@ ExodusIIMesh::create_dm()
     _F_;
     PetscErrorCode ierr;
 
-    ierr =
-        DMPlexCreateExodusFromFile(comm(), this->file_name.c_str(), this->interpolate, &this->dm);
+    ierr = DMPlexCreateExodusFromFile(get_comm(),
+                                      this->file_name.c_str(),
+                                      this->interpolate,
+                                      &this->dm);
     check_petsc_error(ierr);
 }
 

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -9,42 +9,42 @@ namespace godzilla {
 registerObject(ExodusIIMesh);
 
 InputParameters
-ExodusIIMesh::validParams()
+ExodusIIMesh::valid_params()
 {
-    InputParameters params = UnstructuredMesh::validParams();
-    params.addRequiredParam<std::string>("file", "The name of the ExodusII file.");
+    InputParameters params = UnstructuredMesh::valid_params();
+    params.add_required_param<std::string>("file", "The name of the ExodusII file.");
     return params;
 }
 
 ExodusIIMesh::ExodusIIMesh(const InputParameters & parameters) :
     UnstructuredMesh(parameters),
-    file_name(getParam<std::string>("file")),
+    file_name(get_param<std::string>("file")),
     interpolate(PETSC_TRUE)
 {
     _F_;
 
-    if (!utils::pathExists(this->file_name))
-        logError("Unable to open '",
-                 this->file_name,
-                 "' for reading. Make sure it exists and you have read permissions.");
+    if (!utils::path_exists(this->file_name))
+        log_error("Unable to open '",
+                  this->file_name,
+                  "' for reading. Make sure it exists and you have read permissions.");
 }
 
 const std::string
-ExodusIIMesh::getFileName() const
+ExodusIIMesh::get_file_name() const
 {
     _F_;
     return this->file_name;
 }
 
 void
-ExodusIIMesh::createDM()
+ExodusIIMesh::create_dm()
 {
     _F_;
     PetscErrorCode ierr;
 
     ierr =
         DMPlexCreateExodusFromFile(comm(), this->file_name.c_str(), this->interpolate, &this->dm);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 } // namespace godzilla

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -12,9 +12,9 @@ registerObject(ExodusIIOutput);
 static const int MAX_PATH = 1024;
 
 InputParameters
-ExodusIIOutput::validParams()
+ExodusIIOutput::valid_params()
 {
-    InputParameters params = FileOutput::validParams();
+    InputParameters params = FileOutput::valid_params();
     return params;
 }
 
@@ -27,7 +27,7 @@ ExodusIIOutput::ExodusIIOutput(const InputParameters & params) :
 }
 
 std::string
-ExodusIIOutput::getFileExt() const
+ExodusIIOutput::get_file_ext() const
 {
     _F_;
     return std::string("exo");
@@ -40,50 +40,50 @@ ExodusIIOutput::create()
     PetscErrorCode ierr;
 
     ierr = PetscViewerCreate(comm(), &this->viewer);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscViewerSetType(this->viewer, PETSCVIEWEREXODUSII);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscViewerFileSetMode(this->viewer, FILE_MODE_WRITE);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     PetscInt order = 1;
     ierr = PetscViewerExodusIISetOrder(this->viewer, order);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
-    createCellSets();
+    create_cell_sets();
 
     this->fepi = dynamic_cast<const FEProblemInterface *>(&this->problem);
 }
 
 void
-ExodusIIOutput::createCellSets()
+ExodusIIOutput::create_cell_sets()
 {
     _F_;
     PetscErrorCode ierr;
 
-    PetscInt dim = this->problem.getDimension();
-    DM dm = this->problem.getDM();
+    PetscInt dim = this->problem.get_dimension();
+    DM dm = this->problem.get_dm();
     DMLabel cs_label = nullptr;
     ierr = DMGetLabel(dm, "Cell Sets", &cs_label);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     if (cs_label == nullptr) {
         ierr = DMCreateLabel(dm, "Cell Sets");
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         ierr = DMGetLabel(dm, "Cell Sets", &cs_label);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         // NOTE: Right now we only have a single block in the mesh, unless we load ExodusII mesh.
         // When we have support for multiple blocks, this will need to be changed
         PetscInt block_id = 1;
         ierr = DMLabelAddStratum(cs_label, block_id);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         // This works for simple meshes
         PetscInt elem_start, elem_end;
         ierr = DMPlexGetDepthStratum(dm, dim, &elem_start, &elem_end);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
         PetscInt num_elems = elem_end - elem_start;
         PetscInt * elem_ids = new PetscInt[num_elems];
         for (PetscInt i = 0; i < num_elems; i++)
@@ -91,11 +91,11 @@ ExodusIIOutput::createCellSets()
 
         IS is;
         ierr = ISCreateGeneral(comm(), num_elems, elem_ids, PETSC_COPY_VALUES, &is);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
         ierr = DMLabelSetStratumIS(cs_label, block_id, is);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
         ierr = ISDestroy(&is);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         delete[] elem_ids;
     }
@@ -105,47 +105,47 @@ void
 ExodusIIOutput::check()
 {
     _F_;
-    PetscInt dim = this->problem.getDimension();
+    PetscInt dim = this->problem.get_dimension();
     if (dim == 1)
-        logError("PETSc viewer does not support ExodusII output for 1D problems.");
+        log_error("PETSc viewer does not support ExodusII output for 1D problems.");
     if (this->fepi != nullptr)
-        logError("ExodusII output does not support finite element problems yet.");
+        log_error("ExodusII output does not support finite element problems yet.");
 }
 
 void
-ExodusIIOutput::outputStep(PetscInt stepi, DM dm, Vec vec)
+ExodusIIOutput::output_step(PetscInt stepi, DM dm, Vec vec)
 {
     _F_;
     PetscErrorCode ierr;
 
-    setFileName();
+    set_file_name();
 
     if (this->file_seq_no == 0)
-        outputMesh(dm);
+        output_mesh(dm);
 
     int exoid;
     ierr = PetscViewerExodusIIGetId(this->viewer, &exoid);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     if (this->file_seq_no == 0)
-        writeVariableInfo(exoid, vec);
+        write_variable_info(exoid, vec);
 
     if (stepi == -1) {
-        PetscReal time = this->problem.getTime();
+        PetscReal time = this->problem.get_time();
         PetscInt num_step = 0;
         ierr = DMSetOutputSequenceNumber(dm, num_step, time);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
     }
 
     this->file_seq_no++;
 }
 
 void
-ExodusIIOutput::writeVariableInfo(int exoid, Vec vec)
+ExodusIIOutput::write_variable_info(int exoid, Vec vec)
 {
     _F_;
     // PetscErrorCode ierr;
-    // DM dm = this->problem.getDM();
+    // DM dm = this->problem.get_dm();
     //
     // PetscInt num_nodal_vars = 1;
     // const char * vec_name;
@@ -158,9 +158,9 @@ ExodusIIOutput::writeVariableInfo(int exoid, Vec vec)
     // FIXME: this produces a liner error, most likely missing netcdf + exodusII libs in the linker
     // line.
     // ierr = ex_put_variable_param(exoid, EX_NODAL, num_nodal_vars);
-    // checkPetscError(ierr);
+    // check_petsc_error(ierr);
     // ierr = ex_put_variable_names(exoid, EX_NODAL, num_nodal_vars, nodal_var_name);
-    // checkPetscError(ierr);
+    // check_petsc_error(ierr);
 }
 
 } // namespace godzilla

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -39,7 +39,7 @@ ExodusIIOutput::create()
     _F_;
     PetscErrorCode ierr;
 
-    ierr = PetscViewerCreate(comm(), &this->viewer);
+    ierr = PetscViewerCreate(get_comm(), &this->viewer);
     check_petsc_error(ierr);
     ierr = PetscViewerSetType(this->viewer, PETSCVIEWEREXODUSII);
     check_petsc_error(ierr);
@@ -90,7 +90,7 @@ ExodusIIOutput::create_cell_sets()
             elem_ids[i] = i + elem_start;
 
         IS is;
-        ierr = ISCreateGeneral(comm(), num_elems, elem_ids, PETSC_COPY_VALUES, &is);
+        ierr = ISCreateGeneral(get_comm(), num_elems, elem_ids, PETSC_COPY_VALUES, &is);
         check_petsc_error(ierr);
         ierr = DMLabelSetStratumIS(cs_label, block_id, is);
         check_petsc_error(ierr);

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -6,9 +6,9 @@
 namespace godzilla {
 
 InputParameters
-FENonlinearProblem::validParams()
+FENonlinearProblem::valid_params()
 {
-    InputParameters params = NonlinearProblem::validParams();
+    InputParameters params = NonlinearProblem::valid_params();
     return params;
 }
 
@@ -25,7 +25,7 @@ void
 FENonlinearProblem::create()
 {
     _F_;
-    FEProblemInterface::create(getDM());
+    FEProblemInterface::create(get_dm());
     NonlinearProblem::create();
 }
 
@@ -34,37 +34,37 @@ FENonlinearProblem::init()
 {
     _F_;
     NonlinearProblem::init();
-    FEProblemInterface::init(getDM());
+    FEProblemInterface::init(get_dm());
 }
 
 void
-FENonlinearProblem::setUpCallbacks()
+FENonlinearProblem::set_up_callbacks()
 {
     _F_;
     PetscErrorCode ierr;
-    DM dm = this->getDM();
+    DM dm = this->get_dm();
     ierr = DMPlexSetSNESLocalFEM(dm, this, this, this);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = SNESSetJacobian(this->snes, this->J, this->Jp, NULL, NULL);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-FENonlinearProblem::setUpInitialGuess()
+FENonlinearProblem::set_up_initial_guess()
 {
     _F_;
-    FEProblemInterface::setUpInitialGuess(getDM(), this->x);
+    FEProblemInterface::set_up_initial_guess(get_dm(), this->x);
 }
 
 PetscErrorCode
-FENonlinearProblem::computeResidualCallback(Vec x, Vec f)
+FENonlinearProblem::compute_residual_callback(Vec x, Vec f)
 {
     _F_;
     return 0;
 }
 
 PetscErrorCode
-FENonlinearProblem::computeJacobianCallback(Vec x, Mat J, Mat Jp)
+FENonlinearProblem::compute_jacobian_callback(Vec x, Mat J, Mat Jp)
 {
     _F_;
     return 0;

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -25,7 +25,7 @@ zero_fn(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nc, PetscSca
 
 FEProblemInterface::FEProblemInterface(Problem & problem, const InputParameters & params) :
     problem(problem),
-    logger(const_cast<Logger &>(params.get<const App *>("_app")->getLogger())),
+    logger(const_cast<Logger &>(params.get<const App *>("_app")->get_logger())),
     qorder(PETSC_DETERMINE),
     ds(nullptr)
 {
@@ -48,7 +48,7 @@ void
 FEProblemInterface::create(DM dm)
 {
     _F_;
-    onSetFields();
+    on_set_fields();
 
     for (auto & aux : this->auxs)
         aux->create();
@@ -62,12 +62,12 @@ void
 FEProblemInterface::init(DM dm)
 {
     _F_;
-    setUpFEs(dm);
-    setUpProblem(dm);
+    set_up_fes(dm);
+    set_up_problem(dm);
 }
 
 const std::string &
-FEProblemInterface::getFieldName(PetscInt fid) const
+FEProblemInterface::get_field_name(PetscInt fid) const
 {
     _F_;
     const auto & it = this->fields.find(fid);
@@ -78,7 +78,7 @@ FEProblemInterface::getFieldName(PetscInt fid) const
 }
 
 PetscInt
-FEProblemInterface::getFieldId(const std::string & name) const
+FEProblemInterface::get_field_id(const std::string & name) const
 {
     _F_;
     const auto & it = this->fields_by_name.find(name);
@@ -89,7 +89,7 @@ FEProblemInterface::getFieldId(const std::string & name) const
 }
 
 bool
-FEProblemInterface::hasFieldById(PetscInt fid) const
+FEProblemInterface::has_field_by_id(PetscInt fid) const
 {
     _F_;
     const auto & it = this->fields.find(fid);
@@ -97,7 +97,7 @@ FEProblemInterface::hasFieldById(PetscInt fid) const
 }
 
 bool
-FEProblemInterface::hasFieldByName(const std::string & name) const
+FEProblemInterface::has_field_by_name(const std::string & name) const
 {
     _F_;
     const auto & it = this->fields_by_name.find(name);
@@ -105,7 +105,7 @@ FEProblemInterface::hasFieldByName(const std::string & name) const
 }
 
 const std::string &
-FEProblemInterface::getAuxFieldName(PetscInt fid) const
+FEProblemInterface::get_aux_field_name(PetscInt fid) const
 {
     _F_;
     const auto & it = this->aux_fields.find(fid);
@@ -116,7 +116,7 @@ FEProblemInterface::getAuxFieldName(PetscInt fid) const
 }
 
 PetscInt
-FEProblemInterface::getAuxFieldId(const std::string & name) const
+FEProblemInterface::get_aux_field_id(const std::string & name) const
 {
     _F_;
     const auto & it = this->aux_fields_by_name.find(name);
@@ -127,7 +127,7 @@ FEProblemInterface::getAuxFieldId(const std::string & name) const
 }
 
 bool
-FEProblemInterface::hasAuxFieldById(PetscInt fid) const
+FEProblemInterface::has_aux_field_by_id(PetscInt fid) const
 {
     _F_;
     const auto & it = this->aux_fields.find(fid);
@@ -135,7 +135,7 @@ FEProblemInterface::hasAuxFieldById(PetscInt fid) const
 }
 
 bool
-FEProblemInterface::hasAuxFieldByName(const std::string & name) const
+FEProblemInterface::has_aux_field_by_name(const std::string & name) const
 {
     _F_;
     const auto & it = this->aux_fields_by_name.find(name);
@@ -143,7 +143,7 @@ FEProblemInterface::hasAuxFieldByName(const std::string & name) const
 }
 
 void
-FEProblemInterface::addFE(PetscInt id, const std::string & name, PetscInt nc, PetscInt k)
+FEProblemInterface::add_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k)
 {
     _F_;
     auto it = this->fields.find(id);
@@ -157,7 +157,7 @@ FEProblemInterface::addFE(PetscInt id, const std::string & name, PetscInt nc, Pe
 }
 
 void
-FEProblemInterface::addAuxFE(PetscInt id, const std::string & name, PetscInt nc, PetscInt k)
+FEProblemInterface::add_aux_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k)
 {
     _F_;
     auto it = this->aux_fields.find(id);
@@ -171,57 +171,57 @@ FEProblemInterface::addAuxFE(PetscInt id, const std::string & name, PetscInt nc,
 }
 
 void
-FEProblemInterface::setConstants(const std::vector<PetscReal> & consts)
+FEProblemInterface::set_constants(const std::vector<PetscReal> & consts)
 {
     _F_;
     this->consts = consts;
 }
 
 void
-FEProblemInterface::addInitialCondition(InitialCondition * ic)
+FEProblemInterface::add_initial_condition(InitialCondition * ic)
 {
     _F_;
-    PetscInt fid = ic->getFieldId();
+    PetscInt fid = ic->get_field_id();
     const auto & it = this->ics.find(fid);
     if (it == this->ics.end())
         this->ics[fid].ic = ic;
     else
         // TODO: improve this error message
         this->logger.error("Initial condition '",
-                           ic->getName(),
+                           ic->get_name(),
                            "' is being applied to a field that already has an initial condition.");
 }
 
 void
-FEProblemInterface::addBoundaryCondition(BoundaryCondition * bc)
+FEProblemInterface::add_boundary_condition(BoundaryCondition * bc)
 {
     _F_;
     this->bcs.push_back(bc);
 }
 
 void
-FEProblemInterface::addAuxiliaryField(AuxiliaryField * aux)
+FEProblemInterface::add_auxiliary_field(AuxiliaryField * aux)
 {
     _F_;
     this->auxs.push_back(aux);
 }
 
 void
-FEProblemInterface::setUpBoundaryConditions(DM dm)
+FEProblemInterface::set_up_boundary_conditions(DM dm)
 {
     _F_;
     /// TODO: refactor this into a method
     bool no_errors = true;
     for (auto & bc : this->bcs) {
-        const std::string & bnd_name = bc->getBoundary();
+        const std::string & bnd_name = bc->get_boundary();
         PetscErrorCode ierr;
         PetscBool exists = PETSC_FALSE;
         ierr = DMHasLabel(dm, bnd_name.c_str(), &exists);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
         if (!exists) {
             no_errors = false;
             this->logger.error("Boundary condition '",
-                               bc->getName(),
+                               bc->get_name(),
                                "' is set on boundary '",
                                bnd_name,
                                "' which does not exist in the mesh.");
@@ -230,11 +230,11 @@ FEProblemInterface::setUpBoundaryConditions(DM dm)
 
     if (no_errors)
         for (auto & bc : this->bcs)
-            bc->setUp(dm);
+            bc->set_up(dm);
 }
 
 void
-FEProblemInterface::setUpInitialGuess(DM dm, Vec x)
+FEProblemInterface::set_up_initial_guess(DM dm, Vec x)
 {
     _F_;
     PetscInt n_ics = this->ics.size();
@@ -255,12 +255,12 @@ FEProblemInterface::setUpInitialGuess(DM dm, Vec x)
                 const ICInfo & ic_info = it.second;
                 const InitialCondition * ic = ic_info.ic;
 
-                PetscInt ic_nc = ic->getNumComponents();
+                PetscInt ic_nc = ic->get_num_components();
                 PetscInt field_nc = this->fields[fid].nc;
                 if (ic_nc != field_nc) {
                     no_errors = false;
                     this->logger.error("Initial condition '",
-                                       ic->getName(),
+                                       ic->get_name(),
                                        "' operates on ",
                                        ic_nc,
                                        " components, but is set on a field with ",
@@ -273,8 +273,8 @@ FEProblemInterface::setUpInitialGuess(DM dm, Vec x)
             }
 
             if (no_errors) {
-                ierr = DMProjectFunction(dm, getTime(), ic_funcs, ic_ctxs, INSERT_VALUES, x);
-                checkPetscError(ierr);
+                ierr = DMProjectFunction(dm, get_time(), ic_funcs, ic_ctxs, INSERT_VALUES, x);
+                check_petsc_error(ierr);
             }
         }
     }
@@ -282,13 +282,13 @@ FEProblemInterface::setUpInitialGuess(DM dm, Vec x)
         // no initial conditions -> use zero
         PetscErrorCode ierr;
         PetscFunc * initial_guess[1] = { internal::zero_fn };
-        ierr = DMProjectFunction(dm, getTime(), initial_guess, NULL, INSERT_VALUES, x);
-        checkPetscError(ierr);
+        ierr = DMProjectFunction(dm, get_time(), initial_guess, NULL, INSERT_VALUES, x);
+        check_petsc_error(ierr);
     }
 }
 
 void
-FEProblemInterface::setUpFEs(DM dm)
+FEProblemInterface::set_up_fes(DM dm)
 {
     _F_;
     MPI_Comm comm;
@@ -296,7 +296,7 @@ FEProblemInterface::setUpFEs(DM dm)
 
     PetscErrorCode ierr;
 
-    PetscInt dim = this->problem.getDimension();
+    PetscInt dim = this->problem.get_dimension();
 
     // FIXME: determine if the mesh is made of simplex elements
     PetscBool is_simplex = PETSC_FALSE;
@@ -304,22 +304,22 @@ FEProblemInterface::setUpFEs(DM dm)
     for (auto & it : this->fields) {
         FieldInfo & fi = it.second;
         ierr = PetscFECreateLagrange(comm, dim, fi.nc, is_simplex, fi.k, this->qorder, &fi.fe);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
         ierr = PetscFESetName(fi.fe, fi.name.c_str());
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
     }
 
     for (auto & it : this->aux_fields) {
         FieldInfo & fi = it.second;
         ierr = PetscFECreateLagrange(comm, dim, fi.nc, is_simplex, fi.k, this->qorder, &fi.fe);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
         ierr = PetscFESetName(fi.fe, fi.name.c_str());
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
     }
 }
 
 void
-FEProblemInterface::setUpProblem(DM dm)
+FEProblemInterface::set_up_problem(DM dm)
 {
     _F_;
     PetscErrorCode ierr;
@@ -327,60 +327,60 @@ FEProblemInterface::setUpProblem(DM dm)
     for (auto & it : this->fields) {
         FieldInfo & fi = it.second;
         ierr = DMSetField(dm, fi.id, fi.block, (PetscObject) fi.fe);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
     }
 
     ierr = DMCreateDS(dm);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = DMGetDS(dm, &this->ds);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
-    onSetWeakForm();
-    setUpBoundaryConditions(dm);
-    setUpConstants();
+    on_set_weak_form();
+    set_up_boundary_conditions(dm);
+    set_up_constants();
 
     DM cdm = dm;
     while (cdm) {
-        setUpAuxiliaryDM(cdm);
+        set_up_auxiliary_dm(cdm);
 
         ierr = DMCopyDisc(dm, cdm);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         ierr = DMGetCoarseDM(cdm, &cdm);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
     }
 }
 
 void
-FEProblemInterface::setUpAuxiliaryDM(DM dm)
+FEProblemInterface::set_up_auxiliary_dm(DM dm)
 {
     _F_;
     PetscErrorCode ierr;
 
     DM dm_aux;
     ierr = DMClone(dm, &dm_aux);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     for (auto & it : this->aux_fields) {
         FieldInfo & fi = it.second;
         ierr = DMSetField(dm_aux, fi.id, fi.block, (PetscObject) fi.fe);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
     }
 
     ierr = DMCreateDS(dm_aux);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     bool no_errors = true;
     for (auto & aux : this->auxs) {
-        PetscInt fid = aux->getFieldId();
-        if (hasAuxFieldById(fid)) {
-            PetscInt aux_nc = aux->getNumComponents();
+        PetscInt fid = aux->get_field_id();
+        if (has_aux_field_by_id(fid)) {
+            PetscInt aux_nc = aux->get_num_components();
             PetscInt field_nc = this->aux_fields[fid].nc;
             if (aux_nc != field_nc) {
                 no_errors = false;
                 this->logger.error("Auxiliary field '",
-                                   aux->getName(),
+                                   aux->get_name(),
                                    "' has ",
                                    aux_nc,
                                    " component(s), but is set on a field with ",
@@ -391,7 +391,7 @@ FEProblemInterface::setUpAuxiliaryDM(DM dm)
         else {
             no_errors = false;
             this->logger.error("Auxiliary field '",
-                               aux->getName(),
+                               aux->get_name(),
                                "' is set on auxiliary field with ID '",
                                fid,
                                "', but such ID does not exist.");
@@ -399,14 +399,14 @@ FEProblemInterface::setUpAuxiliaryDM(DM dm)
     }
     if (no_errors)
         for (auto & aux : this->auxs) {
-            aux->setUp(dm, dm_aux);
+            aux->set_up(dm, dm_aux);
         }
 
     ierr = DMDestroy(&dm_aux);
 }
 
 void
-FEProblemInterface::setUpConstants()
+FEProblemInterface::set_up_constants()
 {
     _F_;
     if (this->consts.size() == 0)
@@ -414,38 +414,38 @@ FEProblemInterface::setUpConstants()
 
     PetscErrorCode ierr;
     ierr = PetscDSSetConstants(this->ds, this->consts.size(), this->consts.data());
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-FEProblemInterface::setResidualBlock(PetscInt field_id,
-                                     PetscFEResidualFunc * f0,
-                                     PetscFEResidualFunc * f1)
+FEProblemInterface::set_residual_block(PetscInt field_id,
+                                       PetscFEResidualFunc * f0,
+                                       PetscFEResidualFunc * f1)
 {
     _F_;
     PetscErrorCode ierr;
     ierr = PetscDSSetResidual(this->ds, field_id, f0, f1);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-FEProblemInterface::setJacobianBlock(PetscInt fid,
-                                     PetscInt gid,
-                                     PetscFEJacobianFunc * g0,
-                                     PetscFEJacobianFunc * g1,
-                                     PetscFEJacobianFunc * g2,
-                                     PetscFEJacobianFunc * g3)
+FEProblemInterface::set_jacobian_block(PetscInt fid,
+                                       PetscInt gid,
+                                       PetscFEJacobianFunc * g0,
+                                       PetscFEJacobianFunc * g1,
+                                       PetscFEJacobianFunc * g2,
+                                       PetscFEJacobianFunc * g3)
 {
     _F_;
     PetscErrorCode ierr;
     ierr = PetscDSSetJacobian(this->ds, fid, gid, g0, g1, g2, g3);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 const PetscReal &
-FEProblemInterface::getTime() const
+FEProblemInterface::get_time() const
 {
-    return this->problem.getTime();
+    return this->problem.get_time();
 }
 
 } // namespace godzilla

--- a/src/FileOutput.cpp
+++ b/src/FileOutput.cpp
@@ -6,16 +6,16 @@ namespace godzilla {
 static const int MAX_PATH = 1024;
 
 InputParameters
-FileOutput::validParams()
+FileOutput::valid_params()
 {
-    InputParameters params = Output::validParams();
-    params.addRequiredParam<std::string>("file", "The name of the output file.");
+    InputParameters params = Output::valid_params();
+    params.add_required_param<std::string>("file", "The name of the output file.");
     return params;
 }
 
 FileOutput::FileOutput(const InputParameters & params) :
     Output(params),
-    file_base(getParam<std::string>("file")),
+    file_base(get_param<std::string>("file")),
     viewer(nullptr)
 {
     _F_;
@@ -26,69 +26,74 @@ FileOutput::~FileOutput()
     _F_;
     PetscErrorCode ierr;
     ierr = PetscViewerDestroy(&this->viewer);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 const std::string &
-FileOutput::getFileName() const
+FileOutput::get_file_name() const
 {
     _F_;
     return this->file_name;
 }
 
 void
-FileOutput::setFileName()
+FileOutput::set_file_name()
 {
     _F_;
     PetscErrorCode ierr;
     char fn[MAX_PATH];
-    snprintf(fn, MAX_PATH, "%s.%s", this->file_base.c_str(), this->getFileExt().c_str());
+    snprintf(fn, MAX_PATH, "%s.%s", this->file_base.c_str(), this->get_file_ext().c_str());
     ierr = PetscViewerFileSetName(this->viewer, fn);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     this->file_name = std::string(fn);
 }
 
 void
-FileOutput::setSequenceFileName(unsigned int stepi)
+FileOutput::set_sequence_file_name(unsigned int stepi)
 {
     _F_;
     PetscErrorCode ierr;
     char fn[MAX_PATH];
-    snprintf(fn, MAX_PATH, "%s.%d.%s", this->file_base.c_str(), stepi, this->getFileExt().c_str());
+    snprintf(fn,
+             MAX_PATH,
+             "%s.%d.%s",
+             this->file_base.c_str(),
+             stepi,
+             this->get_file_ext().c_str());
     ierr = PetscViewerFileSetName(this->viewer, fn);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     this->file_name = std::string(fn);
 }
 
 void
-FileOutput::outputMesh(DM dm)
+FileOutput::output_mesh(DM dm)
 {
     _F_;
     PetscErrorCode ierr;
     ierr = DMView(dm, this->viewer);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-FileOutput::outputSolution(Vec vec)
+FileOutput::output_solution(Vec vec)
 {
     _F_;
     PetscErrorCode ierr;
     ierr = VecView(vec, this->viewer);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-FileOutput::outputStep(PetscInt stepi, DM dm, Vec vec)
+FileOutput::output_step(PetscInt stepi, DM dm, Vec vec)
 {
     _F_;
     if (stepi == -1)
-        setFileName();
+        set_file_name();
     else
-        setSequenceFileName(stepi);
-    godzillaPrint(9, "Output to file: ", this->file_name);
-    outputMesh(dm);
-    outputSolution(vec);
+        set_sequence_file_name(stepi);
+    godzilla_print(9, "Output to file: ", this->file_name);
+    output_mesh(dm);
+    output_solution(vec);
 }
 
 } // namespace godzilla

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -5,9 +5,9 @@
 namespace godzilla {
 
 InputParameters
-Function::validParams()
+Function::valid_params()
 {
-    InputParameters params = Object::validParams();
+    InputParameters params = Object::valid_params();
     return params;
 }
 

--- a/src/FunctionAuxiliaryField.cpp
+++ b/src/FunctionAuxiliaryField.cpp
@@ -21,10 +21,10 @@ __function_auxiliary_field(PetscInt dim,
 }
 
 InputParameters
-FunctionAuxiliaryField::validParams()
+FunctionAuxiliaryField::valid_params()
 {
-    InputParameters params = AuxiliaryField::validParams();
-    params += FunctionInterface::validParams();
+    InputParameters params = AuxiliaryField::valid_params();
+    params += FunctionInterface::valid_params();
     return params;
 }
 
@@ -43,13 +43,13 @@ FunctionAuxiliaryField::create()
 }
 
 PetscInt
-FunctionAuxiliaryField::getNumComponents() const
+FunctionAuxiliaryField::get_num_components() const
 {
     return this->num_comps;
 }
 
 void
-FunctionAuxiliaryField::setUp(DM dm, DM dm_aux)
+FunctionAuxiliaryField::set_up(DM dm, DM dm_aux)
 {
     _F_;
     PetscErrorCode ierr;
@@ -57,18 +57,18 @@ FunctionAuxiliaryField::setUp(DM dm, DM dm_aux)
     void * ctxs[1] = { this };
 
     ierr = DMCreateLocalVector(dm_aux, &this->a);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = DMProjectFunctionLocal(dm_aux,
-                                  this->fepi.getTime(),
+                                  this->fepi.get_time(),
                                   func,
                                   ctxs,
                                   INSERT_ALL_VALUES,
                                   this->a);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = DMSetAuxiliaryVec(dm, this->block, 0, 0, this->a);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
@@ -80,7 +80,7 @@ FunctionAuxiliaryField::evaluate(PetscInt dim,
 {
     _F_;
     for (PetscInt i = 0; i < nc; i++)
-        u[i] = evaluateFunction(i, dim, time, x);
+        u[i] = evaluate_function(i, dim, time, x);
 }
 
 } // namespace godzilla

--- a/src/FunctionAuxiliaryField.cpp
+++ b/src/FunctionAuxiliaryField.cpp
@@ -80,7 +80,7 @@ FunctionAuxiliaryField::evaluate(PetscInt dim,
 {
     _F_;
     for (PetscInt i = 0; i < nc; i++)
-        u[i] = evaluate_function(i, dim, time, x);
+        u[i] = FunctionInterface::evaluate(i, dim, time, x);
 }
 
 } // namespace godzilla

--- a/src/FunctionEvaluator.cpp
+++ b/src/FunctionEvaluator.cpp
@@ -19,10 +19,10 @@ FunctionEvaluator::create(const std::string & expr)
 }
 
 void
-FunctionEvaluator::registerFunction(Function * fn)
+FunctionEvaluator::register_function(Function * fn)
 {
     _F_;
-    fn->registerCallback(this->parser);
+    fn->register_callback(this->parser);
 }
 
 PetscReal

--- a/src/FunctionIC.cpp
+++ b/src/FunctionIC.cpp
@@ -40,7 +40,7 @@ FunctionIC::evaluate(PetscInt dim,
                      PetscScalar u[])
 {
     for (PetscInt i = 0; i < Nc; i++)
-        u[i] = evaluate_function(i, dim, time, x);
+        u[i] = FunctionInterface::evaluate(i, dim, time, x);
 }
 
 } // namespace godzilla

--- a/src/FunctionIC.cpp
+++ b/src/FunctionIC.cpp
@@ -6,10 +6,10 @@ namespace godzilla {
 registerObject(FunctionIC);
 
 InputParameters
-FunctionIC::validParams()
+FunctionIC::valid_params()
 {
-    InputParameters params = InitialCondition::validParams();
-    params += FunctionInterface::validParams();
+    InputParameters params = InitialCondition::valid_params();
+    params += FunctionInterface::valid_params();
     return params;
 }
 
@@ -27,7 +27,7 @@ FunctionIC::create()
 }
 
 PetscInt
-FunctionIC::getNumComponents() const
+FunctionIC::get_num_components() const
 {
     return this->num_comps;
 }
@@ -40,7 +40,7 @@ FunctionIC::evaluate(PetscInt dim,
                      PetscScalar u[])
 {
     for (PetscInt i = 0; i < Nc; i++)
-        u[i] = evaluateFunction(i, dim, time, x);
+        u[i] = evaluate_function(i, dim, time, x);
 }
 
 } // namespace godzilla

--- a/src/FunctionInterface.cpp
+++ b/src/FunctionInterface.cpp
@@ -6,10 +6,10 @@
 namespace godzilla {
 
 InputParameters
-FunctionInterface::validParams()
+FunctionInterface::valid_params()
 {
     InputParameters params = emptyInputParameters();
-    params.addRequiredParam<std::vector<std::string>>("value", "Function expression to evaluate.");
+    params.add_required_param<std::vector<std::string>>("value", "Function expression to evaluate.");
     return params;
 }
 
@@ -30,18 +30,18 @@ FunctionInterface::create()
         this->evalr[i].create(this->expression[i]);
 
     assert(this->fi_app != nullptr);
-    Problem * p = this->fi_app->getProblem();
+    Problem * p = this->fi_app->get_problem();
     if (p) {
-        const auto & funcs = p->getFunctions();
+        const auto & funcs = p->get_functions();
         for (unsigned int i = 0; i < this->num_comps; i++) {
             for (auto & f : funcs)
-                this->evalr[i].registerFunction(f);
+                this->evalr[i].register_function(f);
         }
     }
 }
 
 PetscReal
-FunctionInterface::evaluateFunction(unsigned int idx,
+FunctionInterface::evaluate_function(unsigned int idx,
                                     PetscInt dim,
                                     PetscReal time,
                                     const PetscReal x[])

--- a/src/FunctionInterface.cpp
+++ b/src/FunctionInterface.cpp
@@ -8,7 +8,7 @@ namespace godzilla {
 InputParameters
 FunctionInterface::valid_params()
 {
-    InputParameters params = emptyInputParameters();
+    InputParameters params;
     params.add_required_param<std::vector<std::string>>("value", "Function expression to evaluate.");
     return params;
 }

--- a/src/FunctionInterface.cpp
+++ b/src/FunctionInterface.cpp
@@ -9,7 +9,8 @@ InputParameters
 FunctionInterface::valid_params()
 {
     InputParameters params;
-    params.add_required_param<std::vector<std::string>>("value", "Function expression to evaluate.");
+    params.add_required_param<std::vector<std::string>>("value",
+                                                        "Function expression to evaluate.");
     return params;
 }
 
@@ -41,10 +42,7 @@ FunctionInterface::create()
 }
 
 PetscReal
-FunctionInterface::evaluate_function(unsigned int idx,
-                                    PetscInt dim,
-                                    PetscReal time,
-                                    const PetscReal x[])
+FunctionInterface::evaluate(unsigned int idx, PetscInt dim, PetscReal time, const PetscReal x[])
 {
     return this->evalr[idx].evaluate(dim, time, x);
 }

--- a/src/HDF5Output.cpp
+++ b/src/HDF5Output.cpp
@@ -31,7 +31,7 @@ void
 HDF5Output::create()
 {
     PetscErrorCode ierr;
-    ierr = PetscViewerCreate(comm(), &this->viewer);
+    ierr = PetscViewerCreate(get_comm(), &this->viewer);
     check_petsc_error(ierr);
     ierr = PetscViewerSetType(this->viewer, PETSCVIEWERHDF5);
     check_petsc_error(ierr);

--- a/src/HDF5Output.cpp
+++ b/src/HDF5Output.cpp
@@ -10,9 +10,9 @@ registerObject(HDF5Output);
 static const int MAX_PATH = 1024;
 
 InputParameters
-HDF5Output::validParams()
+HDF5Output::valid_params()
 {
-    InputParameters params = FileOutput::validParams();
+    InputParameters params = FileOutput::valid_params();
     return params;
 }
 
@@ -22,7 +22,7 @@ HDF5Output::HDF5Output(const InputParameters & params) : FileOutput(params)
 }
 
 std::string
-HDF5Output::getFileExt() const
+HDF5Output::get_file_ext() const
 {
     return std::string("h5");
 }
@@ -32,11 +32,11 @@ HDF5Output::create()
 {
     PetscErrorCode ierr;
     ierr = PetscViewerCreate(comm(), &this->viewer);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscViewerSetType(this->viewer, PETSCVIEWERHDF5);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscViewerFileSetMode(this->viewer, FILE_MODE_WRITE);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -59,7 +59,7 @@ ImplicitFENonlinearProblem::init()
 {
     _F_;
     PetscErrorCode ierr;
-    TransientInterface::init(comm());
+    TransientInterface::init(get_comm());
     ierr = TSSetApplicationContext(this->ts, this);
     check_petsc_error(ierr);
     ierr = TSGetSNES(this->ts, &this->snes);

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -13,7 +13,7 @@ __transient_pre_step(TS ts)
     void * ctx;
     TSGetApplicationContext(ts, &ctx);
     ImplicitFENonlinearProblem * prob = static_cast<ImplicitFENonlinearProblem *>(ctx);
-    return prob->onPreStep();
+    return prob->on_pre_step();
 }
 
 PetscErrorCode
@@ -23,7 +23,7 @@ __transient_post_step(TS ts)
     void * ctx;
     TSGetApplicationContext(ts, &ctx);
     ImplicitFENonlinearProblem * prob = static_cast<ImplicitFENonlinearProblem *>(ctx);
-    return prob->onPostStep();
+    return prob->on_post_step();
 }
 
 PetscErrorCode
@@ -31,14 +31,14 @@ __transient_monitor(TS ts, PetscInt stepi, PetscReal time, Vec X, void * ctx)
 {
     _F_;
     ImplicitFENonlinearProblem * prob = static_cast<ImplicitFENonlinearProblem *>(ctx);
-    return prob->tsMonitorCallback(stepi, time, X);
+    return prob->ts_monitor_callback(stepi, time, X);
 }
 
 InputParameters
-ImplicitFENonlinearProblem::validParams()
+ImplicitFENonlinearProblem::valid_params()
 {
-    InputParameters params = FENonlinearProblem::validParams();
-    params += TransientInterface::validParams();
+    InputParameters params = FENonlinearProblem::valid_params();
+    params += TransientInterface::valid_params();
     return params;
 }
 
@@ -61,11 +61,11 @@ ImplicitFENonlinearProblem::init()
     PetscErrorCode ierr;
     TransientInterface::init(comm());
     ierr = TSSetApplicationContext(this->ts, this);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = TSGetSNES(this->ts, &this->snes);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
-    FEProblemInterface::init(getDM());
+    FEProblemInterface::init(get_dm());
 }
 
 void
@@ -73,40 +73,40 @@ ImplicitFENonlinearProblem::create()
 {
     _F_;
     FENonlinearProblem::create();
-    TransientInterface::create(getDM());
+    TransientInterface::create(get_dm());
 }
 
 PetscErrorCode
-ImplicitFENonlinearProblem::onPreStep()
+ImplicitFENonlinearProblem::on_pre_step()
 {
     _F_;
     return 0;
 }
 
 PetscErrorCode
-ImplicitFENonlinearProblem::onPostStep()
+ImplicitFENonlinearProblem::on_post_step()
 {
     _F_;
     PetscErrorCode ierr;
     Vec sln;
     ierr = TSGetSolution(this->ts, &sln);
-    checkPetscError(ierr);
-    computePostprocessors();
-    outputStep(sln);
+    check_petsc_error(ierr);
+    compute_postprocessors();
+    output_step(sln);
     return 0;
 }
 
 PetscErrorCode
-ImplicitFENonlinearProblem::tsMonitorCallback(PetscInt stepi, PetscReal t, Vec X)
+ImplicitFENonlinearProblem::ts_monitor_callback(PetscInt stepi, PetscReal t, Vec X)
 {
     _F_;
     PetscErrorCode ierr;
     PetscReal dt;
     ierr = TSGetTimeStep(this->ts, &dt);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     this->time = t;
     this->step_num = stepi;
-    godzillaPrint(6, stepi, " Time ", t, ", dt = ", dt);
+    godzilla_print(6, stepi, " Time ", t, ", dt = ", dt);
     return 0;
 }
 
@@ -121,40 +121,40 @@ void
 ImplicitFENonlinearProblem::run()
 {
     _F_;
-    godzillaPrint(5, "Executing...");
+    godzilla_print(5, "Executing...");
     // output initial condition
-    outputStep(this->x);
+    output_step(this->x);
     solve();
 }
 
 void
-ImplicitFENonlinearProblem::setUpCallbacks()
+ImplicitFENonlinearProblem::set_up_callbacks()
 {
     _F_;
     PetscErrorCode ierr;
-    DM dm = getDM();
+    DM dm = get_dm();
 
     ierr = DMTSSetBoundaryLocal(dm, DMPlexTSComputeBoundary, this);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = DMTSSetIFunctionLocal(dm, DMPlexTSComputeIFunctionFEM, this);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = DMTSSetIJacobianLocal(dm, DMPlexTSComputeIJacobianFEM, this);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-ImplicitFENonlinearProblem::setUpMonitors()
+ImplicitFENonlinearProblem::set_up_monitors()
 {
     _F_;
-    FENonlinearProblem::setUpMonitors();
+    FENonlinearProblem::set_up_monitors();
 
     PetscErrorCode ierr;
     ierr = TSSetPreStep(this->ts, __transient_pre_step);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = TSSetPostStep(this->ts, __transient_post_step);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = TSMonitorSet(this->ts, __transient_monitor, this, NULL);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
@@ -164,14 +164,14 @@ ImplicitFENonlinearProblem::output()
 }
 
 void
-ImplicitFENonlinearProblem::outputStep(Vec vec)
+ImplicitFENonlinearProblem::output_step(Vec vec)
 {
     _F_;
     PetscErrorCode ierr;
-    DM dm = getDM();
+    DM dm = get_dm();
 
     for (auto & o : this->outputs)
-        o->outputStep(this->step_num, dm, vec);
+        o->output_step(this->step_num, dm, vec);
 }
 
 } // namespace godzilla

--- a/src/InitialCondition.cpp
+++ b/src/InitialCondition.cpp
@@ -21,9 +21,9 @@ __initial_condition_function(PetscInt dim,
 }
 
 InputParameters
-InitialCondition::validParams()
+InitialCondition::valid_params()
 {
-    InputParameters params = Object::validParams();
+    InputParameters params = Object::valid_params();
     return params;
 }
 
@@ -35,7 +35,7 @@ InitialCondition::InitialCondition(const InputParameters & params) :
 }
 
 PetscInt
-InitialCondition::getFieldId() const
+InitialCondition::get_field_id() const
 {
     _F_;
     // FIXME: when we have support for multiple-fields, this needs to tell us where it belongs

--- a/src/InputParameters.cpp
+++ b/src/InputParameters.cpp
@@ -3,13 +3,6 @@
 
 namespace godzilla {
 
-InputParameters
-emptyInputParameters()
-{
-    InputParameters params;
-    return params;
-}
-
 InputParameters::InputParameters() {}
 
 InputParameters::InputParameters(const InputParameters & p)

--- a/src/L2Diff.cpp
+++ b/src/L2Diff.cpp
@@ -21,10 +21,10 @@ __l2_diff(PetscInt dim,
 }
 
 InputParameters
-L2Diff::validParams()
+L2Diff::valid_params()
 {
-    InputParameters params = Postprocessor::validParams();
-    params += FunctionInterface::validParams();
+    InputParameters params = Postprocessor::valid_params();
+    params += FunctionInterface::valid_params();
     return params;
 }
 
@@ -49,17 +49,17 @@ L2Diff::compute()
     PetscErrorCode ierr;
     PetscFunc * funcs[1] = { __l2_diff };
     void * ctxs[1] = { this };
-    ierr = DMComputeL2Diff(this->problem.getDM(),
-                           this->problem.getTime(),
+    ierr = DMComputeL2Diff(this->problem.get_dm(),
+                           this->problem.get_time(),
                            funcs,
                            ctxs,
-                           this->problem.getSolutionVector(),
+                           this->problem.get_solution_vector(),
                            &this->l2_diff);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 PetscReal
-L2Diff::getValue()
+L2Diff::get_value()
 {
     _F_;
     return this->l2_diff;
@@ -70,7 +70,7 @@ L2Diff::evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc,
 {
     _F_;
     for (PetscInt i = 0; i < nc; i++)
-        u[i] = evaluateFunction(i, dim, time, x);
+        u[i] = evaluate_function(i, dim, time, x);
 }
 
 } // namespace godzilla

--- a/src/L2Diff.cpp
+++ b/src/L2Diff.cpp
@@ -70,7 +70,7 @@ L2Diff::evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc,
 {
     _F_;
     for (PetscInt i = 0; i < nc; i++)
-        u[i] = evaluate_function(i, dim, time, x);
+        u[i] = FunctionInterface::evaluate(i, dim, time, x);
 }
 
 } // namespace godzilla

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -9,50 +9,50 @@ namespace godzilla {
 registerObject(LineMesh);
 
 InputParameters
-LineMesh::validParams()
+LineMesh::valid_params()
 {
-    InputParameters params = UnstructuredMesh::validParams();
-    params.addParam<PetscReal>("xmin", 0., "Minimum in the x direction");
-    params.addParam<PetscReal>("xmax", 1., "Maximum in the x direction");
-    params.addRequiredParam<PetscInt>("nx", "Number of mesh points in the x direction");
+    InputParameters params = UnstructuredMesh::valid_params();
+    params.add_param<PetscReal>("xmin", 0., "Minimum in the x direction");
+    params.add_param<PetscReal>("xmax", 1., "Maximum in the x direction");
+    params.add_required_param<PetscInt>("nx", "Number of mesh points in the x direction");
     return params;
 }
 
 LineMesh::LineMesh(const InputParameters & parameters) :
     UnstructuredMesh(parameters),
-    xmin(getParam<PetscReal>("xmin")),
-    xmax(getParam<PetscReal>("xmax")),
-    nx(getParam<PetscInt>("nx")),
+    xmin(get_param<PetscReal>("xmin")),
+    xmax(get_param<PetscReal>("xmax")),
+    nx(get_param<PetscInt>("nx")),
     interpolate(PETSC_TRUE)
 {
     _F_;
     if (this->xmax <= this->xmin)
-        logError("Parameter 'xmax' must be larger than 'xmin'.");
+        log_error("Parameter 'xmax' must be larger than 'xmin'.");
 }
 
 PetscReal
-LineMesh::getXMin()
+LineMesh::get_x_min()
 {
     _F_;
     return this->xmin;
 }
 
 PetscReal
-LineMesh::getXMax()
+LineMesh::get_x_max()
 {
     _F_;
     return this->xmax;
 }
 
 PetscInt
-LineMesh::getNx()
+LineMesh::get_nx()
 {
     _F_;
     return this->nx;
 }
 
 void
-LineMesh::createDM()
+LineMesh::create_dm()
 {
     _F_;
     PetscErrorCode ierr;
@@ -71,7 +71,7 @@ LineMesh::createDM()
                                periodicity,
                                interpolate,
                                &this->dm);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     // create user-friendly names for sides
     DMLabel face_sets_label;
@@ -81,25 +81,25 @@ LineMesh::createDM()
     for (unsigned int i = 0; i < 2; i++) {
         IS is;
         ierr = DMLabelGetStratumIS(face_sets_label, i + 1, &is);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         ierr = DMCreateLabel(this->dm, side_name[i]);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         DMLabel label;
         ierr = DMGetLabel(this->dm, side_name[i], &label);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         if (is != nullptr) {
             ierr = DMLabelSetStratumIS(label, i + 1, is);
-            checkPetscError(ierr);
+            check_petsc_error(ierr);
         }
 
         ierr = ISDestroy(&is);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         ierr = DMPlexLabelComplete(this->dm, label);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
     }
 }
 

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -62,7 +62,7 @@ LineMesh::create_dm()
     PetscInt faces[1] = { this->nx };
     DMBoundaryType periodicity[1] = { DM_BOUNDARY_GHOSTED };
 
-    ierr = DMPlexCreateBoxMesh(comm(),
+    ierr = DMPlexCreateBoxMesh(get_comm(),
                                1,
                                PETSC_TRUE,
                                faces,

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -11,7 +11,7 @@ __compute_rhs(KSP ksp, Vec b, void * ctx)
 {
     _F_;
     LinearProblem * problem = static_cast<LinearProblem *>(ctx);
-    return problem->computeRhsCallback(b);
+    return problem->compute_rhs_callback(b);
 }
 
 PetscErrorCode
@@ -19,7 +19,7 @@ __compute_operators(KSP ksp, Mat A, Mat B, void * ctx)
 {
     _F_;
     LinearProblem * problem = static_cast<LinearProblem *>(ctx);
-    return problem->computeOperatorsCallback(A, B);
+    return problem->compute_operators_callback(A, B);
 }
 
 PetscErrorCode
@@ -27,22 +27,22 @@ __ksp_monitor_linear(KSP ksp, PetscInt it, PetscReal rnorm, void * ctx)
 {
     _F_;
     LinearProblem * problem = static_cast<LinearProblem *>(ctx);
-    return problem->kspMonitorCallback(it, rnorm);
+    return problem->ksp_monitor_callback(it, rnorm);
 }
 
 InputParameters
-LinearProblem::validParams()
+LinearProblem::valid_params()
 {
-    InputParameters params = Problem::validParams();
-    params.addParam<PetscReal>("lin_rel_tol",
-                               1e-5,
-                               "Relative convergence tolerance for the linear solver");
-    params.addParam<PetscReal>("lin_abs_tol",
-                               1e-50,
-                               "Absolute convergence tolerance for the linear solver");
-    params.addParam<PetscInt>("lin_max_iter",
-                              10000,
-                              "Maximum number of iterations for the linear solver");
+    InputParameters params = Problem::valid_params();
+    params.add_param<PetscReal>("lin_rel_tol",
+                                1e-5,
+                                "Relative convergence tolerance for the linear solver");
+    params.add_param<PetscReal>("lin_abs_tol",
+                                1e-50,
+                                "Absolute convergence tolerance for the linear solver");
+    params.add_param<PetscInt>("lin_max_iter",
+                               10000,
+                               "Maximum number of iterations for the linear solver");
     return params;
 }
 
@@ -53,9 +53,9 @@ LinearProblem::LinearProblem(const InputParameters & parameters) :
     b(NULL),
     A(NULL),
     B(NULL),
-    lin_rel_tol(getParam<PetscReal>("lin_rel_tol")),
-    lin_abs_tol(getParam<PetscReal>("lin_abs_tol")),
-    lin_max_iter(getParam<PetscInt>("lin_max_iter"))
+    lin_rel_tol(get_param<PetscReal>("lin_rel_tol")),
+    lin_abs_tol(get_param<PetscReal>("lin_abs_tol")),
+    lin_max_iter(get_param<PetscInt>("lin_max_iter"))
 {
     _F_;
 }
@@ -76,14 +76,14 @@ LinearProblem::~LinearProblem()
 }
 
 DM
-LinearProblem::getDM() const
+LinearProblem::get_dm() const
 {
     _F_;
-    return this->mesh->getDM();
+    return this->mesh->get_dm();
 }
 
 Vec
-LinearProblem::getSolutionVector() const
+LinearProblem::get_solution_vector() const
 {
     _F_;
     return this->x;
@@ -94,12 +94,12 @@ LinearProblem::create()
 {
     _F_;
     init();
-    allocateObjects();
-    onSetMatrixProperties();
+    allocate_objects();
+    on_set_matrix_properties();
 
-    setUpSolverParameters();
-    setUpMonitors();
-    setUpCallbacks();
+    set_up_solver_parameters();
+    set_up_monitors();
+    set_up_callbacks();
 
     Problem::create();
 }
@@ -109,65 +109,65 @@ LinearProblem::init()
 {
     _F_;
     PetscErrorCode ierr;
-    DM dm = getDM();
+    DM dm = get_dm();
 
     ierr = KSPCreate(comm(), &this->ksp);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = KSPSetDM(this->ksp, dm);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = DMSetApplicationContext(dm, this);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-LinearProblem::allocateObjects()
+LinearProblem::allocate_objects()
 {
     _F_;
     PetscErrorCode ierr;
-    DM dm = getDM();
+    DM dm = get_dm();
 
     ierr = DMCreateGlobalVector(dm, &this->x);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscObjectSetName((PetscObject) this->x, "sln");
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = VecDuplicate(this->x, &this->b);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscObjectSetName((PetscObject) this->b, "rhs");
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = DMCreateMatrix(dm, &this->A);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscObjectSetName((PetscObject) this->A, "A");
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     // TODO: Add API for setting up preconditioners
     this->B = this->A;
 }
 
 void
-LinearProblem::setUpCallbacks()
+LinearProblem::set_up_callbacks()
 {
     _F_;
     PetscErrorCode ierr;
 
     ierr = KSPSetComputeRHS(this->ksp, __compute_rhs, this);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = KSPSetComputeOperators(this->ksp, __compute_operators, this);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-LinearProblem::setUpMonitors()
+LinearProblem::set_up_monitors()
 {
     _F_;
     PetscErrorCode ierr;
 
     ierr = KSPMonitorSet(this->ksp, __ksp_monitor_linear, this, 0);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-LinearProblem::setUpSolverParameters()
+LinearProblem::set_up_solver_parameters()
 {
     _F_;
     PetscErrorCode ierr;
@@ -177,16 +177,16 @@ LinearProblem::setUpSolverParameters()
                             this->lin_abs_tol,
                             PETSC_DEFAULT,
                             this->lin_max_iter);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = KSPSetFromOptions(ksp);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 PetscErrorCode
-LinearProblem::kspMonitorCallback(PetscInt it, PetscReal rnorm)
+LinearProblem::ksp_monitor_callback(PetscInt it, PetscReal rnorm)
 {
     _F_;
-    godzillaPrint(8, it, " Linear residual: ", std::scientific, rnorm);
+    godzilla_print(8, it, " Linear residual: ", std::scientific, rnorm);
     return 0;
 }
 
@@ -197,9 +197,9 @@ LinearProblem::solve()
     PetscErrorCode ierr;
 
     ierr = KSPSolve(this->ksp, this->b, this->x);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = KSPGetConvergedReason(this->ksp, &this->converged_reason);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 bool
@@ -223,7 +223,7 @@ LinearProblem::run()
 {
     _F_;
     solve();
-    computePostprocessors();
+    compute_postprocessors();
     if (converged())
         output();
 }
@@ -233,11 +233,11 @@ LinearProblem::output()
 {
     _F_;
     for (auto & o : this->outputs)
-        o->outputStep(-1, getDM(), this->x);
+        o->output_step(-1, get_dm(), this->x);
 }
 
 void
-LinearProblem::onSetMatrixProperties()
+LinearProblem::on_set_matrix_properties()
 {
 }
 

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -111,7 +111,7 @@ LinearProblem::init()
     PetscErrorCode ierr;
     DM dm = get_dm();
 
-    ierr = KSPCreate(comm(), &this->ksp);
+    ierr = KSPCreate(get_comm(), &this->ksp);
     check_petsc_error(ierr);
     ierr = KSPSetDM(this->ksp, dm);
     check_petsc_error(ierr);

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -9,21 +9,21 @@ Logger::Logger() : num_errors(0), num_warnings(0)
 }
 
 std::size_t
-Logger::getNumEntries() const
+Logger::get_num_entries() const
 {
     _F_;
     return this->entries.size();
 }
 
 std::size_t
-Logger::getNumErrors() const
+Logger::get_num_errors() const
 {
     _F_;
     return this->num_errors;
 }
 
 std::size_t
-Logger::getNumWarnings() const
+Logger::get_num_warnings() const
 {
     _F_;
     return this->num_warnings;

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -5,9 +5,9 @@
 namespace godzilla {
 
 InputParameters
-Mesh::validParams()
+Mesh::valid_params()
 {
-    InputParameters params = Object::validParams();
+    InputParameters params = Object::valid_params();
     return params;
 }
 
@@ -25,19 +25,19 @@ Mesh::~Mesh()
     if (this->dm) {
         PetscErrorCode ierr;
         ierr = DMDestroy(&this->dm);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
     }
 }
 
 DM
-Mesh::getDM() const
+Mesh::get_dm() const
 {
     _F_;
     return this->dm;
 }
 
 PetscInt
-Mesh::getDimension() const
+Mesh::get_dimension() const
 {
     _F_;
     return this->dim;
@@ -49,11 +49,11 @@ Mesh::create()
     _F_;
     PetscErrorCode ierr;
 
-    createDM();
+    create_dm();
     ierr = DMSetUp(this->dm);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = DMGetDimension(this->dm, &this->dim);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     distribute();
 }
 

--- a/src/NaturalBC.cpp
+++ b/src/NaturalBC.cpp
@@ -4,9 +4,9 @@
 namespace godzilla {
 
 InputParameters
-NaturalBC::validParams()
+NaturalBC::valid_params()
 {
-    InputParameters params = BoundaryCondition::validParams();
+    InputParameters params = BoundaryCondition::valid_params();
     return params;
 }
 
@@ -19,31 +19,31 @@ NaturalBC::NaturalBC(const InputParameters & params) :
 }
 
 DMBoundaryConditionType
-NaturalBC::getBcType() const
+NaturalBC::get_bc_type() const
 {
     _F_;
     return DM_BC_NATURAL;
 }
 
 void
-NaturalBC::setUpCallback()
+NaturalBC::set_up_callback()
 {
     _F_;
     PetscErrorCode ierr;
     ierr = PetscDSAddBoundary(this->ds,
-                              getBcType(),
-                              getName().c_str(),
+                              get_bc_type(),
+                              get_name().c_str(),
                               this->label,
                               this->n_ids,
                               this->ids,
-                              getFieldId(),
-                              getNumComponents(),
-                              getNumComponents() == 0 ? nullptr : getComponents().data(),
+                              get_field_id(),
+                              get_num_components(),
+                              get_num_components() == 0 ? nullptr : get_components().data(),
                               nullptr,
                               nullptr,
                               (void *) this,
                               &this->bd);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = PetscDSGetBoundary(ds,
                               this->bd,
@@ -59,27 +59,27 @@ NaturalBC::setUpCallback()
                               nullptr,
                               nullptr,
                               nullptr);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
-    onSetWeakForm();
+    on_set_weak_form();
 }
 
 void
-NaturalBC::setResidualBlock(PetscFEBndResidualFunc * f0, PetscFEBndResidualFunc * f1)
+NaturalBC::set_residual_block(PetscFEBndResidualFunc * f0, PetscFEBndResidualFunc * f1)
 {
     _F_;
     for (PetscInt i = 0; i < this->n_ids; i++) {
         PetscInt id = this->ids[i];
-        PetscWeakFormSetIndexBdResidual(this->wf, this->label, id, getFieldId(), 0, 0, f0, 0, f1);
+        PetscWeakFormSetIndexBdResidual(this->wf, this->label, id, get_field_id(), 0, 0, f0, 0, f1);
     }
 }
 
 void
-NaturalBC::setJacobianBlock(PetscInt gid,
-                            PetscFEBndJacobianFunc * g0,
-                            PetscFEBndJacobianFunc * g1,
-                            PetscFEBndJacobianFunc * g2,
-                            PetscFEBndJacobianFunc * g3)
+NaturalBC::set_jacobian_block(PetscInt gid,
+                              PetscFEBndJacobianFunc * g0,
+                              PetscFEBndJacobianFunc * g1,
+                              PetscFEBndJacobianFunc * g2,
+                              PetscFEBndJacobianFunc * g3)
 {
     _F_;
     for (PetscInt i = 0; i < this->n_ids; i++) {
@@ -87,7 +87,7 @@ NaturalBC::setJacobianBlock(PetscInt gid,
         PetscWeakFormSetIndexBdJacobian(this->wf,
                                         this->label,
                                         id,
-                                        getFieldId(),
+                                        get_field_id(),
                                         gid,
                                         0,
                                         0,

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -143,7 +143,7 @@ NonlinearProblem::init()
     PetscErrorCode ierr;
     DM dm = get_dm();
 
-    ierr = SNESCreate(comm(), &this->snes);
+    ierr = SNESCreate(get_comm(), &this->snes);
     check_petsc_error(ierr);
     ierr = SNESSetDM(this->snes, dm);
     check_petsc_error(ierr);

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -12,7 +12,7 @@ __compute_residual(SNES snes, Vec x, Vec f, void * ctx)
 {
     _F_;
     NonlinearProblem * problem = static_cast<NonlinearProblem *>(ctx);
-    return problem->computeResidualCallback(x, f);
+    return problem->compute_residual_callback(x, f);
 }
 
 PetscErrorCode
@@ -20,7 +20,7 @@ __compute_jacobian(SNES snes, Vec x, Mat J, Mat Jp, void * ctx)
 {
     _F_;
     NonlinearProblem * problem = static_cast<NonlinearProblem *>(ctx);
-    return problem->computeJacobianCallback(x, J, Jp);
+    return problem->compute_jacobian_callback(x, J, Jp);
 }
 
 PetscErrorCode
@@ -28,7 +28,7 @@ __ksp_monitor(KSP ksp, PetscInt it, PetscReal rnorm, void * ctx)
 {
     _F_;
     NonlinearProblem * problem = static_cast<NonlinearProblem *>(ctx);
-    return problem->kspMonitorCallback(it, rnorm);
+    return problem->ksp_monitor_callback(it, rnorm);
 }
 
 PetscErrorCode
@@ -36,36 +36,36 @@ __snes_monitor(SNES snes, PetscInt it, PetscReal norm, void * ctx)
 {
     _F_;
     NonlinearProblem * problem = static_cast<NonlinearProblem *>(ctx);
-    return problem->snesMonitorCallback(it, norm);
+    return problem->snes_monitor_callback(it, norm);
 }
 
 InputParameters
-NonlinearProblem::validParams()
+NonlinearProblem::valid_params()
 {
-    InputParameters params = Problem::validParams();
-    params.addParam<std::string>("line_search", "bt", "The type of line search to be used");
-    params.addParam<PetscReal>("nl_rel_tol",
-                               1e-8,
-                               "Relative convergence tolerance for the non-linear solver");
-    params.addParam<PetscReal>("nl_abs_tol",
-                               1e-15,
-                               "Absolute convergence tolerance for the non-linear solver");
-    params.addParam<PetscReal>(
+    InputParameters params = Problem::valid_params();
+    params.add_param<std::string>("line_search", "bt", "The type of line search to be used");
+    params.add_param<PetscReal>("nl_rel_tol",
+                                1e-8,
+                                "Relative convergence tolerance for the non-linear solver");
+    params.add_param<PetscReal>("nl_abs_tol",
+                                1e-15,
+                                "Absolute convergence tolerance for the non-linear solver");
+    params.add_param<PetscReal>(
         "nl_step_tol",
         1e-15,
         "Convergence tolerance in terms of the norm of the change in the solution between steps");
-    params.addParam<PetscInt>("nl_max_iter",
-                              40,
-                              "Maximum number of iterations for the non-linear solver");
-    params.addParam<PetscReal>("lin_rel_tol",
-                               1e-5,
-                               "Relative convergence tolerance for the linear solver");
-    params.addParam<PetscReal>("lin_abs_tol",
-                               1e-50,
-                               "Absolute convergence tolerance for the linear solver");
-    params.addParam<PetscInt>("lin_max_iter",
-                              10000,
-                              "Maximum number of iterations for the linear solver");
+    params.add_param<PetscInt>("nl_max_iter",
+                               40,
+                               "Maximum number of iterations for the non-linear solver");
+    params.add_param<PetscReal>("lin_rel_tol",
+                                1e-5,
+                                "Relative convergence tolerance for the linear solver");
+    params.add_param<PetscReal>("lin_abs_tol",
+                                1e-50,
+                                "Absolute convergence tolerance for the linear solver");
+    params.add_param<PetscInt>("lin_max_iter",
+                               10000,
+                               "Maximum number of iterations for the linear solver");
     return params;
 }
 
@@ -76,17 +76,17 @@ NonlinearProblem::NonlinearProblem(const InputParameters & parameters) :
     r(NULL),
     J(NULL),
     Jp(NULL),
-    line_search_type(getParam<std::string>("line_search")),
-    nl_rel_tol(getParam<PetscReal>("nl_rel_tol")),
-    nl_abs_tol(getParam<PetscReal>("nl_abs_tol")),
-    nl_step_tol(getParam<PetscReal>("nl_step_tol")),
-    nl_max_iter(getParam<PetscInt>("nl_max_iter")),
-    lin_rel_tol(getParam<PetscReal>("lin_rel_tol")),
-    lin_abs_tol(getParam<PetscReal>("lin_abs_tol")),
-    lin_max_iter(getParam<PetscInt>("lin_max_iter"))
+    line_search_type(get_param<std::string>("line_search")),
+    nl_rel_tol(get_param<PetscReal>("nl_rel_tol")),
+    nl_abs_tol(get_param<PetscReal>("nl_abs_tol")),
+    nl_step_tol(get_param<PetscReal>("nl_step_tol")),
+    nl_max_iter(get_param<PetscInt>("nl_max_iter")),
+    lin_rel_tol(get_param<PetscReal>("lin_rel_tol")),
+    lin_abs_tol(get_param<PetscReal>("lin_abs_tol")),
+    lin_max_iter(get_param<PetscInt>("lin_max_iter"))
 {
     _F_;
-    line_search_type = utils::toLower(line_search_type);
+    line_search_type = utils::to_lower(line_search_type);
 }
 
 NonlinearProblem::~NonlinearProblem()
@@ -105,14 +105,14 @@ NonlinearProblem::~NonlinearProblem()
 }
 
 DM
-NonlinearProblem::getDM() const
+NonlinearProblem::get_dm() const
 {
     _F_;
-    return this->mesh->getDM();
+    return this->mesh->get_dm();
 }
 
 Vec
-NonlinearProblem::getSolutionVector() const
+NonlinearProblem::get_solution_vector() const
 {
     _F_;
     return this->x;
@@ -123,15 +123,15 @@ NonlinearProblem::create()
 {
     _F_;
     init();
-    allocateObjects();
-    onSetMatrixProperties();
+    allocate_objects();
+    on_set_matrix_properties();
 
-    setUpSolverParameters();
-    setUpLineSearch();
-    setUpMonitors();
-    setUpCallbacks();
+    set_up_solver_parameters();
+    set_up_line_search();
+    set_up_monitors();
+    set_up_callbacks();
 
-    setUpInitialGuess();
+    set_up_initial_guess();
 
     Problem::create();
 }
@@ -141,53 +141,53 @@ NonlinearProblem::init()
 {
     _F_;
     PetscErrorCode ierr;
-    DM dm = getDM();
+    DM dm = get_dm();
 
     ierr = SNESCreate(comm(), &this->snes);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = SNESSetDM(this->snes, dm);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = DMSetApplicationContext(dm, this);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-NonlinearProblem::setUpInitialGuess()
+NonlinearProblem::set_up_initial_guess()
 {
     _F_;
     PetscErrorCode ierr;
     ierr = VecSet(this->x, 0.);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-NonlinearProblem::allocateObjects()
+NonlinearProblem::allocate_objects()
 {
     _F_;
     PetscErrorCode ierr;
-    DM dm = getDM();
+    DM dm = get_dm();
 
     ierr = DMCreateGlobalVector(dm, &this->x);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscObjectSetName((PetscObject) this->x, "sln");
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = VecDuplicate(this->x, &this->r);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscObjectSetName((PetscObject) this->r, "res");
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = DMCreateMatrix(dm, &this->J);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscObjectSetName((PetscObject) this->J, "Jac");
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     // full newton
     this->Jp = this->J;
 }
 
 void
-NonlinearProblem::setUpLineSearch()
+NonlinearProblem::set_up_line_search()
 {
     _F_;
     SNESLineSearch line_search;
@@ -209,18 +209,18 @@ NonlinearProblem::setUpLineSearch()
 }
 
 void
-NonlinearProblem::setUpCallbacks()
+NonlinearProblem::set_up_callbacks()
 {
     _F_;
     PetscErrorCode ierr;
     ierr = SNESSetFunction(this->snes, this->r, __compute_residual, this);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = SNESSetJacobian(this->snes, this->J, this->Jp, __compute_jacobian, this);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-NonlinearProblem::setUpMonitors()
+NonlinearProblem::set_up_monitors()
 {
     _F_;
     SNESMonitorSet(this->snes, __snes_monitor, this, 0);
@@ -231,7 +231,7 @@ NonlinearProblem::setUpMonitors()
 }
 
 void
-NonlinearProblem::setUpSolverParameters()
+NonlinearProblem::set_up_solver_parameters()
 {
     _F_;
     PetscErrorCode ierr;
@@ -241,34 +241,34 @@ NonlinearProblem::setUpSolverParameters()
                              this->nl_step_tol,
                              this->nl_max_iter,
                              -1);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = SNESSetFromOptions(this->snes);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     KSP ksp;
     ierr = SNESGetKSP(this->snes, &ksp);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = KSPSetTolerances(ksp,
                             this->lin_rel_tol,
                             this->lin_abs_tol,
                             PETSC_DEFAULT,
                             this->lin_max_iter);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = KSPSetFromOptions(ksp);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 PetscErrorCode
-NonlinearProblem::snesMonitorCallback(PetscInt it, PetscReal norm)
+NonlinearProblem::snes_monitor_callback(PetscInt it, PetscReal norm)
 {
-    godzillaPrint(7, it, " Non-linear residual: ", std::scientific, norm);
+    godzilla_print(7, it, " Non-linear residual: ", std::scientific, norm);
     return 0;
 }
 
 PetscErrorCode
-NonlinearProblem::kspMonitorCallback(PetscInt it, PetscReal rnorm)
+NonlinearProblem::ksp_monitor_callback(PetscInt it, PetscReal rnorm)
 {
-    godzillaPrint(8, "    ", it, " Linear residual: ", std::scientific, rnorm);
+    godzilla_print(8, "    ", it, " Linear residual: ", std::scientific, rnorm);
     return 0;
 }
 
@@ -278,9 +278,9 @@ NonlinearProblem::solve()
     _F_;
     PetscErrorCode ierr;
     ierr = SNESSolve(this->snes, NULL, this->x);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = SNESGetConvergedReason(this->snes, &this->converged_reason);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 bool
@@ -299,7 +299,7 @@ NonlinearProblem::run()
 {
     _F_;
     solve();
-    computePostprocessors();
+    compute_postprocessors();
     if (converged())
         output();
 }
@@ -309,11 +309,11 @@ NonlinearProblem::output()
 {
     _F_;
     for (auto & o : this->outputs)
-        o->outputStep(-1, getDM(), this->x);
+        o->output_step(-1, get_dm(), this->x);
 }
 
 void
-NonlinearProblem::onSetMatrixProperties()
+NonlinearProblem::on_set_matrix_properties()
 {
 }
 

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -4,22 +4,22 @@
 namespace godzilla {
 
 InputParameters
-Object::validParams()
+Object::valid_params()
 {
     InputParameters params = emptyInputParameters();
-    params.addPrivateParam<const App *>("_app", nullptr);
-    params.addPrivateParam<std::string>("_type");
-    params.addPrivateParam<std::string>("_name");
+    params.add_private_param<const App *>("_app", nullptr);
+    params.add_private_param<std::string>("_type");
+    params.add_private_param<std::string>("_name");
     return params;
 }
 
 Object::Object(const InputParameters & parameters) :
-    LoggingInterface(const_cast<Logger &>(parameters.get<const App *>("_app")->getLogger()),
+    LoggingInterface(const_cast<Logger &>(parameters.get<const App *>("_app")->get_logger()),
                      parameters.get<std::string>("_name")),
     pars(parameters),
-    app(*getParam<const App *>("_app")),
-    type(getParam<std::string>("_type")),
-    name(getParam<std::string>("_name"))
+    app(*get_param<const App *>("_app")),
+    type(get_param<std::string>("_type")),
+    name(get_param<std::string>("_name"))
 {
     _F_;
 }
@@ -30,35 +30,35 @@ Object::~Object()
 }
 
 const std::string &
-Object::getType() const
+Object::get_type() const
 {
     _F_;
     return this->type;
 }
 
 const std::string &
-Object::getName() const
+Object::get_name() const
 {
     _F_;
     return this->name;
 }
 
 const InputParameters &
-Object::getParameters() const
+Object::get_parameters() const
 {
     _F_;
     return this->pars;
 }
 
 bool
-Object::isParamValid(const std::string & name) const
+Object::is_param_valid(const std::string & name) const
 {
     _F_;
-    return this->pars.isParamValid(name);
+    return this->pars.is_param_valid(name);
 }
 
 const App &
-Object::getApp() const
+Object::get_app() const
 {
     _F_;
     return this->app;
@@ -68,21 +68,21 @@ const MPI_Comm &
 Object::comm() const
 {
     _F_;
-    return this->app.getComm();
+    return this->app.get_comm();
 }
 
 const PetscMPIInt &
-Object::processorId() const
+Object::processor_id() const
 {
     _F_;
-    return this->app.getCommRank();
+    return this->app.get_comm_rank();
 }
 
 const PetscMPIInt &
-Object::commSize() const
+Object::comm_size() const
 {
     _F_;
-    return this->app.getCommSize();
+    return this->app.get_comm_size();
 }
 
 void

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -65,7 +65,7 @@ Object::get_app() const
 }
 
 const MPI_Comm &
-Object::comm() const
+Object::get_comm() const
 {
     _F_;
     return this->app.get_comm();

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -72,7 +72,7 @@ Object::get_comm() const
 }
 
 const PetscMPIInt &
-Object::processor_id() const
+Object::get_processor_id() const
 {
     _F_;
     return this->app.get_comm_rank();

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -79,7 +79,7 @@ Object::processor_id() const
 }
 
 const PetscMPIInt &
-Object::comm_size() const
+Object::get_comm_size() const
 {
     _F_;
     return this->app.get_comm_size();

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -6,7 +6,7 @@ namespace godzilla {
 InputParameters
 Object::valid_params()
 {
-    InputParameters params = emptyInputParameters();
+    InputParameters params;
     params.add_private_param<const App *>("_app", nullptr);
     params.add_private_param<std::string>("_type");
     params.add_private_param<std::string>("_name");

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -4,17 +4,17 @@
 namespace godzilla {
 
 InputParameters
-Output::validParams()
+Output::valid_params()
 {
-    InputParameters params = Object::validParams();
-    params.addPrivateParam<Problem *>("_problem");
+    InputParameters params = Object::valid_params();
+    params.add_private_param<Problem *>("_problem");
     return params;
 }
 
 Output::Output(const InputParameters & params) :
     Object(params),
     PrintInterface(this),
-    problem(*getParam<Problem *>("_problem"))
+    problem(*get_param<Problem *>("_problem"))
 {
     _F_;
 }

--- a/src/PiecewiseLinear.cpp
+++ b/src/PiecewiseLinear.cpp
@@ -14,26 +14,26 @@ __piecewise_linear_function_eval(void * ctx, double x)
 }
 
 InputParameters
-PiecewiseLinear::validParams()
+PiecewiseLinear::valid_params()
 {
-    InputParameters params = Function::validParams();
-    params.addRequiredParam<std::vector<PetscReal>>("x", "Independent variable");
-    params.addRequiredParam<std::vector<PetscReal>>("y", "Dependent variable");
+    InputParameters params = Function::valid_params();
+    params.add_required_param<std::vector<PetscReal>>("x", "Independent variable");
+    params.add_required_param<std::vector<PetscReal>>("y", "Dependent variable");
     return params;
 }
 
 PiecewiseLinear::PiecewiseLinear(const InputParameters & params) :
     Function(params),
-    linpol(getParam<std::vector<PetscReal>>("x"), getParam<std::vector<PetscReal>>("y"))
+    linpol(get_param<std::vector<PetscReal>>("x"), get_param<std::vector<PetscReal>>("y"))
 {
     _F_;
 }
 
 void
-PiecewiseLinear::registerCallback(mu::Parser & parser)
+PiecewiseLinear::register_callback(mu::Parser & parser)
 {
     _F_;
-    parser.DefineFunUserData(getName(), __piecewise_linear_function_eval, this);
+    parser.DefineFunUserData(get_name(), __piecewise_linear_function_eval, this);
 }
 
 PetscReal

--- a/src/Postprocessor.cpp
+++ b/src/Postprocessor.cpp
@@ -5,17 +5,17 @@
 namespace godzilla {
 
 InputParameters
-Postprocessor::validParams()
+Postprocessor::valid_params()
 {
-    InputParameters params = Object::validParams();
-    params.addPrivateParam<const Problem *>("_problem", nullptr);
+    InputParameters params = Object::valid_params();
+    params.add_private_param<const Problem *>("_problem", nullptr);
     return params;
 }
 
 Postprocessor::Postprocessor(const InputParameters & params) :
     Object(params),
     PrintInterface(this),
-    problem(*getParam<Problem *>("_problem"))
+    problem(*get_param<Problem *>("_problem"))
 {
 }
 

--- a/src/PrintInterface.cpp
+++ b/src/PrintInterface.cpp
@@ -15,7 +15,7 @@ PrintInterface::PrintInterface(const App & app) :
 PrintInterface::PrintInterface(const Object * obj) :
     verbosity_level(dynamic_cast<const App &>(obj->get_app()).get_verbosity_level()),
     prefix(obj->get_name() + ": "),
-    pi_comm(obj->comm())
+    pi_comm(obj->get_comm())
 {
     _F_;
 }

--- a/src/PrintInterface.cpp
+++ b/src/PrintInterface.cpp
@@ -5,16 +5,16 @@
 namespace godzilla {
 
 PrintInterface::PrintInterface(const App & app) :
-    verbosity_level(app.getVerbosityLevel()),
+    verbosity_level(app.get_verbosity_level()),
     prefix(""),
-    pi_comm(app.getComm())
+    pi_comm(app.get_comm())
 {
     _F_;
 }
 
 PrintInterface::PrintInterface(const Object * obj) :
-    verbosity_level(dynamic_cast<const App &>(obj->getApp()).getVerbosityLevel()),
-    prefix(obj->getName() + ": "),
+    verbosity_level(dynamic_cast<const App &>(obj->get_app()).get_verbosity_level()),
+    prefix(obj->get_name() + ": "),
     pi_comm(obj->comm())
 {
     _F_;

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -8,17 +8,17 @@
 namespace godzilla {
 
 InputParameters
-Problem::validParams()
+Problem::valid_params()
 {
-    InputParameters params = Object::validParams();
-    params.addPrivateParam<const Mesh *>("_mesh");
+    InputParameters params = Object::valid_params();
+    params.add_private_param<const Mesh *>("_mesh");
     return params;
 }
 
 Problem::Problem(const InputParameters & parameters) :
     Object(parameters),
     PrintInterface(this),
-    mesh(getParam<const Mesh *>("_mesh")),
+    mesh(get_param<const Mesh *>("_mesh")),
     time(0.)
 {
 }
@@ -49,49 +49,49 @@ Problem::create()
 }
 
 PetscInt
-Problem::getDimension() const
+Problem::get_dimension() const
 {
     _F_;
-    return this->mesh->getDimension();
+    return this->mesh->get_dimension();
 }
 
 const PetscReal &
-Problem::getTime() const
+Problem::get_time() const
 {
     _F_;
     return this->time;
 }
 
 const std::vector<Function *> &
-Problem::getFunctions() const
+Problem::get_functions() const
 {
     _F_;
     return this->functions;
 }
 
 void
-Problem::addFunction(Function * fn)
+Problem::add_function(Function * fn)
 {
     _F_;
     this->functions.push_back(fn);
 }
 
 void
-Problem::addOutput(Output * output)
+Problem::add_output(Output * output)
 {
     _F_;
     this->outputs.push_back(output);
 }
 
 void
-Problem::addPostprocessor(Postprocessor * pp)
+Problem::add_postprocessor(Postprocessor * pp)
 {
     _F_;
-    this->pps[pp->getName()] = pp;
+    this->pps[pp->get_name()] = pp;
 }
 
 void
-Problem::computePostprocessors()
+Problem::compute_postprocessors()
 {
     _F_;
     for (auto & pp : this->pps)
@@ -99,7 +99,7 @@ Problem::computePostprocessors()
 }
 
 Postprocessor *
-Problem::getPostprocessor(const std::string & name) const
+Problem::get_postprocessor(const std::string & name) const
 {
     _F_;
     const auto & it = this->pps.find(name);

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -91,7 +91,7 @@ RectangleMesh::create_dm()
     PetscInt faces[2] = { this->nx, this->ny };
     DMBoundaryType periodicity[2] = { DM_BOUNDARY_GHOSTED, DM_BOUNDARY_GHOSTED };
 
-    ierr = DMPlexCreateBoxMesh(comm(),
+    ierr = DMPlexCreateBoxMesh(get_comm(),
                                2,
                                this->simplex,
                                faces,

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -8,80 +8,80 @@ namespace godzilla {
 registerObject(RectangleMesh);
 
 InputParameters
-RectangleMesh::validParams()
+RectangleMesh::valid_params()
 {
-    InputParameters params = UnstructuredMesh::validParams();
-    params.addParam<PetscReal>("xmin", 0., "Minimum in the x direction");
-    params.addParam<PetscReal>("xmax", 1., "Maximum in the x direction");
-    params.addParam<PetscReal>("ymin", 0., "Minimum in the y direction");
-    params.addParam<PetscReal>("ymax", 1., "Maximum in the y direction");
-    params.addRequiredParam<PetscInt>("nx", "Number of mesh points in the x direction");
-    params.addRequiredParam<PetscInt>("ny", "Number of mesh points in the y direction");
+    InputParameters params = UnstructuredMesh::valid_params();
+    params.add_param<PetscReal>("xmin", 0., "Minimum in the x direction");
+    params.add_param<PetscReal>("xmax", 1., "Maximum in the x direction");
+    params.add_param<PetscReal>("ymin", 0., "Minimum in the y direction");
+    params.add_param<PetscReal>("ymax", 1., "Maximum in the y direction");
+    params.add_required_param<PetscInt>("nx", "Number of mesh points in the x direction");
+    params.add_required_param<PetscInt>("ny", "Number of mesh points in the y direction");
     return params;
 }
 
 RectangleMesh::RectangleMesh(const InputParameters & parameters) :
     UnstructuredMesh(parameters),
-    xmin(getParam<PetscReal>("xmin")),
-    xmax(getParam<PetscReal>("xmax")),
-    ymin(getParam<PetscReal>("ymin")),
-    ymax(getParam<PetscReal>("ymax")),
-    nx(getParam<PetscInt>("nx")),
-    ny(getParam<PetscInt>("ny")),
+    xmin(get_param<PetscReal>("xmin")),
+    xmax(get_param<PetscReal>("xmax")),
+    ymin(get_param<PetscReal>("ymin")),
+    ymax(get_param<PetscReal>("ymax")),
+    nx(get_param<PetscInt>("nx")),
+    ny(get_param<PetscInt>("ny")),
     simplex(PETSC_FALSE),
     interpolate(PETSC_TRUE)
 {
     _F_;
     if (this->xmax <= this->xmin)
-        logError("Parameter 'xmax' must be larger than 'xmin'.");
+        log_error("Parameter 'xmax' must be larger than 'xmin'.");
     if (this->ymax <= this->ymin)
-        logError("Parameter 'ymax' must be larger than 'ymin'.");
+        log_error("Parameter 'ymax' must be larger than 'ymin'.");
 }
 
 PetscInt
-RectangleMesh::getXMin() const
+RectangleMesh::get_x_min() const
 {
     _F_;
     return this->xmin;
 }
 
 PetscInt
-RectangleMesh::getXMax() const
+RectangleMesh::get_x_max() const
 {
     _F_;
     return this->xmax;
 }
 
 PetscInt
-RectangleMesh::getNx() const
+RectangleMesh::get_nx() const
 {
     _F_;
     return this->nx;
 }
 
 PetscInt
-RectangleMesh::getYMin() const
+RectangleMesh::get_y_min() const
 {
     _F_;
     return this->ymin;
 }
 
 PetscInt
-RectangleMesh::getYMax() const
+RectangleMesh::get_y_max() const
 {
     _F_;
     return this->ymax;
 }
 
 PetscInt
-RectangleMesh::getNy() const
+RectangleMesh::get_ny() const
 {
     _F_;
     return this->ny;
 }
 
 void
-RectangleMesh::createDM()
+RectangleMesh::create_dm()
 {
     _F_;
     PetscErrorCode ierr;
@@ -100,7 +100,7 @@ RectangleMesh::createDM()
                                periodicity,
                                interpolate,
                                &this->dm);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     // create user-friendly names for sides
     DMLabel face_sets_label;
@@ -110,25 +110,25 @@ RectangleMesh::createDM()
     for (unsigned int i = 0; i < 4; i++) {
         IS is;
         ierr = DMLabelGetStratumIS(face_sets_label, i + 1, &is);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         ierr = DMCreateLabel(this->dm, side_name[i]);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         DMLabel label;
         ierr = DMGetLabel(this->dm, side_name[i], &label);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         if (is) {
             ierr = DMLabelSetStratumIS(label, i + 1, is);
-            checkPetscError(ierr);
+            check_petsc_error(ierr);
         }
 
         ierr = ISDestroy(&is);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
 
         ierr = DMPlexLabelComplete(this->dm, label);
-        checkPetscError(ierr);
+        check_petsc_error(ierr);
     }
 }
 

--- a/src/Terminal.cpp
+++ b/src/Terminal.cpp
@@ -13,7 +13,7 @@ Terminal::Color Terminal::Color::white("\33[37m");
 Terminal::Color Terminal::Color::normal("\33[39m");
 
 bool
-Terminal::hasColors()
+Terminal::has_colors()
 {
     return num_colors > 1;
 }
@@ -25,7 +25,7 @@ unsigned int Terminal::num_colors = 256;
 std::ostream &
 operator<<(std::ostream & os, const godzilla::Terminal::Color & clr)
 {
-    if (godzilla::Terminal::hasColors())
+    if (godzilla::Terminal::has_colors())
         os << clr.str;
     return os;
 }

--- a/src/TransientInterface.cpp
+++ b/src/TransientInterface.cpp
@@ -8,12 +8,12 @@
 namespace godzilla {
 
 InputParameters
-TransientInterface::validParams()
+TransientInterface::valid_params()
 {
     InputParameters params = emptyInputParameters();
-    params.addParam<PetscReal>("start_time", 0., "Start time of the simulation");
-    params.addRequiredParam<PetscReal>("end_time", "Simulation end time");
-    params.addRequiredParam<PetscReal>("dt", "Time step size");
+    params.add_param<PetscReal>("start_time", 0., "Start time of the simulation");
+    params.add_required_param<PetscReal>("end_time", "Simulation end time");
+    params.add_required_param<PetscReal>("dt", "Time step size");
     return params;
 }
 
@@ -39,7 +39,7 @@ TransientInterface::init(const MPI_Comm & comm)
     _F_;
     PetscErrorCode ierr;
     ierr = TSCreate(comm, &this->ts);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
@@ -48,29 +48,29 @@ TransientInterface::create(DM dm)
     _F_;
     PetscErrorCode ierr;
 
-    setUpTimeScheme();
+    set_up_time_scheme();
 
     ierr = TSSetDM(this->ts, dm);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = TSSetTime(this->ts, this->start_time);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = TSSetMaxTime(this->ts, this->end_time);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = TSSetTimeStep(this->ts, this->dt);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = TSSetStepNumber(this->ts, 1);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-TransientInterface::setUpTimeScheme()
+TransientInterface::set_up_time_scheme()
 {
     _F_;
     PetscErrorCode ierr;
     // TODO: allow other schemes
     ierr = TSSetType(this->ts, TSBEULER);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void

--- a/src/TransientInterface.cpp
+++ b/src/TransientInterface.cpp
@@ -10,7 +10,7 @@ namespace godzilla {
 InputParameters
 TransientInterface::valid_params()
 {
-    InputParameters params = emptyInputParameters();
+    InputParameters params;
     params.add_param<PetscReal>("start_time", 0., "Start time of the simulation");
     params.add_required_param<PetscReal>("end_time", "Simulation end time");
     params.add_required_param<PetscReal>("dt", "Time step size");

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -18,7 +18,7 @@ UnstructuredMesh::UnstructuredMesh(const InputParameters & parameters) :
 {
     _F_;
     PetscErrorCode ierr;
-    ierr = PetscPartitionerCreate(comm(), &this->partitioner);
+    ierr = PetscPartitionerCreate(get_comm(), &this->partitioner);
     check_petsc_error(ierr);
 }
 

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -6,9 +6,9 @@
 namespace godzilla {
 
 InputParameters
-UnstructuredMesh::validParams()
+UnstructuredMesh::valid_params()
 {
-    InputParameters params = Mesh::validParams();
+    InputParameters params = Mesh::valid_params();
     return params;
 }
 
@@ -19,7 +19,7 @@ UnstructuredMesh::UnstructuredMesh(const InputParameters & parameters) :
     _F_;
     PetscErrorCode ierr;
     ierr = PetscPartitionerCreate(comm(), &this->partitioner);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 UnstructuredMesh::~UnstructuredMesh()
@@ -27,20 +27,20 @@ UnstructuredMesh::~UnstructuredMesh()
     _F_;
     PetscErrorCode ierr;
     ierr = PetscPartitionerDestroy(&this->partitioner);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-UnstructuredMesh::setPartitionerType(const std::string & type)
+UnstructuredMesh::set_partitioner_type(const std::string & type)
 {
     _F_;
     PetscErrorCode ierr;
     ierr = PetscPartitionerSetType(this->partitioner, type.c_str());
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void
-UnstructuredMesh::setPartitionOverlap(PetscInt overlap)
+UnstructuredMesh::set_partition_overlap(PetscInt overlap)
 {
     _F_;
     this->partition_overlap = overlap;
@@ -53,14 +53,14 @@ UnstructuredMesh::distribute()
     PetscErrorCode ierr;
 
     ierr = PetscPartitionerSetUp(this->partitioner);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     ierr = DMPlexSetPartitioner(this->dm, this->partitioner);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     DM dm_dist = nullptr;
     ierr = DMPlexDistribute(this->dm, this->partition_overlap, NULL, &dm_dist);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     if (dm_dist) {
         DMDestroy(&this->dm);
         this->dm = dm_dist;
@@ -68,14 +68,14 @@ UnstructuredMesh::distribute()
 }
 
 void
-UnstructuredMesh::outputPartitioning(PetscViewer viewer)
+UnstructuredMesh::output_partitioning(PetscViewer viewer)
 {
     _F_;
     PetscErrorCode ierr;
 
     DM dm_part;
     ierr = DMClone(this->dm, &dm_part);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 
     DMSetNumFields(dm_part, 1);
     PetscSection s;
@@ -99,7 +99,7 @@ UnstructuredMesh::outputPartitioning(PetscViewer viewer)
 
     DMGlobalToLocalBegin(dm_part, global, INSERT_VALUES, local);
     DMGlobalToLocalEnd(dm_part, global, INSERT_VALUES, local);
-    VecScale(local, processorId());
+    VecScale(local, processor_id());
 
     DMLocalToGlobalBegin(dm_part, local, INSERT_VALUES, global);
     DMLocalToGlobalEnd(dm_part, local, INSERT_VALUES, global);

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -99,7 +99,7 @@ UnstructuredMesh::output_partitioning(PetscViewer viewer)
 
     DMGlobalToLocalBegin(dm_part, global, INSERT_VALUES, local);
     DMGlobalToLocalEnd(dm_part, global, INSERT_VALUES, local);
-    VecScale(local, processor_id());
+    VecScale(local, get_processor_id());
 
     DMLocalToGlobalBegin(dm_part, local, INSERT_VALUES, global);
     DMLocalToGlobalEnd(dm_part, local, INSERT_VALUES, global);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -8,7 +8,7 @@ namespace godzilla {
 namespace utils {
 
 bool
-pathExists(const std::string & path)
+path_exists(const std::string & path)
 {
     _F_;
     struct stat buffer;
@@ -16,7 +16,7 @@ pathExists(const std::string & path)
 }
 
 std::string
-toUpper(const std::string & name)
+to_upper(const std::string & name)
 {
     _F_;
     std::string upper(name);
@@ -25,7 +25,7 @@ toUpper(const std::string & name)
 }
 
 std::string
-toLower(const std::string & name)
+to_lower(const std::string & name)
 {
     _F_;
     std::string lower(name);

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -31,7 +31,7 @@ VTKOutput::create()
 {
     _F_;
     PetscErrorCode ierr;
-    ierr = PetscViewerCreate(comm(), &this->viewer);
+    ierr = PetscViewerCreate(get_comm(), &this->viewer);
     check_petsc_error(ierr);
     ierr = PetscViewerSetType(this->viewer, PETSCVIEWERVTK);
     check_petsc_error(ierr);

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -9,9 +9,9 @@ registerObject(VTKOutput);
 static const int MAX_PATH = 1024;
 
 InputParameters
-VTKOutput::validParams()
+VTKOutput::valid_params()
 {
-    InputParameters params = FileOutput::validParams();
+    InputParameters params = FileOutput::valid_params();
     return params;
 }
 
@@ -21,7 +21,7 @@ VTKOutput::VTKOutput(const InputParameters & params) : FileOutput(params)
 }
 
 std::string
-VTKOutput::getFileExt() const
+VTKOutput::get_file_ext() const
 {
     return std::string("vtk");
 }
@@ -32,11 +32,11 @@ VTKOutput::create()
     _F_;
     PetscErrorCode ierr;
     ierr = PetscViewerCreate(comm(), &this->viewer);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscViewerSetType(this->viewer, PETSCVIEWERVTK);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
     ierr = PetscViewerFileSetMode(this->viewer, FILE_MODE_WRITE);
-    checkPetscError(ierr);
+    check_petsc_error(ierr);
 }
 
 void

--- a/test/include/ExodusIIOutput_test.h
+++ b/test/include/ExodusIIOutput_test.h
@@ -10,18 +10,18 @@ protected:
     gOutput(Problem * problem, const std::string & file_name)
     {
         const std::string class_name = "ExodusIIOutput";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<Problem *>("_problem") = problem;
         params->set<std::string>("file") = file_name;
-        return this->app->buildObject<ExodusIIOutput>(class_name, "out", params);
+        return this->app->build_object<ExodusIIOutput>(class_name, "out", params);
     }
 
     Problem *
     gFEProblem1d(Mesh * mesh)
     {
         const std::string class_name = "GTestFENonlinearProblem";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<const Mesh *>("_mesh") = mesh;
-        return this->app->buildObject<Problem>(class_name, "problem", params);
+        return this->app->build_object<Problem>(class_name, "problem", params);
     }
 };

--- a/test/include/FENonlinearProblem_test.h
+++ b/test/include/FENonlinearProblem_test.h
@@ -15,8 +15,8 @@ public:
     GTestFENonlinearProblem(const InputParameters & params);
     virtual ~GTestFENonlinearProblem();
 
-    virtual PetscErrorCode computeResidualCallback(Vec x, Vec f) override;
-    virtual PetscErrorCode computeJacobianCallback(Vec x, Mat J, Mat Jp) override;
+    virtual PetscErrorCode compute_residual_callback(Vec x, Vec f) override;
+    virtual PetscErrorCode compute_jacobian_callback(Vec x, Mat J, Mat Jp) override;
     const std::vector<PetscReal> &
     getConstants()
     {
@@ -24,9 +24,9 @@ public:
     }
 
     virtual void
-    setUpConstants()
+    set_up_constants()
     {
-        FENonlinearProblem::setUpConstants();
+        FENonlinearProblem::set_up_constants();
     }
 
     PetscDS
@@ -36,14 +36,14 @@ public:
     }
 
     void
-    computePostprocessors() override
+    compute_postprocessors() override
     {
-        FENonlinearProblem::computePostprocessors();
+        FENonlinearProblem::compute_postprocessors();
     }
 
 protected:
-    virtual void onSetFields() override;
-    virtual void onSetWeakForm() override;
+    virtual void on_set_fields() override;
+    virtual void on_set_weak_form() override;
 
     /// ID for the "u" field
     const PetscInt iu;
@@ -55,7 +55,7 @@ public:
     GTest2FieldsFENonlinearProblem(const InputParameters & params);
 
 protected:
-    virtual void onSetFields() override;
+    virtual void on_set_fields() override;
 
     /// ID for the "v" field
     const PetscInt iv;
@@ -67,7 +67,7 @@ public:
     GTest2CompIC(const InputParameters & params) : InitialCondition(params) {}
 
     virtual PetscInt
-    getNumComponents() const
+    get_num_components() const
     {
         return 2;
     }
@@ -90,16 +90,16 @@ public:
 
         {
             const std::string class_name = "LineMesh";
-            InputParameters * params = Factory::getValidParams(class_name);
+            InputParameters * params = Factory::get_valid_params(class_name);
             params->set<PetscInt>("nx") = 2;
-            this->mesh = this->app->buildObject<Mesh>(class_name, "mesh", params);
+            this->mesh = this->app->build_object<Mesh>(class_name, "mesh", params);
         }
         {
             const std::string class_name = "GTestFENonlinearProblem";
-            InputParameters * params = Factory::getValidParams(class_name);
+            InputParameters * params = Factory::get_valid_params(class_name);
             params->set<const Mesh *>("_mesh") = this->mesh;
             this->prob =
-                this->app->buildObject<GTestFENonlinearProblem>(class_name, "prob", params);
+                this->app->build_object<GTestFENonlinearProblem>(class_name, "prob", params);
         }
         this->app->problem = this->prob;
     }

--- a/test/include/GYMLFile_test.h
+++ b/test/include/GYMLFile_test.h
@@ -31,7 +31,15 @@ class GTestProblem : public Problem {
 public:
     GTestProblem(const InputParameters & params) : Problem(params)
     {
-        DMPlexCreateBoxMesh(comm(), 1, PETSC_TRUE, NULL, NULL, NULL, NULL, PETSC_FALSE, &this->dm);
+        DMPlexCreateBoxMesh(get_comm(),
+                            1,
+                            PETSC_TRUE,
+                            NULL,
+                            NULL,
+                            NULL,
+                            NULL,
+                            PETSC_FALSE,
+                            &this->dm);
         DMSetUp(this->dm);
         DMCreateGlobalVector(this->dm, &this->x);
     }

--- a/test/include/GYMLFile_test.h
+++ b/test/include/GYMLFile_test.h
@@ -13,8 +13,8 @@ class MockGYMLFile : public GYMLFile {
 public:
     MockGYMLFile(const App & app) : GYMLFile(app) {}
 
-    MOCK_METHOD(void, buildMesh, (), ());
-    MOCK_METHOD(void, buildProblem, (), ());
+    MOCK_METHOD(void, build_mesh, (), ());
+    MOCK_METHOD(void, build_problem, (), ());
 };
 
 class GYMLFileTest : public GodzillaAppTest {
@@ -43,12 +43,12 @@ public:
     }
 
     DM
-    getDM() const override
+    get_dm() const override
     {
         return this->dm;
     }
     Vec
-    getSolutionVector() const override
+    get_solution_vector() const override
     {
         return this->x;
     }
@@ -75,5 +75,5 @@ protected:
     Vec x;
 
 public:
-    static InputParameters validParams();
+    static InputParameters valid_params();
 };

--- a/test/include/GodzillaApp_test.h
+++ b/test/include/GodzillaApp_test.h
@@ -10,15 +10,15 @@ public:
     TestApp() : App("godzilla", MPI_COMM_WORLD), problem(nullptr) {}
 
     virtual Problem *
-    getProblem() const
+    get_problem() const
     {
         return this->problem;
     }
 
     virtual void
-    checkIntegrity()
+    check_integrity()
     {
-        if (this->log.getNumEntries() > 0)
+        if (this->log.get_num_entries() > 0)
             this->log.print();
     }
 

--- a/test/include/HDF5Output_test.h
+++ b/test/include/HDF5Output_test.h
@@ -10,9 +10,9 @@ protected:
     gOutput(Problem * problem, const std::string & file_name)
     {
         const std::string class_name = "HDF5Output";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<Problem *>("_problem") = problem;
         params->set<std::string>("file") = file_name;
-        return this->app->buildObject<HDF5Output>(class_name, "out", params);
+        return this->app->build_object<HDF5Output>(class_name, "out", params);
     }
 };

--- a/test/include/ImplicitFENonlinearProblem_test.h
+++ b/test/include/ImplicitFENonlinearProblem_test.h
@@ -15,21 +15,21 @@ public:
     gMesh1d()
     {
         const std::string class_name = "LineMesh";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<PetscInt>("nx") = 2;
-        return this->app->buildObject<Mesh>(class_name, "mesh", params);
+        return this->app->build_object<Mesh>(class_name, "mesh", params);
     }
 
     GTestImplicitFENonlinearProblem *
     gProblem1d(Mesh * mesh)
     {
         const std::string class_name = "GTestImplicitFENonlinearProblem";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<const Mesh *>("_mesh") = mesh;
         params->set<PetscReal>("start_time") = 0.;
         params->set<PetscReal>("end_time") = 20;
         params->set<PetscReal>("dt") = 5;
-        return this->app->buildObject<GTestImplicitFENonlinearProblem>(class_name, "prob", params);
+        return this->app->build_object<GTestImplicitFENonlinearProblem>(class_name, "prob", params);
     }
 };
 
@@ -42,8 +42,8 @@ public:
     virtual ~GTestImplicitFENonlinearProblem();
 
 protected:
-    virtual void onSetFields() override;
-    virtual void onSetWeakForm() override;
+    virtual void on_set_fields() override;
+    virtual void on_set_weak_form() override;
 
     /// ID for the "u" field
     const PetscInt iu;

--- a/test/include/LinearProblem_test.h
+++ b/test/include/LinearProblem_test.h
@@ -12,57 +12,57 @@ protected:
     gMesh1d()
     {
         const std::string class_name = "LineMesh";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<PetscInt>("nx") = 1;
-        return this->app->buildObject<Mesh>(class_name, "mesh", params);
+        return this->app->build_object<Mesh>(class_name, "mesh", params);
     }
 
     Mesh *
     gMesh2d()
     {
         const std::string class_name = "RectangleMesh";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<PetscInt>("nx") = 1;
         params->set<PetscInt>("ny") = 1;
-        return this->app->buildObject<Mesh>(class_name, "mesh", params);
+        return this->app->build_object<Mesh>(class_name, "mesh", params);
     }
 
     Mesh *
     gMesh3d()
     {
         const std::string class_name = "BoxMesh";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<PetscInt>("nx") = 1;
         params->set<PetscInt>("ny") = 1;
         params->set<PetscInt>("nz") = 1;
-        return this->app->buildObject<Mesh>(class_name, "mesh", params);
+        return this->app->build_object<Mesh>(class_name, "mesh", params);
     }
 
     Problem *
     gProblem1d(Mesh * mesh)
     {
         const std::string class_name = "G1DTestLinearProblem";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<const Mesh *>("_mesh") = mesh;
-        return this->app->buildObject<Problem>(class_name, "problem", params);
+        return this->app->build_object<Problem>(class_name, "problem", params);
     }
 
     Problem *
     gProblem2d(Mesh * mesh)
     {
         const std::string class_name = "G2DTestLinearProblem";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<const Mesh *>("_mesh") = mesh;
-        return this->app->buildObject<Problem>(class_name, "problem", params);
+        return this->app->build_object<Problem>(class_name, "problem", params);
     }
 
     Problem *
     gProblem3d(Mesh * mesh)
     {
         const std::string class_name = "G3DTestLinearProblem";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<const Mesh *>("_mesh") = mesh;
-        return this->app->buildObject<Problem>(class_name, "problem", params);
+        return this->app->build_object<Problem>(class_name, "problem", params);
     }
 };
 
@@ -75,8 +75,8 @@ public:
     virtual void create() override;
 
 protected:
-    virtual PetscErrorCode computeRhsCallback(Vec b) override;
-    virtual PetscErrorCode computeOperatorsCallback(Mat A, Mat B) override;
+    virtual PetscErrorCode compute_rhs_callback(Vec b) override;
+    virtual PetscErrorCode compute_operators_callback(Mat A, Mat B) override;
 
     PetscSection s;
 };
@@ -90,8 +90,8 @@ public:
     virtual void create() override;
 
 protected:
-    virtual PetscErrorCode computeRhsCallback(Vec b) override;
-    virtual PetscErrorCode computeOperatorsCallback(Mat A, Mat B) override;
+    virtual PetscErrorCode compute_rhs_callback(Vec b) override;
+    virtual PetscErrorCode compute_operators_callback(Mat A, Mat B) override;
 
     PetscSection s;
 };
@@ -105,8 +105,8 @@ public:
     virtual void create() override;
 
 protected:
-    virtual PetscErrorCode computeRhsCallback(Vec b) override;
-    virtual PetscErrorCode computeOperatorsCallback(Mat A, Mat B) override;
+    virtual PetscErrorCode compute_rhs_callback(Vec b) override;
+    virtual PetscErrorCode compute_operators_callback(Mat A, Mat B) override;
 
     PetscSection s;
 };

--- a/test/include/NonlinearProblem_test.h
+++ b/test/include/NonlinearProblem_test.h
@@ -11,18 +11,18 @@ protected:
     gMesh1d()
     {
         const std::string class_name = "LineMesh";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<PetscInt>("nx") = 1;
-        return this->app->buildObject<Mesh>(class_name, "mesh", params);
+        return this->app->build_object<Mesh>(class_name, "mesh", params);
     }
 
     Problem *
     gProblem1d(Mesh * mesh)
     {
         const std::string class_name = "G1DTestNonlinearProblem";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<const Mesh *>("_mesh") = mesh;
-        return this->app->buildObject<Problem>(class_name, "problem", params);
+        return this->app->build_object<Problem>(class_name, "problem", params);
     }
 };
 
@@ -35,8 +35,8 @@ public:
     virtual void create() override;
 
 protected:
-    virtual PetscErrorCode computeResidualCallback(Vec x, Vec f) override;
-    virtual PetscErrorCode computeJacobianCallback(Vec x, Mat J, Mat Jp) override;
+    virtual PetscErrorCode compute_residual_callback(Vec x, Vec f) override;
+    virtual PetscErrorCode compute_jacobian_callback(Vec x, Mat J, Mat Jp) override;
 
     PetscSection s;
 };

--- a/test/include/VTKOutput_test.h
+++ b/test/include/VTKOutput_test.h
@@ -10,9 +10,9 @@ protected:
     gOutput(Problem * problem, const std::string & file_name)
     {
         const std::string class_name = "VTKOutput";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<Problem *>("_problem") = problem;
         params->set<std::string>("file") = file_name;
-        return this->app->buildObject<VTKOutput>(class_name, "out", params);
+        return this->app->build_object<VTKOutput>(class_name, "out", params);
     }
 };

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -13,46 +13,46 @@ TEST(AuxiliaryFieldTest, non_existent_id)
 
     TestApp app;
 
-    InputParameters mesh_pars = LineMesh::validParams();
+    InputParameters mesh_pars = LineMesh::valid_params();
     mesh_pars.set<const App *>("_app") = &app;
     mesh_pars.set<PetscInt>("nx") = 2;
     LineMesh mesh(mesh_pars);
     mesh.create();
 
-    InputParameters prob_pars = GTestFENonlinearProblem::validParams();
+    InputParameters prob_pars = GTestFENonlinearProblem::valid_params();
     prob_pars.set<const App *>("_app") = &app;
     prob_pars.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
-    prob.addAuxFE(0, "aux1", 1, 1);
+    prob.add_aux_fe(0, "aux1", 1, 1);
 
     class TestAuxFld : public AuxiliaryField {
     public:
         explicit TestAuxFld(const InputParameters & params) : AuxiliaryField(params) {}
         virtual PetscInt
-        getFieldId() const
+        get_field_id() const
         {
             return 1;
         }
         virtual void
-        setUp(DM dm, DM dm_aux)
+        set_up(DM dm, DM dm_aux)
         {
         }
         virtual PetscInt
-        getNumComponents() const
+        get_num_components() const
         {
             return 2;
         }
     };
 
-    InputParameters params = AuxiliaryField::validParams();
+    InputParameters params = AuxiliaryField::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "aux";
     params.set<FEProblemInterface *>("_fepi") = &prob;
     auto aux = TestAuxFld(params);
-    prob.addAuxiliaryField(&aux);
+    prob.add_auxiliary_field(&aux);
     prob.create();
 
-    app.checkIntegrity();
+    app.check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr("Auxiliary field 'aux' is set on auxiliary field with ID '1', "
@@ -65,46 +65,46 @@ TEST(AuxiliaryFieldTest, inconsistent_comp_number)
 
     TestApp app;
 
-    InputParameters mesh_pars = LineMesh::validParams();
+    InputParameters mesh_pars = LineMesh::valid_params();
     mesh_pars.set<const App *>("_app") = &app;
     mesh_pars.set<PetscInt>("nx") = 2;
     LineMesh mesh(mesh_pars);
     mesh.create();
 
-    InputParameters prob_pars = GTestFENonlinearProblem::validParams();
+    InputParameters prob_pars = GTestFENonlinearProblem::valid_params();
     prob_pars.set<const App *>("_app") = &app;
     prob_pars.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
-    prob.addAuxFE(0, "aux1", 1, 1);
+    prob.add_aux_fe(0, "aux1", 1, 1);
 
     class TestAuxFld : public AuxiliaryField {
     public:
         explicit TestAuxFld(const InputParameters & params) : AuxiliaryField(params) {}
         virtual PetscInt
-        getFieldId() const
+        get_field_id() const
         {
             return 0;
         }
         virtual void
-        setUp(DM dm, DM dm_aux)
+        set_up(DM dm, DM dm_aux)
         {
         }
         virtual PetscInt
-        getNumComponents() const
+        get_num_components() const
         {
             return 2;
         }
     };
 
-    InputParameters params = AuxiliaryField::validParams();
+    InputParameters params = AuxiliaryField::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "aux";
     params.set<FEProblemInterface *>("_fepi") = &prob;
     auto aux = TestAuxFld(params);
-    prob.addAuxiliaryField(&aux);
+    prob.add_auxiliary_field(&aux);
     prob.create();
 
-    app.checkIntegrity();
+    app.check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr("Auxiliary field 'aux' has 2 component(s), but is set on a "

--- a/test/src/BoundaryCondition_test.cpp
+++ b/test/src/BoundaryCondition_test.cpp
@@ -14,24 +14,24 @@ TEST(BoundaryConditionTest, api)
         {
         }
 
-        MOCK_METHOD(PetscInt, getFieldId, (), (const));
-        MOCK_METHOD(PetscInt, getNumComponents, (), (const));
-        MOCK_METHOD((DMBoundaryConditionType), getBcType, (), (const));
+        MOCK_METHOD(PetscInt, get_field_id, (), (const));
+        MOCK_METHOD(PetscInt, get_num_components, (), (const));
+        MOCK_METHOD((DMBoundaryConditionType), get_bc_type, (), (const));
         MOCK_METHOD(void,
                     evaluate,
                     (PetscInt, PetscReal, const PetscReal x[], PetscInt Nc, PetscScalar u[]),
                     ());
-        MOCK_METHOD(std::vector<PetscInt>, getComponents, (), (const));
-        MOCK_METHOD(void, setUpCallback, ());
+        MOCK_METHOD(std::vector<PetscInt>, get_components, (), (const));
+        MOCK_METHOD(void, set_up_callback, ());
     };
 
     TestApp app;
 
-    InputParameters params = BoundaryCondition::validParams();
+    InputParameters params = BoundaryCondition::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "obj";
     params.set<std::string>("boundary") = "side1";
     MockBoundaryCondition bc(params);
 
-    EXPECT_EQ(bc.getBoundary(), "side1");
+    EXPECT_EQ(bc.get_boundary(), "side1");
 }

--- a/test/src/BoxMesh_test.cpp
+++ b/test/src/BoxMesh_test.cpp
@@ -10,7 +10,7 @@ TEST(BoxMeshTest, api)
 {
     TestApp app;
 
-    InputParameters params = BoxMesh::validParams();
+    InputParameters params = BoxMesh::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "box_mesh";
     params.set<PetscReal>("xmin") = 1;
@@ -24,22 +24,22 @@ TEST(BoxMeshTest, api)
     params.set<PetscInt>("nz") = 7;
     BoxMesh mesh(params);
 
-    EXPECT_EQ(mesh.getXMin(), 1);
-    EXPECT_EQ(mesh.getXMax(), 4);
-    EXPECT_EQ(mesh.getNx(), 9);
+    EXPECT_EQ(mesh.get_x_min(), 1);
+    EXPECT_EQ(mesh.get_x_max(), 4);
+    EXPECT_EQ(mesh.get_nx(), 9);
 
-    EXPECT_EQ(mesh.getYMin(), 2);
-    EXPECT_EQ(mesh.getYMax(), 5);
-    EXPECT_EQ(mesh.getNy(), 8);
+    EXPECT_EQ(mesh.get_y_min(), 2);
+    EXPECT_EQ(mesh.get_y_max(), 5);
+    EXPECT_EQ(mesh.get_ny(), 8);
 
-    EXPECT_EQ(mesh.getZMin(), 3);
-    EXPECT_EQ(mesh.getZMax(), 6);
-    EXPECT_EQ(mesh.getNz(), 7);
+    EXPECT_EQ(mesh.get_z_min(), 3);
+    EXPECT_EQ(mesh.get_z_max(), 6);
+    EXPECT_EQ(mesh.get_nz(), 7);
 
     mesh.create();
-    DM dm = mesh.getDM();
+    DM dm = mesh.get_dm();
 
-    EXPECT_EQ(mesh.getDimension(), 3);
+    EXPECT_EQ(mesh.get_dimension(), 3);
 
     PetscReal gmin[4], gmax[4];
     DMGetBoundingBox(dm, gmin, gmax);
@@ -65,7 +65,7 @@ TEST(BoxMeshTest, incorrect_dims)
 
     TestApp app;
 
-    InputParameters params = BoxMesh::validParams();
+    InputParameters params = BoxMesh::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "obj";
     params.set<PetscReal>("xmin") = 4;
@@ -79,7 +79,7 @@ TEST(BoxMeshTest, incorrect_dims)
     params.set<PetscInt>("nz") = 7;
     BoxMesh mesh(params);
 
-    app.checkIntegrity();
+    app.check_integrity();
 
     auto output = testing::internal::GetCapturedStderr();
     EXPECT_THAT(output, testing::HasSubstr("obj: Parameter 'xmax' must be larger than 'xmin'."));

--- a/test/src/CallStack_test.cpp
+++ b/test/src/CallStack_test.cpp
@@ -21,7 +21,7 @@ TEST(CallStackTest, dump)
     _F_;
 
     testing::internal::CaptureStderr();
-    godzilla::internal::getCallstack().dump();
+    godzilla::internal::get_callstack().dump();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 ::testing::StartsWith("Call stack:\n  #0:"));

--- a/test/src/ConstantIC_test.cpp
+++ b/test/src/ConstantIC_test.cpp
@@ -9,13 +9,13 @@ TEST(ConstantICTest, api)
 {
     App app("test", MPI_COMM_WORLD);
 
-    InputParameters params = ConstantIC::validParams();
+    InputParameters params = ConstantIC::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::vector<PetscReal>>("value") = { 3, 4, 5 };
     ConstantIC obj(params);
 
-    EXPECT_EQ(obj.getFieldId(), 0);
-    EXPECT_EQ(obj.getNumComponents(), 3);
+    EXPECT_EQ(obj.get_field_id(), 0);
+    EXPECT_EQ(obj.get_num_components(), 3);
 
     PetscInt dim = 2;
     PetscReal time = 0.;

--- a/test/src/DirichletBC_test.cpp
+++ b/test/src/DirichletBC_test.cpp
@@ -12,15 +12,15 @@ TEST(DirichletBCTest, api)
 {
     TestApp app;
 
-    InputParameters params = DirichletBC::validParams();
+    InputParameters params = DirichletBC::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::vector<std::string>>("value") = { "t * (x + y + z)" };
     DirichletBC obj(params);
     obj.create();
 
-    EXPECT_EQ(obj.getFieldId(), 0);
-    EXPECT_EQ(obj.getNumComponents(), 1);
-    EXPECT_EQ(obj.getBcType(), DM_BC_ESSENTIAL);
+    EXPECT_EQ(obj.get_field_id(), 0);
+    EXPECT_EQ(obj.get_num_components(), 1);
+    EXPECT_EQ(obj.get_bc_type(), DM_BC_ESSENTIAL);
 
     PetscInt dim = 3;
     PetscReal time = 2.5;
@@ -36,28 +36,28 @@ TEST(DirichletBCTest, with_user_defined_fn)
 {
     TestApp app;
 
-    InputParameters mesh_pars = LineMesh::validParams();
+    InputParameters mesh_pars = LineMesh::valid_params();
     mesh_pars.set<const App *>("_app") = &app;
     mesh_pars.set<PetscInt>("nx") = 2;
     LineMesh mesh(mesh_pars);
 
-    InputParameters prob_pars = GTestProblem::validParams();
+    InputParameters prob_pars = GTestProblem::valid_params();
     prob_pars.set<const App *>("_app") = &app;
     GTestProblem problem(prob_pars);
     app.problem = &problem;
 
     std::string class_name = "PiecewiseLinear";
-    InputParameters * fn_pars = Factory::getValidParams(class_name);
+    InputParameters * fn_pars = Factory::get_valid_params(class_name);
     fn_pars->set<const App *>("_app") = &app;
     fn_pars->set<std::vector<PetscReal>>("x") = { 0., 1. };
     fn_pars->set<std::vector<PetscReal>>("y") = { 1., 2. };
-    Function * fn = app.buildObject<PiecewiseLinear>(class_name, "ipol", fn_pars);
-    problem.addFunction(fn);
+    Function * fn = app.build_object<PiecewiseLinear>(class_name, "ipol", fn_pars);
+    problem.add_function(fn);
 
-    InputParameters * bc_pars = Factory::getValidParams("DirichletBC");
+    InputParameters * bc_pars = Factory::get_valid_params("DirichletBC");
     bc_pars->set<const App *>("_app") = &app;
     bc_pars->set<std::vector<std::string>>("value") = { "ipol(x)" };
-    DirichletBC * bc = app.buildObject<DirichletBC>("DirichletBC", "name", bc_pars);
+    DirichletBC * bc = app.build_object<DirichletBC>("DirichletBC", "name", bc_pars);
     bc->create();
 
     PetscInt dim = 1;

--- a/test/src/Error_test.cpp
+++ b/test/src/Error_test.cpp
@@ -15,5 +15,5 @@ TEST(ErrorTest, mem_check)
 
 TEST(ErrorTest, check_petsc_error)
 {
-    EXPECT_DEATH(checkPetscError(123), "error: PETSc error: 123");
+    EXPECT_DEATH(check_petsc_error(123), "error: PETSc error: 123");
 }

--- a/test/src/ExodusIIMesh_test.cpp
+++ b/test/src/ExodusIIMesh_test.cpp
@@ -12,18 +12,18 @@ TEST(ExodusIIMeshTest, api)
     TestApp app;
     std::string file_name = std::string(GODZILLA_UNIT_TESTS_ROOT) + std::string("/assets/square.e");
 
-    InputParameters params = ExodusIIMesh::validParams();
+    InputParameters params = ExodusIIMesh::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "obj";
     params.set<std::string>("file") = file_name;
     ExodusIIMesh mesh(params);
 
-    EXPECT_EQ(mesh.getFileName(), file_name);
+    EXPECT_EQ(mesh.get_file_name(), file_name);
 
     mesh.create();
-    DM dm = mesh.getDM();
+    DM dm = mesh.get_dm();
 
-    EXPECT_EQ(mesh.getDimension(), 2);
+    EXPECT_EQ(mesh.get_dimension(), 2);
 
     PetscReal gmin[4], gmax[4];
     DMGetBoundingBox(dm, gmin, gmax);
@@ -46,13 +46,13 @@ TEST(ExodusIIMeshTest, nonexitent_file)
 
     TestApp app;
 
-    InputParameters params = ExodusIIMesh::validParams();
+    InputParameters params = ExodusIIMesh::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "obj";
     params.set<std::string>("file") = "asdf.e";
     ExodusIIMesh mesh(params);
 
-    app.checkIntegrity();
+    app.check_integrity();
 
     EXPECT_THAT(
         testing::internal::GetCapturedStderr(),

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -11,7 +11,7 @@ TEST_F(ExodusIIOutputTest, get_file_ext)
     auto prob = gProblem1d(mesh);
     prob->create();
     auto out = gOutput(prob, "out");
-    EXPECT_EQ(out->getFileExt(), "exo");
+    EXPECT_EQ(out->get_file_ext(), "exo");
 }
 
 TEST_F(ExodusIIOutputTest, create)
@@ -21,7 +21,7 @@ TEST_F(ExodusIIOutputTest, create)
     auto prob = gProblem1d(mesh);
     prob->create();
     auto out = gOutput(prob, "out");
-    prob->addOutput(out);
+    prob->add_output(out);
     prob->create();
 }
 
@@ -46,7 +46,7 @@ TEST_F(ExodusIIOutputTest, no_fe)
     auto out = gOutput(prob, "out");
     out->create();
     out->check();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     EXPECT_THAT(
         testing::internal::GetCapturedStderr(),
@@ -64,7 +64,7 @@ TEST_F(ExodusIIOutputTest, output_1d)
     auto out = gOutput(prob, "out");
     out->create();
     out->check();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     EXPECT_THAT(
         testing::internal::GetCapturedStderr(),
@@ -80,11 +80,11 @@ TEST_F(ExodusIIOutputTest, output_2d)
     auto out = gOutput(prob, "out");
     out->create();
     out->check();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     prob->solve();
     EXPECT_EQ(prob->converged(), true);
-    out->outputStep(-1, mesh->getDM(), prob->getSolutionVector());
+    out->output_step(-1, mesh->get_dm(), prob->get_solution_vector());
 }
 
 TEST_F(ExodusIIOutputTest, output_3d)
@@ -96,12 +96,12 @@ TEST_F(ExodusIIOutputTest, output_3d)
     auto out = gOutput(prob, "out");
     out->create();
     out->check();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     prob->solve();
     EXPECT_EQ(prob->converged(), true);
 
-    out->outputStep(-1, mesh->getDM(), prob->getSolutionVector());
+    out->output_step(-1, mesh->get_dm(), prob->get_solution_vector());
 }
 
 TEST_F(ExodusIIOutputTest, set_file_name)
@@ -113,8 +113,8 @@ TEST_F(ExodusIIOutputTest, set_file_name)
     auto out = gOutput(prob, "out");
     out->create();
 
-    out->setFileName();
-    EXPECT_EQ(out->getFileName(), "out.exo");
+    out->set_file_name();
+    EXPECT_EQ(out->get_file_name(), "out.exo");
 }
 
 TEST_F(ExodusIIOutputTest, set_seq_file_name)
@@ -126,6 +126,6 @@ TEST_F(ExodusIIOutputTest, set_seq_file_name)
     auto out = gOutput(prob, "out");
     out->create();
 
-    out->setSequenceFileName(2);
-    EXPECT_EQ(out->getFileName(), "out.2.exo");
+    out->set_sequence_file_name(2);
+    EXPECT_EQ(out->get_file_name(), "out.2.exo");
 }

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -96,47 +96,48 @@ TEST_F(FENonlinearProblemTest, fields)
     mesh->create();
     prob->create();
 
-    EXPECT_EQ(prob->getFieldName(0), "u");
-    EXPECT_EQ(prob->getFieldId("u"), 0);
-    EXPECT_EQ(prob->hasFieldById(0), true);
-    EXPECT_EQ(prob->hasFieldByName("u"), true);
+    EXPECT_EQ(prob->get_field_name(0), "u");
+    EXPECT_EQ(prob->get_field_id("u"), 0);
+    EXPECT_EQ(prob->has_field_by_id(0), true);
+    EXPECT_EQ(prob->has_field_by_name("u"), true);
 
-    EXPECT_DEATH(prob->getFieldName(65536), "error: Field with ID = '65536' does not exist.");
-    EXPECT_DEATH(prob->getFieldId("nonexistent"),
+    EXPECT_DEATH(prob->get_field_name(65536), "error: Field with ID = '65536' does not exist.");
+    EXPECT_DEATH(prob->get_field_id("nonexistent"),
                  "error: Field 'nonexistent' does not exist\\. Typo\\?");
-    EXPECT_EQ(prob->hasFieldById(65536), false);
-    EXPECT_EQ(prob->hasFieldByName("nonexistent"), false);
+    EXPECT_EQ(prob->has_field_by_id(65536), false);
+    EXPECT_EQ(prob->has_field_by_name("nonexistent"), false);
 }
 
 TEST_F(FENonlinearProblemTest, add_duplicate_field_id)
 {
-    prob->addFE(0, "first", 1, 1);
-    EXPECT_DEATH(prob->addFE(0, "second", 1, 1),
+    prob->add_fe(0, "first", 1, 1);
+    EXPECT_DEATH(prob->add_fe(0, "second", 1, 1),
                  "error: Cannot add field 'second' with ID = 0. ID already exists.");
 }
 
 TEST_F(FENonlinearProblemTest, get_aux_fields)
 {
     mesh->create();
-    prob->addAuxFE(0, "aux_one", 1, 1);
+    prob->add_aux_fe(0, "aux_one", 1, 1);
     prob->create();
 
-    EXPECT_EQ(prob->getAuxFieldName(0), "aux_one");
-    EXPECT_EQ(prob->getAuxFieldId("aux_one"), 0);
-    EXPECT_EQ(prob->hasAuxFieldById(0), true);
-    EXPECT_EQ(prob->hasAuxFieldByName("aux_one"), true);
+    EXPECT_EQ(prob->get_aux_field_name(0), "aux_one");
+    EXPECT_EQ(prob->get_aux_field_id("aux_one"), 0);
+    EXPECT_EQ(prob->has_aux_field_by_id(0), true);
+    EXPECT_EQ(prob->has_aux_field_by_name("aux_one"), true);
 
-    EXPECT_DEATH(prob->getAuxFieldName(1), "error: Auxiliary field with ID = '1' does not exist.");
-    EXPECT_DEATH(prob->getAuxFieldId("aux_two"),
+    EXPECT_DEATH(prob->get_aux_field_name(1),
+                 "error: Auxiliary field with ID = '1' does not exist.");
+    EXPECT_DEATH(prob->get_aux_field_id("aux_two"),
                  "error: Auxiliary field 'aux_two' does not exist\\. Typo\\?");
-    EXPECT_EQ(prob->hasAuxFieldById(1), false);
-    EXPECT_EQ(prob->hasAuxFieldByName("aux_two"), false);
+    EXPECT_EQ(prob->has_aux_field_by_id(1), false);
+    EXPECT_EQ(prob->has_aux_field_by_name("aux_two"), false);
 }
 
 TEST_F(FENonlinearProblemTest, add_duplicate_aux_field_id)
 {
-    prob->addAuxFE(0, "first", 1, 1);
-    EXPECT_DEATH(prob->addAuxFE(0, "second", 1, 1),
+    prob->add_aux_fe(0, "first", 1, 1);
+    EXPECT_DEATH(prob->add_aux_fe(0, "second", 1, 1),
                  "error: Cannot add auxiliary field 'second' with ID = 0. ID is already taken.");
 }
 
@@ -144,20 +145,20 @@ TEST_F(FENonlinearProblemTest, solve)
 {
     {
         const std::string class_name = "ConstantIC";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<std::vector<PetscReal>>("value") = { 0.1 };
-        auto ic = this->app->buildObject<InitialCondition>(class_name, "ic", params);
-        prob->addInitialCondition(ic);
+        auto ic = this->app->build_object<InitialCondition>(class_name, "ic", params);
+        prob->add_initial_condition(ic);
     }
 
     {
         const std::string class_name = "DirichletBC";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<const App *>("_app") = this->app;
         params->set<std::string>("boundary") = "marker";
         params->set<std::vector<std::string>>("value") = { "x*x" };
-        auto bc = this->app->buildObject<BoundaryCondition>(class_name, "bc", params);
-        prob->addBoundaryCondition(bc);
+        auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc", params);
+        prob->add_boundary_condition(bc);
     }
 
     mesh->create();
@@ -168,7 +169,7 @@ TEST_F(FENonlinearProblemTest, solve)
     bool conv = prob->converged();
     EXPECT_EQ(conv, true);
 
-    const Vec x = prob->getSolutionVector();
+    const Vec x = prob->get_solution_vector();
     PetscInt ni = 1;
     PetscInt ix[1] = { 0 };
     PetscScalar xx[1];
@@ -180,17 +181,17 @@ TEST_F(FENonlinearProblemTest, solve_no_ic)
 {
     {
         const std::string class_name = "DirichletBC";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<std::string>("boundary") = "marker";
         params->set<std::vector<std::string>>("value") = { "x*x" };
-        auto bc = this->app->buildObject<BoundaryCondition>(class_name, "bc", params);
-        prob->addBoundaryCondition(bc);
+        auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc", params);
+        prob->add_boundary_condition(bc);
     }
 
     mesh->create();
     prob->create();
 
-    const Vec x = prob->getSolutionVector();
+    const Vec x = prob->get_solution_vector();
     PetscInt ni = 1;
     PetscInt ix[1] = { 0 };
     PetscScalar xx[1];
@@ -204,13 +205,13 @@ TEST_F(FENonlinearProblemTest, err_ic_comp_mismatch)
 
     {
         const std::string class_name = "GTest2CompIC";
-        InputParameters * params = Factory::getValidParams(class_name);
-        auto ic = this->app->buildObject<InitialCondition>(class_name, "ic", params);
-        prob->addInitialCondition(ic);
+        InputParameters * params = Factory::get_valid_params(class_name);
+        auto ic = this->app->build_object<InitialCondition>(class_name, "ic", params);
+        prob->add_initial_condition(ic);
     }
     mesh->create();
     prob->create();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     EXPECT_THAT(
         testing::internal::GetCapturedStderr(),
@@ -224,17 +225,17 @@ TEST_F(FENonlinearProblemTest, err_duplicate_ics)
 
     {
         const std::string class_name = "ConstantIC";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<std::vector<PetscReal>>("value") = { 0.1 };
-        auto ic = this->app->buildObject<InitialCondition>(class_name, "ic1", params);
-        prob->addInitialCondition(ic);
+        auto ic = this->app->build_object<InitialCondition>(class_name, "ic1", params);
+        prob->add_initial_condition(ic);
     }
     const std::string class_name = "ConstantIC";
-    InputParameters * params = Factory::getValidParams(class_name);
+    InputParameters * params = Factory::get_valid_params(class_name);
     params->set<std::vector<PetscReal>>("value") = { 0.2 };
-    auto ic = this->app->buildObject<InitialCondition>(class_name, "ic2", params);
-    prob->addInitialCondition(ic);
-    this->app->checkIntegrity();
+    auto ic = this->app->build_object<InitialCondition>(class_name, "ic2", params);
+    prob->add_initial_condition(ic);
+    this->app->check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr(
@@ -251,9 +252,9 @@ TEST(TwoFieldFENonlinearProblemTest, err_not_enough_ics)
         TestApp() : App("godzilla", MPI_COMM_WORLD) {}
 
         virtual void
-        checkIntegrity()
+        check_integrity()
         {
-            if (this->log.getNumEntries() > 0)
+            if (this->log.get_num_entries() > 0)
                 this->log.print();
         }
     } app;
@@ -262,28 +263,28 @@ TEST(TwoFieldFENonlinearProblemTest, err_not_enough_ics)
 
     {
         const std::string class_name = "LineMesh";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<PetscInt>("nx") = 2;
-        mesh = app.buildObject<Mesh>(class_name, "mesh", params);
+        mesh = app.build_object<Mesh>(class_name, "mesh", params);
     }
     {
         const std::string class_name = "GTest2FieldsFENonlinearProblem";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<const Mesh *>("_mesh") = mesh;
-        prob = app.buildObject<FENonlinearProblem>(class_name, "prob", params);
+        prob = app.build_object<FENonlinearProblem>(class_name, "prob", params);
     }
 
     {
         const std::string class_name = "ConstantIC";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<std::vector<PetscReal>>("value") = { 0.1 };
-        auto ic = app.buildObject<InitialCondition>(class_name, "ic1", params);
-        prob->addInitialCondition(ic);
+        auto ic = app.build_object<InitialCondition>(class_name, "ic1", params);
+        prob->add_initial_condition(ic);
     }
 
     mesh->create();
     prob->create();
-    app.checkIntegrity();
+    app.check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr("Provided 2 field(s), but 1 initial condition(s)."));
@@ -295,16 +296,16 @@ TEST_F(FENonlinearProblemTest, err_nonexisting_bc_bnd)
 
     {
         const std::string class_name = "DirichletBC";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<std::string>("boundary") = "asdf";
         params->set<std::vector<std::string>>("value") = { "0.1" };
-        auto bc = this->app->buildObject<BoundaryCondition>(class_name, "bc1", params);
-        prob->addBoundaryCondition(bc);
+        auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc1", params);
+        prob->add_boundary_condition(bc);
     }
 
     mesh->create();
     prob->create();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr(
@@ -316,20 +317,20 @@ TEST_F(FENonlinearProblemTest, compute_residual_callback)
 {
     Vec x = nullptr;
     Vec f = nullptr;
-    EXPECT_EQ(this->prob->computeResidualCallback(x, f), 0);
+    EXPECT_EQ(this->prob->compute_residual_callback(x, f), 0);
 }
 
 TEST_F(FENonlinearProblemTest, compute_jacobian_callback)
 {
     Vec x = nullptr;
     Mat J = nullptr;
-    EXPECT_EQ(this->prob->computeJacobianCallback(x, J, J), 0);
+    EXPECT_EQ(this->prob->compute_jacobian_callback(x, J, J), 0);
 }
 
 TEST_F(FENonlinearProblemTest, set_constant)
 {
     std::vector<PetscReal> consts = { 5, 3, 1 };
-    this->prob->setConstants(consts);
+    this->prob->set_constants(consts);
 
     auto & k = this->prob->getConstants();
     EXPECT_EQ(k[0], 5);
@@ -342,8 +343,8 @@ TEST_F(FENonlinearProblemTest, set_constant_2)
     this->mesh->create();
     this->prob->create();
     std::vector<PetscReal> consts = { 5, 3, 1 };
-    this->prob->setConstants(consts);
-    this->prob->setUpConstants();
+    this->prob->set_constants(consts);
+    this->prob->set_up_constants();
     PetscDS ds = this->prob->getDS();
     PetscInt n_consts;
     const PetscReal * cs;
@@ -365,30 +366,30 @@ GTestFENonlinearProblem::GTestFENonlinearProblem(const InputParameters & params)
 GTestFENonlinearProblem::~GTestFENonlinearProblem() {}
 
 void
-GTestFENonlinearProblem::onSetFields()
+GTestFENonlinearProblem::on_set_fields()
 {
     _F_;
     PetscInt order = 1;
-    addFE(this->iu, "u", 1, order);
+    add_fe(this->iu, "u", 1, order);
 }
 
 void
-GTestFENonlinearProblem::onSetWeakForm()
+GTestFENonlinearProblem::on_set_weak_form()
 {
-    setResidualBlock(this->iu, f0_u, f1_u);
-    setJacobianBlock(this->iu, this->iu, NULL, NULL, NULL, g3_uu);
+    set_residual_block(this->iu, f0_u, f1_u);
+    set_jacobian_block(this->iu, this->iu, NULL, NULL, NULL, g3_uu);
 }
 
 PetscErrorCode
-GTestFENonlinearProblem::computeResidualCallback(Vec x, Vec f)
+GTestFENonlinearProblem::compute_residual_callback(Vec x, Vec f)
 {
-    return FENonlinearProblem::computeResidualCallback(x, f);
+    return FENonlinearProblem::compute_residual_callback(x, f);
 }
 
 PetscErrorCode
-GTestFENonlinearProblem::computeJacobianCallback(Vec x, Mat J, Mat Jp)
+GTestFENonlinearProblem::compute_jacobian_callback(Vec x, Mat J, Mat Jp)
 {
-    return FENonlinearProblem::computeJacobianCallback(x, J, Jp);
+    return FENonlinearProblem::compute_jacobian_callback(x, J, Jp);
 }
 
 //
@@ -400,8 +401,8 @@ GTest2FieldsFENonlinearProblem::GTest2FieldsFENonlinearProblem(const InputParame
 }
 
 void
-GTest2FieldsFENonlinearProblem::onSetFields()
+GTest2FieldsFENonlinearProblem::on_set_fields()
 {
-    GTestFENonlinearProblem::onSetFields();
-    addFE(this->iv, "v", 1, 1);
+    GTestFENonlinearProblem::on_set_fields();
+    add_fe(this->iv, "v", 1, 1);
 }

--- a/test/src/Factory_test.cpp
+++ b/test/src/Factory_test.cpp
@@ -9,8 +9,8 @@ using namespace godzilla;
 
 TEST(FactoryTest, valid_params_unreg_obj)
 {
-    EXPECT_DEATH(InputParameters * params = Factory::getValidParams("ASDF"),
-                 "Getting validParams for object 'ASDF' failed.  Object is not registred.");
+    EXPECT_DEATH(InputParameters * params = Factory::get_valid_params("ASDF"),
+                 "Getting valid_params for object 'ASDF' failed.  Object is not registred.");
 }
 
 TEST(FactoryTest, create_unreg_obj)
@@ -24,17 +24,17 @@ TEST(FactoryTest, create_reg_obj)
 {
     App app("test", MPI_COMM_WORLD);
 
-    InputParameters * params = Factory::getValidParams("LineMesh");
+    InputParameters * params = Factory::get_valid_params("LineMesh");
     params->set<PetscInt>("nx") = 1;
-    app.buildObject<LineMesh>("LineMesh", "name", params);
+    app.build_object<LineMesh>("LineMesh", "name", params);
 }
 
 TEST(FactoryTest, create_wrong_type)
 {
     App app("test", MPI_COMM_WORLD);
 
-    InputParameters * params = Factory::getValidParams("LineMesh");
+    InputParameters * params = Factory::get_valid_params("LineMesh");
     params->set<PetscInt>("nx") = 1;
-    EXPECT_DEATH(app.buildObject<RectangleMesh>("LineMesh", "name", params),
+    EXPECT_DEATH(app.build_object<RectangleMesh>("LineMesh", "name", params),
                  "error: Instantiation of object 'name:\\[LineMesh\\]' failed\\.");
 }

--- a/test/src/Factory_test.cpp
+++ b/test/src/Factory_test.cpp
@@ -15,7 +15,7 @@ TEST(FactoryTest, valid_params_unreg_obj)
 
 TEST(FactoryTest, create_unreg_obj)
 {
-    InputParameters params = emptyInputParameters();
+    InputParameters params;
     EXPECT_DEATH(Factory::create<Object>("ASDF", "name", params),
                  "Trying to create object of unregistered type 'ASDF'.");
 }

--- a/test/src/FunctionAuxiliaryField_test.cpp
+++ b/test/src/FunctionAuxiliaryField_test.cpp
@@ -10,31 +10,31 @@ TEST(FunctionAuxiliaryFieldTest, create)
 {
     TestApp app;
 
-    InputParameters mesh_params = LineMesh::validParams();
+    InputParameters mesh_params = LineMesh::valid_params();
     mesh_params.set<const App *>("_app") = &app;
     mesh_params.set<PetscInt>("nx") = 2;
     LineMesh mesh(mesh_params);
 
-    InputParameters prob_params = GTestFENonlinearProblem::validParams();
+    InputParameters prob_params = GTestFENonlinearProblem::valid_params();
     prob_params.set<const App *>("_app") = &app;
     prob_params.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    prob.addAuxFE(0, "aux1", 1, 1);
+    prob.add_aux_fe(0, "aux1", 1, 1);
 
-    InputParameters aux_params = FunctionAuxiliaryField::validParams();
+    InputParameters aux_params = FunctionAuxiliaryField::valid_params();
     aux_params.set<const App *>("_app") = &app;
     aux_params.set<std::string>("_name") = "aux1";
     aux_params.set<FEProblemInterface *>("_fepi") = &prob;
     aux_params.set<std::vector<std::string>>("value") = { "1234" };
     FunctionAuxiliaryField aux(aux_params);
-    prob.addAuxiliaryField(&aux);
+    prob.add_auxiliary_field(&aux);
 
     mesh.create();
     prob.create();
 
-    EXPECT_EQ(aux.getFieldId(), 0);
+    EXPECT_EQ(aux.get_field_id(), 0);
 
-    EXPECT_EQ(aux.getNumComponents(), 1);
+    EXPECT_EQ(aux.get_num_components(), 1);
 
     PetscInt dim = 1;
     PetscReal time = 0;

--- a/test/src/FunctionIC_test.cpp
+++ b/test/src/FunctionIC_test.cpp
@@ -9,13 +9,13 @@ TEST(FunctionICTest, api)
 {
     App app("test", MPI_COMM_WORLD);
 
-    InputParameters params = FunctionIC::validParams();
+    InputParameters params = FunctionIC::valid_params();
     params.set<std::vector<std::string>>("value") = { "t * (x + y + z)" };
-    auto obj = app.buildObject<InitialCondition>("FunctionIC", "name", params);
+    auto obj = app.build_object<InitialCondition>("FunctionIC", "name", params);
     obj->create();
 
-    EXPECT_EQ(obj->getFieldId(), 0);
-    EXPECT_EQ(obj->getNumComponents(), 1);
+    EXPECT_EQ(obj->get_field_id(), 0);
+    EXPECT_EQ(obj->get_num_components(), 1);
 
     PetscInt dim = 3;
     PetscReal time = 2.;

--- a/test/src/GYMLFile_test.cpp
+++ b/test/src/GYMLFile_test.cpp
@@ -12,17 +12,17 @@ using namespace godzilla;
 registerObject(GTestProblem);
 
 InputParameters
-GTestProblem::validParams()
+GTestProblem::valid_params()
 {
-    InputParameters params = Problem::validParams();
-    params.addParam<std::string>("str", "empty", "str doco");
-    params.addParam<double>("d", 1.234, "d doco");
-    params.addParam<int>("i", -1234, "i doco");
-    params.addParam<unsigned int>("ui", 1234, "ui doco");
-    params.addParam<std::vector<double>>("arr_d", "vec<d> doco");
-    params.addParam<std::vector<int>>("arr_i", "vec<i> doco");
-    params.addParam<std::vector<std::string>>("arr_str", "vec<str> doco");
-    params.addPrivateParam<const Mesh *>("_mesh");
+    InputParameters params = Problem::valid_params();
+    params.add_param<std::string>("str", "empty", "str doco");
+    params.add_param<double>("d", 1.234, "d doco");
+    params.add_param<int>("i", -1234, "i doco");
+    params.add_param<unsigned int>("ui", 1234, "ui doco");
+    params.add_param<std::vector<double>>("arr_d", "vec<d> doco");
+    params.add_param<std::vector<int>>("arr_i", "vec<i> doco");
+    params.add_param<std::vector<std::string>>("arr_str", "vec<str> doco");
+    params.add_private_param<const Mesh *>("_mesh");
     return params;
 }
 
@@ -34,7 +34,7 @@ TEST_F(GYMLFileTest, parse_empty)
         std::string(GODZILLA_UNIT_TESTS_ROOT) + std::string("/assets/empty.yml");
 
     file.parse(file_name);
-    auto yml = file.getYml();
+    auto yml = file.get_yml();
     EXPECT_EQ(yml.size(), 0);
 }
 
@@ -80,7 +80,7 @@ TEST_F(GYMLFileTest, build_missing_req_param)
         std::string(GODZILLA_UNIT_TESTS_ROOT) + std::string("/assets/mesh_missing_req_param.yml");
     file.parse(file_name);
     file.build();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr("mesh: Missing required parameters:"));
@@ -98,11 +98,11 @@ TEST_F(GYMLFileTest, mesh_partitioner)
     file.parse(file_name);
     file.build();
 
-    Mesh * mesh = file.getMesh();
+    Mesh * mesh = file.get_mesh();
     EXPECT_NE(mesh, nullptr);
     mesh->create();
 
-    DM dm = mesh->getDM();
+    DM dm = mesh->get_dm();
     PetscBool distr;
     DMPlexIsDistributed(dm, &distr);
     if (sz > 1)
@@ -121,10 +121,10 @@ TEST_F(GYMLFileTest, build)
     file.parse(file_name);
     file.build();
 
-    auto mesh = dynamic_cast<LineMesh *>(file.getMesh());
+    auto mesh = dynamic_cast<LineMesh *>(file.get_mesh());
     EXPECT_NE(mesh, nullptr);
 
-    auto problem = file.getProblem();
+    auto problem = file.get_problem();
     EXPECT_NE(problem, nullptr);
 }
 
@@ -136,8 +136,8 @@ TEST_F(GYMLFileTest, funcs)
         void
         build()
         {
-            GYMLFile::buildProblem();
-            GYMLFile::buildFunctions();
+            GYMLFile::build_problem();
+            GYMLFile::build_functions();
         }
     } file(*this->app);
 
@@ -147,8 +147,8 @@ TEST_F(GYMLFileTest, funcs)
     file.parse(file_name);
     file.build();
 
-    auto * problem = file.getProblem();
-    const std::vector<Function *> & funcs = problem->getFunctions();
+    auto * problem = file.get_problem();
+    const std::vector<Function *> & funcs = problem->get_functions();
     EXPECT_EQ(funcs.size(), 1);
     EXPECT_NE(dynamic_cast<PiecewiseLinear *>(funcs[0]), nullptr);
 }
@@ -163,10 +163,10 @@ TEST_F(GYMLFileTest, build_vec_as_scalars)
     file.parse(file_name);
     file.build();
 
-    auto mesh = dynamic_cast<LineMesh *>(file.getMesh());
+    auto mesh = dynamic_cast<LineMesh *>(file.get_mesh());
     EXPECT_NE(mesh, nullptr);
 
-    auto problem = file.getProblem();
+    auto problem = file.get_problem();
     EXPECT_NE(problem, nullptr);
 }
 
@@ -179,7 +179,7 @@ TEST_F(GYMLFileTest, wrong_param_type)
         std::string(GODZILLA_UNIT_TESTS_ROOT) + std::string("/assets/wrong_param_type.yml");
     file.parse(file_name);
     file.build();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     auto output = testing::internal::GetCapturedStderr();
     EXPECT_THAT(output,
@@ -197,10 +197,10 @@ TEST_F(GYMLFileTest, build_fe)
     file.parse(file_name);
     file.build();
 
-    auto mesh = dynamic_cast<LineMesh *>(file.getMesh());
+    auto mesh = dynamic_cast<LineMesh *>(file.get_mesh());
     EXPECT_NE(mesh, nullptr);
 
-    auto problem = file.getProblem();
+    auto problem = file.get_problem();
     EXPECT_NE(problem, nullptr);
 }
 
@@ -214,15 +214,15 @@ TEST_F(GYMLFileTest, simple_fe_pps)
     file.parse(file_name);
     file.build();
 
-    auto mesh = dynamic_cast<LineMesh *>(file.getMesh());
+    auto mesh = dynamic_cast<LineMesh *>(file.get_mesh());
     EXPECT_NE(mesh, nullptr);
 
-    auto problem = file.getProblem();
+    auto problem = file.get_problem();
     EXPECT_NE(problem, nullptr);
 
-    Postprocessor * pp = problem->getPostprocessor("l2_err");
+    Postprocessor * pp = problem->get_postprocessor("l2_err");
     EXPECT_NE(pp, nullptr);
-    EXPECT_EQ(pp->getName(), "l2_err");
+    EXPECT_EQ(pp->get_name(), "l2_err");
 }
 
 TEST_F(GYMLFileTest, build_fe_w_aux)
@@ -235,10 +235,10 @@ TEST_F(GYMLFileTest, build_fe_w_aux)
     file.parse(file_name);
     file.build();
 
-    auto mesh = dynamic_cast<LineMesh *>(file.getMesh());
+    auto mesh = dynamic_cast<LineMesh *>(file.get_mesh());
     EXPECT_NE(mesh, nullptr);
 
-    auto problem = dynamic_cast<FEProblemInterface *>(file.getProblem());
+    auto problem = dynamic_cast<FEProblemInterface *>(file.get_problem());
     EXPECT_NE(problem, nullptr);
     // TODO: test that the 'aux1' object from the input file was actually added
 }
@@ -252,7 +252,7 @@ TEST_F(GYMLFileTest, nonfe_problem_with_ics)
         std::string(GODZILLA_UNIT_TESTS_ROOT) + std::string("/assets/nonfe_with_ics.yml");
     file.parse(file_name);
     file.build();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr(
@@ -268,7 +268,7 @@ TEST_F(GYMLFileTest, nonfe_problem_with_bcs)
         std::string(GODZILLA_UNIT_TESTS_ROOT) + std::string("/assets/nonfe_with_bcs.yml");
     file.parse(file_name);
     file.build();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr(
@@ -284,7 +284,7 @@ TEST_F(GYMLFileTest, nonfe_problem_with_auxs)
         std::string(GODZILLA_UNIT_TESTS_ROOT) + std::string("/assets/nonfe_with_auxs.yml");
     file.parse(file_name);
     file.build();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr(

--- a/test/src/GodzillaApp_test.cpp
+++ b/test/src/GodzillaApp_test.cpp
@@ -17,7 +17,7 @@ protected:
     {
     }
     virtual void
-    createDM()
+    create_dm()
     {
     }
 };
@@ -30,8 +30,8 @@ public:
     MOCK_METHOD(void, run, ());
     MOCK_METHOD(void, solve, ());
     MOCK_METHOD(bool, converged, ());
-    MOCK_METHOD(DM, getDM, (), (const));
-    MOCK_METHOD(Vec, getSolutionVector, (), (const));
+    MOCK_METHOD(DM, get_dm, (), (const));
+    MOCK_METHOD(Vec, get_solution_vector, (), (const));
 };
 
 registerObject(MockMesh);
@@ -46,7 +46,7 @@ TEST_F(GodzillaAppTest, run_input)
                       NULL };
 
     App app("godzilla", MPI_COMM_WORLD);
-    app.parseCommandLine(argc, argv);
+    app.parse_command_line(argc, argv);
     app.run();
 
     // TODO: build a MockGodzillaApp and make sure methods get called
@@ -61,7 +61,7 @@ TEST_F(GodzillaAppTest, run_input_non_existent_file)
                       NULL };
 
     App app("godzilla", MPI_COMM_WORLD);
-    app.parseCommandLine(argc, argv);
+    app.parse_command_line(argc, argv);
 
     EXPECT_DEATH(app.run(), "error: Unable to open");
 }
@@ -72,7 +72,7 @@ TEST_F(GodzillaAppTest, no_colors)
     char * argv[] = { (char *) "godzilla", (char *) "--no-colors", NULL };
 
     App app("godzilla", MPI_COMM_WORLD);
-    app.parseCommandLine(argc, argv);
+    app.parse_command_line(argc, argv);
 
     app.run();
     EXPECT_EQ(Terminal::num_colors, 1);
@@ -90,7 +90,7 @@ TEST_F(GodzillaAppTest, verbose_level)
         run()
         {
             App::run();
-            godzillaPrint(1, "Print");
+            godzilla_print(1, "Print");
         }
     };
 
@@ -98,7 +98,7 @@ TEST_F(GodzillaAppTest, verbose_level)
     char * argv[] = { (char *) "godzilla", (char *) "--verbose", (char *) "2", NULL };
 
     TestApp app("godzilla", MPI_COMM_WORLD);
-    app.parseCommandLine(argc, argv);
+    app.parse_command_line(argc, argv);
     app.run();
 
     EXPECT_EQ(testing::internal::GetCapturedStdout(), "Print\n");
@@ -114,7 +114,7 @@ TEST_F(GodzillaAppTest, check_integrity)
         run()
         {
             this->log.error("error1");
-            checkIntegrity();
+            check_integrity();
         }
     } app;
 

--- a/test/src/HDF5Output_test.cpp
+++ b/test/src/HDF5Output_test.cpp
@@ -11,7 +11,7 @@ TEST_F(HDF5OutputTest, get_file_ext)
     prob->create();
 
     auto out = gOutput(prob, "out");
-    EXPECT_EQ(out->getFileExt(), "h5");
+    EXPECT_EQ(out->get_file_ext(), "h5");
 }
 
 TEST_F(HDF5OutputTest, create)
@@ -21,7 +21,7 @@ TEST_F(HDF5OutputTest, create)
     auto prob = gProblem1d(mesh);
     prob->create();
     auto out = gOutput(prob, "out");
-    prob->addOutput(out);
+    prob->add_output(out);
     prob->create();
 }
 
@@ -45,8 +45,8 @@ TEST_F(HDF5OutputTest, set_file_name)
 
     auto out = gOutput(prob, "out");
     out->create();
-    out->setFileName();
-    EXPECT_EQ(out->getFileName(), "out.h5");
+    out->set_file_name();
+    EXPECT_EQ(out->get_file_name(), "out.h5");
 }
 
 TEST_F(HDF5OutputTest, set_seq_file_name)
@@ -58,8 +58,8 @@ TEST_F(HDF5OutputTest, set_seq_file_name)
 
     auto out = gOutput(prob, "out");
     out->create();
-    out->setSequenceFileName(2);
-    EXPECT_EQ(out->getFileName(), "out.2.h5");
+    out->set_sequence_file_name(2);
+    EXPECT_EQ(out->get_file_name(), "out.2.h5");
 }
 
 TEST_F(HDF5OutputTest, output)
@@ -70,18 +70,18 @@ TEST_F(HDF5OutputTest, output)
     prob->create();
     auto out = gOutput(prob, "out");
     out->create();
-    out->setFileName();
-    out->outputStep(-1, mesh->getDM(), prob->getSolutionVector());
+    out->set_file_name();
+    out->output_step(-1, mesh->get_dm(), prob->get_solution_vector());
 
-    const std::string file_name = out->getFileName();
+    const std::string file_name = out->get_file_name();
     PetscViewer viewer;
     Vec sln;
     PetscReal diff;
-    DMCreateGlobalVector(mesh->getDM(), &sln);
+    DMCreateGlobalVector(mesh->get_dm(), &sln);
     PetscObjectSetName((PetscObject) sln, "sln");
     PetscViewerHDF5Open(PETSC_COMM_WORLD, file_name.c_str(), FILE_MODE_READ, &viewer);
     VecLoad(sln, viewer);
-    VecAXPY(sln, -1.0, prob->getSolutionVector());
+    VecAXPY(sln, -1.0, prob->get_solution_vector());
     VecNorm(sln, NORM_INFINITY, &diff);
     EXPECT_LT(diff, PETSC_MACHINE_EPSILON);
     PetscViewerDestroy(&viewer);

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -118,19 +118,19 @@ TEST_F(ImplicitFENonlinearProblemTest, run)
 
     {
         const std::string class_name = "ConstantIC";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<std::vector<PetscReal>>("value") = { 0 };
-        auto ic = this->app->buildObject<InitialCondition>(class_name, "ic", params);
-        prob->addInitialCondition(ic);
+        auto ic = this->app->build_object<InitialCondition>(class_name, "ic", params);
+        prob->add_initial_condition(ic);
     }
 
     {
         const std::string class_name = "DirichletBC";
-        InputParameters * params = Factory::getValidParams(class_name);
+        InputParameters * params = Factory::get_valid_params(class_name);
         params->set<std::string>("boundary") = "marker";
         params->set<std::vector<std::string>>("value") = { "x*x" };
-        auto bc = this->app->buildObject<BoundaryCondition>(class_name, "bc", params);
-        prob->addBoundaryCondition(bc);
+        auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc", params);
+        prob->add_boundary_condition(bc);
     }
 
     mesh->create();
@@ -138,7 +138,7 @@ TEST_F(ImplicitFENonlinearProblemTest, run)
 
     prob->run();
 
-    const Vec x = prob->getSolutionVector();
+    const Vec x = prob->get_solution_vector();
 
     PetscInt ni = 1;
     PetscInt ix[1] = { 0 };
@@ -165,7 +165,7 @@ TEST_F(ImplicitFENonlinearProblemTest, output)
 
     auto mesh = gMesh1d();
 
-    InputParameters params = GTestImplicitFENonlinearProblem::validParams();
+    InputParameters params = GTestImplicitFENonlinearProblem::valid_params();
     params.set<const App *>("_app") = this->app;
     params.set<const Mesh *>("_mesh") = mesh;
     params.set<PetscReal>("start_time") = 0.;
@@ -187,45 +187,45 @@ TEST_F(ImplicitFENonlinearProblemTest, output_step)
         }
 
         virtual void
-        outputStep(Vec vec)
+        output_step(Vec vec)
         {
-            ImplicitFENonlinearProblem::outputStep(vec);
+            ImplicitFENonlinearProblem::output_step(vec);
         }
 
-        MOCK_METHOD(void, onSetFields, ());
-        MOCK_METHOD(void, onSetWeakForm, ());
+        MOCK_METHOD(void, on_set_fields, ());
+        MOCK_METHOD(void, on_set_weak_form, ());
     };
 
     class MockOutput : public Output {
     public:
         explicit MockOutput(const InputParameters & params) : Output(params) {}
 
-        MOCK_METHOD(const std::string &, getFileName, (), (const));
-        MOCK_METHOD(void, setFileName, ());
-        MOCK_METHOD(void, setSequenceFileName, (unsigned int stepi));
-        MOCK_METHOD(void, outputMesh, (DM dm));
-        MOCK_METHOD(void, outputSolution, (Vec vec));
-        MOCK_METHOD(void, outputStep, (PetscInt stepi, DM dm, Vec vec));
+        MOCK_METHOD(const std::string &, get_file_name, (), (const));
+        MOCK_METHOD(void, set_file_name, ());
+        MOCK_METHOD(void, set_sequence_file_name, (unsigned int stepi));
+        MOCK_METHOD(void, output_mesh, (DM dm));
+        MOCK_METHOD(void, output_solution, (Vec vec));
+        MOCK_METHOD(void, output_step, (PetscInt stepi, DM dm, Vec vec));
     };
 
     auto mesh = gMesh1d();
     mesh->create();
 
-    InputParameters prob_pars = ImplicitFENonlinearProblem::validParams();
+    InputParameters prob_pars = ImplicitFENonlinearProblem::valid_params();
     prob_pars.set<const App *>("_app") = this->app;
     prob_pars.set<const Mesh *>("_mesh") = mesh;
     MockImplicitFENonlinearProblem prob(prob_pars);
 
-    InputParameters out_pars = Output::validParams();
+    InputParameters out_pars = Output::valid_params();
     out_pars.set<const App *>("_app") = this->app;
     out_pars.set<Problem *>("_problem") = &prob;
     MockOutput out(out_pars);
 
-    prob.addOutput(&out);
+    prob.add_output(&out);
 
-    EXPECT_CALL(out, outputStep);
+    EXPECT_CALL(out, output_step);
 
-    prob.outputStep(prob.getSolutionVector());
+    prob.output_step(prob.get_solution_vector());
 }
 
 // GTestImplicitFENonlinearProblem
@@ -239,16 +239,16 @@ GTestImplicitFENonlinearProblem::GTestImplicitFENonlinearProblem(const InputPara
 GTestImplicitFENonlinearProblem::~GTestImplicitFENonlinearProblem() {}
 
 void
-GTestImplicitFENonlinearProblem::onSetFields()
+GTestImplicitFENonlinearProblem::on_set_fields()
 {
     _F_;
     PetscInt order = 1;
-    addFE(this->iu, "u", 1, order);
+    add_fe(this->iu, "u", 1, order);
 }
 
 void
-GTestImplicitFENonlinearProblem::onSetWeakForm()
+GTestImplicitFENonlinearProblem::on_set_weak_form()
 {
-    setResidualBlock(this->iu, f0_u, f1_u);
-    setJacobianBlock(this->iu, this->iu, g0_uu, NULL, NULL, g3_uu);
+    set_residual_block(this->iu, f0_u, f1_u);
+    set_jacobian_block(this->iu, this->iu, g0_uu, NULL, NULL, g3_uu);
 }

--- a/test/src/InputParameters_test.cpp
+++ b/test/src/InputParameters_test.cpp
@@ -6,22 +6,22 @@ using namespace godzilla;
 
 TEST(InputParametersTest, get)
 {
-    InputParameters params = Object::validParams();
+    InputParameters params = Object::valid_params();
     EXPECT_DEATH(params.get<int>("i"), "No parameter 'i' found.");
 }
 
 TEST(InputParametersTest, param_value)
 {
     InputParameters params = emptyInputParameters();
-    params.addParam<PetscReal>("param", 12.34, "doco");
+    params.add_param<PetscReal>("param", 12.34, "doco");
     EXPECT_EQ(params.get<PetscReal>("param"), 12.34);
-    EXPECT_EQ(params.getDocString("param"), std::string("doco"));
+    EXPECT_EQ(params.get_doc_string("param"), std::string("doco"));
 }
 
 TEST(InputParametersTest, has_value)
 {
     InputParameters params = emptyInputParameters();
-    params.addParam<PetscReal>("param", 12.34, "doco");
+    params.add_param<PetscReal>("param", 12.34, "doco");
     EXPECT_EQ(params.has<PetscReal>("param"), true);
     params.clear();
     EXPECT_EQ(params.has<PetscReal>("param"), false);
@@ -30,35 +30,35 @@ TEST(InputParametersTest, has_value)
 TEST(InputParametersTest, assign)
 {
     InputParameters params1 = emptyInputParameters();
-    params1.addParam<PetscReal>("param", 12.34, "doco");
+    params1.add_param<PetscReal>("param", 12.34, "doco");
 
     InputParameters params2 = params1;
     EXPECT_EQ(params2.has<PetscReal>("param"), true);
     EXPECT_EQ(params2.get<PetscReal>("param"), 12.34);
-    EXPECT_EQ(params2.getDocString("param"), std::string("doco"));
+    EXPECT_EQ(params2.get_doc_string("param"), std::string("doco"));
 }
 
 TEST(InputParametersTest, add_params)
 {
     InputParameters params1 = emptyInputParameters();
-    params1.addParam<PetscReal>("p1", 12.34, "doco1");
+    params1.add_param<PetscReal>("p1", 12.34, "doco1");
 
     InputParameters params2 = emptyInputParameters();
-    params1.addParam<PetscReal>("p2", "doco2");
+    params1.add_param<PetscReal>("p2", "doco2");
 
     params1 += params2;
     EXPECT_EQ(params1.has<PetscReal>("p1"), true);
     EXPECT_EQ(params1.get<PetscReal>("p1"), 12.34);
-    EXPECT_EQ(params1.getDocString("p1"), std::string("doco1"));
+    EXPECT_EQ(params1.get_doc_string("p1"), std::string("doco1"));
     EXPECT_EQ(params1.has<PetscReal>("p2"), true);
-    EXPECT_EQ(params1.getDocString("p2"), std::string("doco2"));
+    EXPECT_EQ(params1.get_doc_string("p2"), std::string("doco2"));
 }
 
 InputParameters
 validParams1()
 {
     InputParameters params = emptyInputParameters();
-    params.addParam<PetscReal>("p", 78.56, "doco p");
+    params.add_param<PetscReal>("p", 78.56, "doco p");
     return params;
 }
 
@@ -66,19 +66,19 @@ TEST(InputParametersTest, valid_params)
 {
     InputParameters params1 = validParams1();
     EXPECT_EQ(params1.get<PetscReal>("p"), 78.56);
-    EXPECT_EQ(params1.getDocString("p"), std::string("doco p"));
+    EXPECT_EQ(params1.get_doc_string("p"), std::string("doco p"));
 }
 
 TEST(InputParametersTest, empty_doc_str)
 {
-    InputParameters params = Object::validParams();
+    InputParameters params = Object::valid_params();
 
-    EXPECT_EQ(params.getDocString("i"), std::string(""));
+    EXPECT_EQ(params.get_doc_string("i"), std::string(""));
 }
 
 TEST(InputParametersTest, set_non_existing_param)
 {
-    InputParameters params = Object::validParams();
+    InputParameters params = Object::valid_params();
     params.set<double>("d") = 1.23;
 
     EXPECT_EQ(params.get<double>("d"), 1.23);

--- a/test/src/InputParameters_test.cpp
+++ b/test/src/InputParameters_test.cpp
@@ -12,7 +12,7 @@ TEST(InputParametersTest, get)
 
 TEST(InputParametersTest, param_value)
 {
-    InputParameters params = emptyInputParameters();
+    InputParameters params;
     params.add_param<PetscReal>("param", 12.34, "doco");
     EXPECT_EQ(params.get<PetscReal>("param"), 12.34);
     EXPECT_EQ(params.get_doc_string("param"), std::string("doco"));
@@ -20,7 +20,7 @@ TEST(InputParametersTest, param_value)
 
 TEST(InputParametersTest, has_value)
 {
-    InputParameters params = emptyInputParameters();
+    InputParameters params;
     params.add_param<PetscReal>("param", 12.34, "doco");
     EXPECT_EQ(params.has<PetscReal>("param"), true);
     params.clear();
@@ -29,7 +29,7 @@ TEST(InputParametersTest, has_value)
 
 TEST(InputParametersTest, assign)
 {
-    InputParameters params1 = emptyInputParameters();
+    InputParameters params1;
     params1.add_param<PetscReal>("param", 12.34, "doco");
 
     InputParameters params2 = params1;
@@ -40,10 +40,10 @@ TEST(InputParametersTest, assign)
 
 TEST(InputParametersTest, add_params)
 {
-    InputParameters params1 = emptyInputParameters();
+    InputParameters params1;
     params1.add_param<PetscReal>("p1", 12.34, "doco1");
 
-    InputParameters params2 = emptyInputParameters();
+    InputParameters params2;
     params1.add_param<PetscReal>("p2", "doco2");
 
     params1 += params2;
@@ -57,7 +57,7 @@ TEST(InputParametersTest, add_params)
 InputParameters
 validParams1()
 {
-    InputParameters params = emptyInputParameters();
+    InputParameters params;
     params.add_param<PetscReal>("p", 78.56, "doco p");
     return params;
 }

--- a/test/src/L2Diff_test.cpp
+++ b/test/src/L2Diff_test.cpp
@@ -9,37 +9,37 @@ TEST(L2DiffTest, compute)
 {
     TestApp app;
 
-    InputParameters mesh_params = LineMesh::validParams();
+    InputParameters mesh_params = LineMesh::valid_params();
     mesh_params.set<const App *>("_app") = &app;
     mesh_params.set<PetscInt>("nx") = 2;
     LineMesh mesh(mesh_params);
 
-    InputParameters prob_params = GTestFENonlinearProblem::validParams();
+    InputParameters prob_params = GTestFENonlinearProblem::valid_params();
     prob_params.set<const App *>("_app") = &app;
     prob_params.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
 
-    InputParameters bc_params = DirichletBC::validParams();
+    InputParameters bc_params = DirichletBC::valid_params();
     bc_params.set<const App *>("_app") = &app;
     bc_params.set<std::vector<std::string>>("value") = { "x*x" };
     bc_params.set<std::string>("boundary") = "marker";
     DirichletBC bc(bc_params);
 
-    InputParameters ps_params = L2Diff::validParams();
+    InputParameters ps_params = L2Diff::valid_params();
     ps_params.set<const App *>("_app") = &app;
     ps_params.set<Problem *>("_problem") = &prob;
     ps_params.set<std::vector<std::string>>("value") = { "x*x" };
     L2Diff ps(ps_params);
 
-    prob.addBoundaryCondition(&bc);
-    prob.addPostprocessor(&ps);
+    prob.add_boundary_condition(&bc);
+    prob.add_postprocessor(&ps);
 
     mesh.create();
     prob.create();
 
     prob.solve();
-    prob.computePostprocessors();
+    prob.compute_postprocessors();
 
-    PetscReal l2_err = ps.getValue();
+    PetscReal l2_err = ps.get_value();
     EXPECT_NEAR(l2_err, 0.0416667, 1e-7);
 }

--- a/test/src/LineMesh_test.cpp
+++ b/test/src/LineMesh_test.cpp
@@ -12,7 +12,7 @@ TEST(LineMeshTest, api)
 {
     TestApp app;
 
-    InputParameters params = LineMesh::validParams();
+    InputParameters params = LineMesh::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "line_mesh";
     params.set<PetscReal>("xmin") = 1;
@@ -20,14 +20,14 @@ TEST(LineMeshTest, api)
     params.set<PetscInt>("nx") = 10;
     LineMesh mesh(params);
 
-    EXPECT_EQ(mesh.getXMin(), 1);
-    EXPECT_EQ(mesh.getXMax(), 2);
-    EXPECT_EQ(mesh.getNx(), 10);
+    EXPECT_EQ(mesh.get_x_min(), 1);
+    EXPECT_EQ(mesh.get_x_max(), 2);
+    EXPECT_EQ(mesh.get_nx(), 10);
 
     mesh.create();
-    DM dm = mesh.getDM();
+    DM dm = mesh.get_dm();
 
-    EXPECT_EQ(mesh.getDimension(), 1);
+    EXPECT_EQ(mesh.get_dimension(), 1);
 
     PetscReal gmin[4], gmax[4];
     DMGetBoundingBox(dm, gmin, gmax);
@@ -47,7 +47,7 @@ TEST(LineMeshTest, incorrect_dims)
 
     TestApp app;
 
-    InputParameters params = LineMesh::validParams();
+    InputParameters params = LineMesh::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "line_mesh";
     params.set<PetscReal>("xmin") = 2;
@@ -55,7 +55,7 @@ TEST(LineMeshTest, incorrect_dims)
     params.set<PetscInt>("nx") = 2;
     LineMesh mesh(params);
 
-    app.checkIntegrity();
+    app.check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr("line_mesh: Parameter 'xmax' must be larger than 'xmin'."));
@@ -68,7 +68,7 @@ TEST(LineMeshTest, distribute)
 
     TestApp app;
 
-    InputParameters params = LineMesh::validParams();
+    InputParameters params = LineMesh::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "line_mesh";
     params.set<PetscReal>("xmin") = 0;
@@ -78,7 +78,7 @@ TEST(LineMeshTest, distribute)
     mesh.create();
 
     PetscBool distr;
-    DMPlexIsDistributed(mesh.getDM(), &distr);
+    DMPlexIsDistributed(mesh.get_dm(), &distr);
     if (sz > 1)
         EXPECT_EQ(distr, 1);
     else
@@ -89,7 +89,7 @@ TEST(LineMeshTest, output_partitioning)
 {
     TestApp app;
 
-    InputParameters params = LineMesh::validParams();
+    InputParameters params = LineMesh::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "line_mesh";
     params.set<PetscReal>("xmin") = 0;
@@ -99,14 +99,14 @@ TEST(LineMeshTest, output_partitioning)
     mesh.create();
 
     PetscViewer viewer;
-    PetscViewerHDF5Open(app.getComm(), "part.h5", FILE_MODE_WRITE, &viewer);
-    mesh.outputPartitioning(viewer);
+    PetscViewerHDF5Open(app.get_comm(), "part.h5", FILE_MODE_WRITE, &viewer);
+    mesh.output_partitioning(viewer);
     PetscViewerDestroy(&viewer);
 
     Vec p;
-    VecCreate(app.getComm(), &p);
+    VecCreate(app.get_comm(), &p);
     PetscObjectSetName((PetscObject) p, "fields/partitioning");
-    PetscViewerHDF5Open(app.getComm(), "part.h5", FILE_MODE_READ, &viewer);
+    PetscViewerHDF5Open(app.get_comm(), "part.h5", FILE_MODE_READ, &viewer);
     VecLoad(p, viewer);
     PetscReal l2_norm;
     VecNorm(p, NORM_2, &l2_norm);

--- a/test/src/LinearProblem_test.cpp
+++ b/test/src/LinearProblem_test.cpp
@@ -27,7 +27,7 @@ TEST_F(LinearProblemTest, solve)
     EXPECT_EQ(conv, true);
 
     // extract the solution and make sure it is [2, 3]
-    Vec x = prob->getSolutionVector();
+    Vec x = prob->get_solution_vector();
     PetscInt ni = 2;
     PetscInt ix[2] = { 0, 1 };
     PetscScalar xx[2];
@@ -50,14 +50,14 @@ TEST_F(LinearProblemTest, run)
             return true;
         }
         MOCK_METHOD(void, output, ());
-        MOCK_METHOD(PetscErrorCode, computeRhsCallback, (Vec b));
-        MOCK_METHOD(PetscErrorCode, computeOperatorsCallback, (Mat A, Mat B));
+        MOCK_METHOD(PetscErrorCode, compute_rhs_callback, (Vec b));
+        MOCK_METHOD(PetscErrorCode, compute_operators_callback, (Mat A, Mat B));
     };
 
     auto mesh = gMesh1d();
     mesh->create();
 
-    InputParameters prob_pars = LinearProblem::validParams();
+    InputParameters prob_pars = LinearProblem::valid_params();
     prob_pars.set<const App *>("_app") = this->app;
     prob_pars.set<const Mesh *>("_mesh") = mesh;
     MockLinearProblem prob(prob_pars);
@@ -78,38 +78,38 @@ TEST_F(LinearProblemTest, output)
         {
             LinearProblem::output();
         }
-        MOCK_METHOD(PetscErrorCode, computeRhsCallback, (Vec b));
-        MOCK_METHOD(PetscErrorCode, computeOperatorsCallback, (Mat A, Mat B));
+        MOCK_METHOD(PetscErrorCode, compute_rhs_callback, (Vec b));
+        MOCK_METHOD(PetscErrorCode, compute_operators_callback, (Mat A, Mat B));
     };
 
     class MockOutput : public Output {
     public:
         explicit MockOutput(const InputParameters & params) : Output(params) {}
 
-        MOCK_METHOD(const std::string &, getFileName, (), (const));
-        MOCK_METHOD(void, setFileName, ());
-        MOCK_METHOD(void, setSequenceFileName, (unsigned int stepi));
-        MOCK_METHOD(void, outputMesh, (DM dm));
-        MOCK_METHOD(void, outputSolution, (Vec vec));
-        MOCK_METHOD(void, outputStep, (PetscInt stepi, DM dm, Vec vec));
+        MOCK_METHOD(const std::string &, get_file_name, (), (const));
+        MOCK_METHOD(void, set_file_name, ());
+        MOCK_METHOD(void, set_sequence_file_name, (unsigned int stepi));
+        MOCK_METHOD(void, output_mesh, (DM dm));
+        MOCK_METHOD(void, output_solution, (Vec vec));
+        MOCK_METHOD(void, output_step, (PetscInt stepi, DM dm, Vec vec));
     };
 
     auto mesh = gMesh1d();
     mesh->create();
 
-    InputParameters prob_pars = LinearProblem::validParams();
+    InputParameters prob_pars = LinearProblem::valid_params();
     prob_pars.set<const App *>("_app") = this->app;
     prob_pars.set<const Mesh *>("_mesh") = mesh;
     MockLinearProblem prob(prob_pars);
 
-    InputParameters out_pars = Output::validParams();
+    InputParameters out_pars = Output::valid_params();
     out_pars.set<const App *>("_app") = this->app;
     out_pars.set<Problem *>("_problem") = &prob;
     MockOutput out(out_pars);
 
-    prob.addOutput(&out);
+    prob.add_output(&out);
 
-    EXPECT_CALL(out, outputStep);
+    EXPECT_CALL(out, output_step);
 
     prob.output();
 }
@@ -130,7 +130,7 @@ G1DTestLinearProblem::~G1DTestLinearProblem()
 void
 G1DTestLinearProblem::create()
 {
-    DM dm = getDM();
+    DM dm = get_dm();
     PetscInt nc[1] = { 1 };
     PetscInt n_dofs[2] = { 1, 0 };
     DMSetNumFields(dm, 1);
@@ -140,7 +140,7 @@ G1DTestLinearProblem::create()
 }
 
 PetscErrorCode
-G1DTestLinearProblem::computeRhsCallback(Vec b)
+G1DTestLinearProblem::compute_rhs_callback(Vec b)
 {
     VecSetValue(b, 0, 2, INSERT_VALUES);
     VecSetValue(b, 1, 3, INSERT_VALUES);
@@ -152,7 +152,7 @@ G1DTestLinearProblem::computeRhsCallback(Vec b)
 }
 
 PetscErrorCode
-G1DTestLinearProblem::computeOperatorsCallback(Mat A, Mat B)
+G1DTestLinearProblem::compute_operators_callback(Mat A, Mat B)
 {
     MatSetValue(A, 0, 0, 1, INSERT_VALUES);
     MatSetValue(A, 1, 1, 1, INSERT_VALUES);
@@ -179,7 +179,7 @@ G2DTestLinearProblem::~G2DTestLinearProblem()
 void
 G2DTestLinearProblem::create()
 {
-    DM dm = getDM();
+    DM dm = get_dm();
     PetscInt nc[1] = { 1 };
     PetscInt n_dofs[3] = { 1, 0, 0 };
     DMSetNumFields(dm, 1);
@@ -189,7 +189,7 @@ G2DTestLinearProblem::create()
 }
 
 PetscErrorCode
-G2DTestLinearProblem::computeRhsCallback(Vec b)
+G2DTestLinearProblem::compute_rhs_callback(Vec b)
 {
     VecSetValue(b, 0, 2, INSERT_VALUES);
     VecSetValue(b, 1, 3, INSERT_VALUES);
@@ -203,7 +203,7 @@ G2DTestLinearProblem::computeRhsCallback(Vec b)
 }
 
 PetscErrorCode
-G2DTestLinearProblem::computeOperatorsCallback(Mat A, Mat B)
+G2DTestLinearProblem::compute_operators_callback(Mat A, Mat B)
 {
     for (PetscInt i = 0; i < 4; i++)
         MatSetValue(A, i, i, 1, INSERT_VALUES);
@@ -230,7 +230,7 @@ G3DTestLinearProblem::~G3DTestLinearProblem()
 void
 G3DTestLinearProblem::create()
 {
-    DM dm = getDM();
+    DM dm = get_dm();
     PetscInt nc[1] = { 1 };
     PetscInt n_dofs[4] = { 1, 0, 0, 0 };
     DMSetNumFields(dm, 1);
@@ -240,7 +240,7 @@ G3DTestLinearProblem::create()
 }
 
 PetscErrorCode
-G3DTestLinearProblem::computeRhsCallback(Vec b)
+G3DTestLinearProblem::compute_rhs_callback(Vec b)
 {
     VecSetValue(b, 0, 2, INSERT_VALUES);
     VecSetValue(b, 1, 3, INSERT_VALUES);
@@ -258,7 +258,7 @@ G3DTestLinearProblem::computeRhsCallback(Vec b)
 }
 
 PetscErrorCode
-G3DTestLinearProblem::computeOperatorsCallback(Mat A, Mat B)
+G3DTestLinearProblem::compute_operators_callback(Mat A, Mat B)
 {
     for (PetscInt i = 0; i < 8; i++)
         MatSetValue(A, i, i, 1, INSERT_VALUES);

--- a/test/src/Logger_test.cpp
+++ b/test/src/Logger_test.cpp
@@ -9,9 +9,9 @@ TEST(LoggerTest, ctor)
 {
     Logger log;
 
-    EXPECT_EQ(log.getNumEntries(), 0);
-    EXPECT_EQ(log.getNumErrors(), 0);
-    EXPECT_EQ(log.getNumWarnings(), 0);
+    EXPECT_EQ(log.get_num_entries(), 0);
+    EXPECT_EQ(log.get_num_errors(), 0);
+    EXPECT_EQ(log.get_num_warnings(), 0);
 }
 
 TEST(LoggerTest, log_error)
@@ -20,9 +20,9 @@ TEST(LoggerTest, log_error)
     Logger log;
 
     log.error("error1");
-    EXPECT_EQ(log.getNumEntries(), 1);
-    EXPECT_EQ(log.getNumErrors(), 1);
-    EXPECT_EQ(log.getNumWarnings(), 0);
+    EXPECT_EQ(log.get_num_entries(), 1);
+    EXPECT_EQ(log.get_num_errors(), 1);
+    EXPECT_EQ(log.get_num_warnings(), 0);
 
     log.print();
     std::string output = testing::internal::GetCapturedStderr();
@@ -36,9 +36,9 @@ TEST(LoggerTest, log_warning)
     Logger log;
 
     log.warning("warn1");
-    EXPECT_EQ(log.getNumEntries(), 1);
-    EXPECT_EQ(log.getNumErrors(), 0);
-    EXPECT_EQ(log.getNumWarnings(), 1);
+    EXPECT_EQ(log.get_num_entries(), 1);
+    EXPECT_EQ(log.get_num_errors(), 0);
+    EXPECT_EQ(log.get_num_warnings(), 1);
 
     log.print();
     std::string output = testing::internal::GetCapturedStderr();
@@ -53,9 +53,9 @@ TEST(LoggerTest, log_err_warning)
 
     log.error("error1");
     log.warning("warn1");
-    EXPECT_EQ(log.getNumEntries(), 2);
-    EXPECT_EQ(log.getNumErrors(), 1);
-    EXPECT_EQ(log.getNumWarnings(), 1);
+    EXPECT_EQ(log.get_num_entries(), 2);
+    EXPECT_EQ(log.get_num_errors(), 1);
+    EXPECT_EQ(log.get_num_warnings(), 1);
 
     log.print();
     std::string output = testing::internal::GetCapturedStderr();

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -14,41 +14,41 @@ TEST(NaturalBCTest, api)
         explicit MockNaturalBC(const InputParameters & params) : NaturalBC(params) {}
 
         virtual PetscInt
-        getFieldId() const
+        get_field_id() const
         {
             return 0;
         }
 
         virtual PetscInt
-        getNumComponents() const
+        get_num_components() const
         {
             return 2;
         }
 
         virtual std::vector<PetscInt>
-        getComponents() const
+        get_components() const
         {
             std::vector<PetscInt> comps = { 3, 5 };
             return comps;
         }
 
         virtual void
-        onSetWeakForm()
+        on_set_weak_form()
         {
         }
     };
 
-    InputParameters params = NaturalBC::validParams();
+    InputParameters params = NaturalBC::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("boundary") = "left";
     MockNaturalBC bc(params);
     bc.create();
 
-    EXPECT_EQ(bc.getFieldId(), 0);
-    EXPECT_EQ(bc.getNumComponents(), 2);
-    EXPECT_EQ(bc.getBcType(), DM_BC_NATURAL);
+    EXPECT_EQ(bc.get_field_id(), 0);
+    EXPECT_EQ(bc.get_num_components(), 2);
+    EXPECT_EQ(bc.get_bc_type(), DM_BC_NATURAL);
 
-    std::vector<PetscInt> comps = bc.getComponents();
+    std::vector<PetscInt> comps = bc.get_components();
     EXPECT_EQ(comps[0], 3);
     EXPECT_EQ(comps[1], 5);
 }
@@ -109,29 +109,29 @@ TEST(NaturalBCTest, fe)
         explicit TestNaturalBC(const InputParameters & params) : NaturalBC(params) {}
 
         virtual PetscInt
-        getFieldId() const
+        get_field_id() const
         {
             return 0;
         }
 
         virtual PetscInt
-        getNumComponents() const
+        get_num_components() const
         {
             return 1;
         }
 
         virtual std::vector<PetscInt>
-        getComponents() const
+        get_components() const
         {
             std::vector<PetscInt> comps = { 0 };
             return comps;
         }
 
         virtual void
-        onSetWeakForm()
+        on_set_weak_form()
         {
-            setResidualBlock(__f0_test_natural_bc, nullptr);
-            setJacobianBlock(getFieldId(), __g0_test_natural_bc, nullptr, nullptr, nullptr);
+            set_residual_block(__f0_test_natural_bc, nullptr);
+            set_jacobian_block(get_field_id(), __g0_test_natural_bc, nullptr, nullptr, nullptr);
         }
 
         PetscInt
@@ -143,23 +143,23 @@ TEST(NaturalBCTest, fe)
 
     TestApp app;
 
-    InputParameters mesh_params = LineMesh::validParams();
+    InputParameters mesh_params = LineMesh::valid_params();
     mesh_params.set<const App *>("_app") = &app;
     mesh_params.set<PetscInt>("nx") = 2;
     LineMesh mesh(mesh_params);
 
-    InputParameters prob_params = GTestFENonlinearProblem::validParams();
+    InputParameters prob_params = GTestFENonlinearProblem::valid_params();
     prob_params.set<const App *>("_app") = &app;
     prob_params.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    prob.addAuxFE(0, "aux1", 1, 1);
+    prob.add_aux_fe(0, "aux1", 1, 1);
 
-    InputParameters bc_params = TestNaturalBC::validParams();
+    InputParameters bc_params = TestNaturalBC::valid_params();
     bc_params.set<const App *>("_app") = &app;
     bc_params.set<std::string>("_name") = "bc1";
     bc_params.set<std::string>("boundary") = "left";
     TestNaturalBC bc(bc_params);
-    prob.addBoundaryCondition(&bc);
+    prob.add_boundary_condition(&bc);
 
     mesh.create();
     prob.create();

--- a/test/src/NonlinearProblem_test.cpp
+++ b/test/src/NonlinearProblem_test.cpp
@@ -24,7 +24,7 @@ TEST_F(NonlinearProblemTest, solve)
     EXPECT_EQ(conv, true);
 
     // extract the solution and make sure it is [2, 3]
-    const Vec x = prob->getSolutionVector();
+    const Vec x = prob->get_solution_vector();
     PetscInt ni = 2;
     PetscInt ix[2] = { 0, 1 };
     PetscScalar xx[2];
@@ -47,14 +47,14 @@ TEST_F(NonlinearProblemTest, run)
             return true;
         }
         MOCK_METHOD(void, output, ());
-        MOCK_METHOD(PetscErrorCode, computeResidualCallback, (Vec x, Vec f));
-        MOCK_METHOD(PetscErrorCode, computeJacobianCallback, (Vec x, Mat J, Mat Jp));
+        MOCK_METHOD(PetscErrorCode, compute_residual_callback, (Vec x, Vec f));
+        MOCK_METHOD(PetscErrorCode, compute_jacobian_callback, (Vec x, Mat J, Mat Jp));
     };
 
     auto mesh = gMesh1d();
     mesh->create();
 
-    InputParameters prob_pars = NonlinearProblem::validParams();
+    InputParameters prob_pars = NonlinearProblem::valid_params();
     prob_pars.set<const App *>("_app") = this->app;
     prob_pars.set<const Mesh *>("_mesh") = mesh;
     MockNonlinearProblem prob(prob_pars);
@@ -75,38 +75,38 @@ TEST_F(NonlinearProblemTest, output)
         {
             NonlinearProblem::output();
         }
-        MOCK_METHOD(PetscErrorCode, computeResidualCallback, (Vec x, Vec f));
-        MOCK_METHOD(PetscErrorCode, computeJacobianCallback, (Vec x, Mat J, Mat Jp));
+        MOCK_METHOD(PetscErrorCode, compute_residual_callback, (Vec x, Vec f));
+        MOCK_METHOD(PetscErrorCode, compute_jacobian_callback, (Vec x, Mat J, Mat Jp));
     };
 
     class MockOutput : public Output {
     public:
         explicit MockOutput(const InputParameters & params) : Output(params) {}
 
-        MOCK_METHOD(const std::string &, getFileName, (), (const));
-        MOCK_METHOD(void, setFileName, ());
-        MOCK_METHOD(void, setSequenceFileName, (unsigned int stepi));
-        MOCK_METHOD(void, outputMesh, (DM dm));
-        MOCK_METHOD(void, outputSolution, (Vec vec));
-        MOCK_METHOD(void, outputStep, (PetscInt stepi, DM dm, Vec vec));
+        MOCK_METHOD(const std::string &, get_file_name, (), (const));
+        MOCK_METHOD(void, set_file_name, ());
+        MOCK_METHOD(void, set_sequence_file_name, (unsigned int stepi));
+        MOCK_METHOD(void, output_mesh, (DM dm));
+        MOCK_METHOD(void, output_solution, (Vec vec));
+        MOCK_METHOD(void, output_step, (PetscInt stepi, DM dm, Vec vec));
     };
 
     auto mesh = gMesh1d();
     mesh->create();
 
-    InputParameters prob_pars = NonlinearProblem::validParams();
+    InputParameters prob_pars = NonlinearProblem::valid_params();
     prob_pars.set<const App *>("_app") = this->app;
     prob_pars.set<const Mesh *>("_mesh") = mesh;
     MockNonlinearProblem prob(prob_pars);
 
-    InputParameters out_pars = Output::validParams();
+    InputParameters out_pars = Output::valid_params();
     out_pars.set<const App *>("_app") = this->app;
     out_pars.set<Problem *>("_problem") = &prob;
     MockOutput out(out_pars);
 
-    prob.addOutput(&out);
+    prob.add_output(&out);
 
-    EXPECT_CALL(out, outputStep);
+    EXPECT_CALL(out, output_step);
 
     prob.output();
 }
@@ -117,8 +117,8 @@ TEST_F(NonlinearProblemTest, line_search_type)
     public:
         explicit MockNonlinearProblem(const InputParameters & params) : NonlinearProblem(params) {}
 
-        MOCK_METHOD(PetscErrorCode, computeResidualCallback, (Vec x, Vec f));
-        MOCK_METHOD(PetscErrorCode, computeJacobianCallback, (Vec x, Mat J, Mat Jp));
+        MOCK_METHOD(PetscErrorCode, compute_residual_callback, (Vec x, Vec f));
+        MOCK_METHOD(PetscErrorCode, compute_jacobian_callback, (Vec x, Mat J, Mat Jp));
 
         SNES
         getSNES()
@@ -132,7 +132,7 @@ TEST_F(NonlinearProblemTest, line_search_type)
 
     std::vector<std::string> ls_type = { "basic", "l2", "cp", "nleqerr", "shell" };
     for (auto & lst : ls_type) {
-        InputParameters prob_pars = NonlinearProblem::validParams();
+        InputParameters prob_pars = NonlinearProblem::valid_params();
         prob_pars.set<const App *>("_app") = this->app;
         prob_pars.set<const Mesh *>("_mesh") = mesh;
         prob_pars.set<std::string>("line_search") = lst;
@@ -164,7 +164,7 @@ G1DTestNonlinearProblem::~G1DTestNonlinearProblem()
 void
 G1DTestNonlinearProblem::create()
 {
-    DM dm = getDM();
+    DM dm = get_dm();
     PetscInt nc[1] = { 1 };
     PetscInt n_dofs[2] = { 1, 0 };
     DMSetNumFields(dm, 1);
@@ -174,7 +174,7 @@ G1DTestNonlinearProblem::create()
 }
 
 PetscErrorCode
-G1DTestNonlinearProblem::computeResidualCallback(Vec x, Vec f)
+G1DTestNonlinearProblem::compute_residual_callback(Vec x, Vec f)
 {
     PetscInt ni = 2;
     PetscInt ix[] = { 0, 1 };
@@ -191,7 +191,7 @@ G1DTestNonlinearProblem::computeResidualCallback(Vec x, Vec f)
 }
 
 PetscErrorCode
-G1DTestNonlinearProblem::computeJacobianCallback(Vec x, Mat J, Mat Jp)
+G1DTestNonlinearProblem::compute_jacobian_callback(Vec x, Mat J, Mat Jp)
 {
     MatSetValue(J, 0, 0, 1, INSERT_VALUES);
     MatSetValue(J, 1, 1, 1, INSERT_VALUES);

--- a/test/src/Object_test.cpp
+++ b/test/src/Object_test.cpp
@@ -25,5 +25,5 @@ TEST(ObjectTest, api)
 
     PetscMPIInt sz;
     MPI_Comm_size(app.get_comm(), &sz);
-    EXPECT_EQ(obj->comm_size(), sz);
+    EXPECT_EQ(obj->get_comm_size(), sz);
 }

--- a/test/src/Object_test.cpp
+++ b/test/src/Object_test.cpp
@@ -21,7 +21,7 @@ TEST(ObjectTest, api)
 
     EXPECT_TRUE(obj->is_param_valid("_name"));
 
-    EXPECT_EQ(obj->processor_id(), 0);
+    EXPECT_EQ(obj->get_processor_id(), 0);
 
     PetscMPIInt sz;
     MPI_Comm_size(app.get_comm(), &sz);

--- a/test/src/Object_test.cpp
+++ b/test/src/Object_test.cpp
@@ -11,19 +11,19 @@ TEST(ObjectTest, api)
 {
     App app("test", MPI_COMM_WORLD);
 
-    InputParameters params = Object::validParams();
-    auto obj = app.buildObject<Object>("Object", "name", params);
+    InputParameters params = Object::valid_params();
+    auto obj = app.build_object<Object>("Object", "name", params);
 
-    EXPECT_EQ(obj->getName(), "name");
-    EXPECT_EQ(obj->getType(), "Object");
+    EXPECT_EQ(obj->get_name(), "name");
+    EXPECT_EQ(obj->get_type(), "Object");
 
-    const auto & p = obj->getParameters();
+    const auto & p = obj->get_parameters();
 
-    EXPECT_TRUE(obj->isParamValid("_name"));
+    EXPECT_TRUE(obj->is_param_valid("_name"));
 
-    EXPECT_EQ(obj->processorId(), 0);
+    EXPECT_EQ(obj->processor_id(), 0);
 
     PetscMPIInt sz;
-    MPI_Comm_size(app.getComm(), &sz);
-    EXPECT_EQ(obj->commSize(), sz);
+    MPI_Comm_size(app.get_comm(), &sz);
+    EXPECT_EQ(obj->comm_size(), sz);
 }

--- a/test/src/PiecewiseLinear_test.cpp
+++ b/test/src/PiecewiseLinear_test.cpp
@@ -9,7 +9,7 @@ TEST(PiecewiseLinearTest, eval)
 {
     TestApp app;
 
-    InputParameters params = PiecewiseLinear::validParams();
+    InputParameters params = PiecewiseLinear::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "ipol";
     params.set<std::vector<PetscReal>>("x") = { 1., 2., 3. };
@@ -17,7 +17,7 @@ TEST(PiecewiseLinearTest, eval)
     PiecewiseLinear obj(params);
 
     mu::Parser parser;
-    obj.registerCallback(parser);
+    obj.register_callback(parser);
 
     parser.SetExpr("ipol(0)");
     EXPECT_EQ(parser.Eval(), 3.);

--- a/test/src/PrintInterface_test.cpp
+++ b/test/src/PrintInterface_test.cpp
@@ -12,7 +12,7 @@ TEST(PrintInterfaceTest, print)
         void
         test()
         {
-            godzillaPrint(0, "Message");
+            godzilla_print(0, "Message");
         }
     } app;
 

--- a/test/src/Problem_test.cpp
+++ b/test/src/Problem_test.cpp
@@ -28,13 +28,13 @@ TEST(ProblemTest, add_pp)
             return false;
         }
         virtual DM
-        getDM() const
+        get_dm() const
         {
             return nullptr;
         }
 
         virtual Vec
-        getSolutionVector() const
+        get_solution_vector() const
         {
             return nullptr;
         }
@@ -50,31 +50,31 @@ TEST(ProblemTest, add_pp)
         }
 
         virtual PetscReal
-        getValue()
+        get_value()
         {
             return 0;
         }
     };
 
-    InputParameters mesh_params = LineMesh::validParams();
+    InputParameters mesh_params = LineMesh::valid_params();
     mesh_params.set<const App *>("_app") = &app;
     mesh_params.set<PetscInt>("nx") = 2;
     LineMesh mesh(mesh_params);
 
-    InputParameters prob_params = Problem::validParams();
+    InputParameters prob_params = Problem::valid_params();
     prob_params.set<const App *>("_app") = &app;
     prob_params.set<const Mesh *>("_mesh") = &mesh;
     TestProblem problem(prob_params);
 
-    InputParameters pp_params = Postprocessor::validParams();
+    InputParameters pp_params = Postprocessor::valid_params();
     pp_params.set<const App *>("_app") = &app;
     pp_params.set<Problem *>("_problem") = &problem;
     pp_params.set<std::string>("_name") = "pp";
     TestPostprocessor pp(pp_params);
 
-    problem.addPostprocessor(&pp);
+    problem.add_postprocessor(&pp);
     problem.check();
 
-    EXPECT_EQ(problem.getPostprocessor("pp"), &pp);
-    EXPECT_EQ(problem.getPostprocessor("asdf"), nullptr);
+    EXPECT_EQ(problem.get_postprocessor("pp"), &pp);
+    EXPECT_EQ(problem.get_postprocessor("asdf"), nullptr);
 }

--- a/test/src/RectangleMesh_test.cpp
+++ b/test/src/RectangleMesh_test.cpp
@@ -10,7 +10,7 @@ TEST(RectangleMeshTest, api)
 {
     TestApp app;
 
-    InputParameters params = RectangleMesh::validParams();
+    InputParameters params = RectangleMesh::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "rect_mesh";
     params.set<PetscReal>("xmin") = 1;
@@ -21,18 +21,18 @@ TEST(RectangleMeshTest, api)
     params.set<PetscInt>("ny") = 8;
     RectangleMesh mesh(params);
 
-    EXPECT_EQ(mesh.getXMin(), 1);
-    EXPECT_EQ(mesh.getXMax(), 3);
-    EXPECT_EQ(mesh.getNx(), 9);
+    EXPECT_EQ(mesh.get_x_min(), 1);
+    EXPECT_EQ(mesh.get_x_max(), 3);
+    EXPECT_EQ(mesh.get_nx(), 9);
 
-    EXPECT_EQ(mesh.getYMin(), 2);
-    EXPECT_EQ(mesh.getYMax(), 4);
-    EXPECT_EQ(mesh.getNy(), 8);
+    EXPECT_EQ(mesh.get_y_min(), 2);
+    EXPECT_EQ(mesh.get_y_max(), 4);
+    EXPECT_EQ(mesh.get_ny(), 8);
 
     mesh.create();
-    DM dm = mesh.getDM();
+    DM dm = mesh.get_dm();
 
-    EXPECT_EQ(mesh.getDimension(), 2);
+    EXPECT_EQ(mesh.get_dimension(), 2);
 
     PetscReal gmin[4], gmax[4];
     DMGetBoundingBox(dm, gmin, gmax);
@@ -55,7 +55,7 @@ TEST(RectangleMeshTest, incorrect_dims)
 
     TestApp app;
 
-    InputParameters params = RectangleMesh::validParams();
+    InputParameters params = RectangleMesh::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::string>("_name") = "obj";
     params.set<PetscReal>("xmin") = 2;
@@ -66,7 +66,7 @@ TEST(RectangleMeshTest, incorrect_dims)
     params.set<PetscInt>("ny") = 8;
     RectangleMesh mesh(params);
 
-    app.checkIntegrity();
+    app.check_integrity();
 
     auto output = testing::internal::GetCapturedStderr();
     EXPECT_THAT(output, testing::HasSubstr("obj: Parameter 'xmax' must be larger than 'xmin'."));

--- a/test/src/Utils_test.cpp
+++ b/test/src/Utils_test.cpp
@@ -5,10 +5,10 @@ using namespace godzilla;
 
 TEST(UtilsTest, to_lower)
 {
-    EXPECT_EQ(utils::toLower("ASDF"), "asdf");
+    EXPECT_EQ(utils::to_lower("ASDF"), "asdf");
 }
 
 TEST(UtilsTest, to_upper)
 {
-    EXPECT_EQ(utils::toUpper("asdf"), "ASDF");
+    EXPECT_EQ(utils::to_upper("asdf"), "ASDF");
 }

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -11,7 +11,7 @@ TEST_F(VTKOutputTest, get_file_ext)
     prob->create();
 
     auto out = gOutput(prob, "out");
-    EXPECT_EQ(out->getFileExt(), "vtk");
+    EXPECT_EQ(out->get_file_ext(), "vtk");
 }
 
 TEST_F(VTKOutputTest, create)
@@ -21,7 +21,7 @@ TEST_F(VTKOutputTest, create)
     auto prob = gProblem1d(mesh);
     prob->create();
     auto out = gOutput(prob, "out");
-    prob->addOutput(out);
+    prob->add_output(out);
     prob->create();
 }
 
@@ -45,9 +45,9 @@ TEST_F(VTKOutputTest, output_1d_step)
     auto out = gOutput(prob, "out");
     out->create();
     out->check();
-    this->app->checkIntegrity();
+    this->app->check_integrity();
 
     prob->solve();
     EXPECT_EQ(prob->converged(), true);
-    out->outputStep(0, mesh->getDM(), prob->getSolutionVector());
+    out->output_step(0, mesh->get_dm(), prob->get_solution_vector());
 }


### PR DESCRIPTION
- Method names are C-style
- Removing emptyInputParameters()
- Renaming 'evaluate_function' to just 'evaluate'
- Object::comm() -> Object::get_comm()
- Object::comm_size -> Object::get_comm_size
- Object::processor_id -> Object::get_processor_id
