### PR TITLE
Lots of improvements

### DIFF
--- a/examples/heat-eqn/CMakeLists.txt
+++ b/examples/heat-eqn/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 add_executable(
     ${PROJECT_NAME}
-        src/ConvectiveHeatFluxConstBC.cpp
+        src/ConvectiveHeatFluxBC.cpp
         src/HeatEquationProblem.cpp
         src/main.cpp
 )

--- a/examples/heat-eqn/include/ConvectiveHeatFluxBC.h
+++ b/examples/heat-eqn/include/ConvectiveHeatFluxBC.h
@@ -4,9 +4,9 @@
 
 namespace godzilla {
 
-class ConvectiveHeatFluxConstBC : public NaturalBC {
+class ConvectiveHeatFluxBC : public NaturalBC {
 public:
-    ConvectiveHeatFluxConstBC(const InputParameters & params);
+    ConvectiveHeatFluxBC(const InputParameters & params);
 
     virtual PetscInt get_field_id() const;
     virtual PetscInt get_num_components() const;
@@ -14,12 +14,6 @@ public:
 
 protected:
     virtual void on_set_weak_form();
-
-    /// Convective heat transfer coefficient
-    const PetscReal & htc;
-
-    /// Ambient temperature
-    const PetscReal & T_infinity;
 
 public:
     static InputParameters valid_params();

--- a/examples/heat-eqn/include/HeatEquationProblem.h
+++ b/examples/heat-eqn/include/HeatEquationProblem.h
@@ -20,4 +20,7 @@ protected:
 
 public:
     static InputParameters valid_params();
+
+    static const PetscInt htc_aux_id = 0;
+    static const PetscInt T_ambient_aux_id = 1;
 };

--- a/examples/heat-eqn/src/ConvectiveHeatFluxBC.cpp
+++ b/examples/heat-eqn/src/ConvectiveHeatFluxBC.cpp
@@ -1,10 +1,11 @@
 #include "Godzilla.h"
-#include "ConvectiveHeatFluxConstBC.h"
+#include "HeatEquationProblem.h"
+#include "ConvectiveHeatFluxBC.h"
 #include "CallStack.h"
 
 namespace godzilla {
 
-registerObject(ConvectiveHeatFluxConstBC);
+registerObject(ConvectiveHeatFluxBC);
 
 void
 __f0_convective_heat_flux_const_bc(PetscInt dim,
@@ -27,8 +28,8 @@ __f0_convective_heat_flux_const_bc(PetscInt dim,
                                    const PetscScalar constants[],
                                    PetscScalar f0[])
 {
-    PetscReal htc = 100;
-    PetscReal T_infinity = 400;
+    PetscReal htc = a[a_off[HeatEquationProblem::htc_aux_id]];
+    PetscReal T_infinity = a[a_off[HeatEquationProblem::T_ambient_aux_id]];
     f0[0] = htc * (u[0] - T_infinity);
 }
 
@@ -59,43 +60,38 @@ __g0_convective_heat_flux_const_bc(PetscInt dim,
 }
 
 InputParameters
-ConvectiveHeatFluxConstBC::valid_params()
+ConvectiveHeatFluxBC::valid_params()
 {
     InputParameters params = NaturalBC::valid_params();
-    params.add_required_param<PetscReal>("htc", "Convective heat transfer coefficient");
-    params.add_required_param<PetscReal>("T_infinity", "Ambient temperature");
     return params;
 }
 
-ConvectiveHeatFluxConstBC::ConvectiveHeatFluxConstBC(const InputParameters & params) :
-    NaturalBC(params),
-    htc(get_param<PetscReal>("htc")),
-    T_infinity(get_param<PetscReal>("T_infinity"))
+ConvectiveHeatFluxBC::ConvectiveHeatFluxBC(const InputParameters & params) : NaturalBC(params)
 {
     _F_;
 }
 
 PetscInt
-ConvectiveHeatFluxConstBC::get_field_id() const
+ConvectiveHeatFluxBC::get_field_id() const
 {
     return 0;
 }
 
 PetscInt
-ConvectiveHeatFluxConstBC::get_num_components() const
+ConvectiveHeatFluxBC::get_num_components() const
 {
     return 1;
 }
 
 std::vector<PetscInt>
-ConvectiveHeatFluxConstBC::get_components() const
+ConvectiveHeatFluxBC::get_components() const
 {
     std::vector<PetscInt> comps = { 0 };
     return comps;
 }
 
 void
-ConvectiveHeatFluxConstBC::on_set_weak_form()
+ConvectiveHeatFluxBC::on_set_weak_form()
 {
     _F_;
     set_residual_block(__f0_convective_heat_flux_const_bc, nullptr);

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -125,6 +125,9 @@ HeatEquationProblem::on_set_fields()
     _F_;
     PetscInt order = 1;
     add_fe(this->itemp, "temp", 1, order);
+
+    add_aux_fe(htc_aux_id, "htc", 1, 1);
+    add_aux_fe(T_ambient_aux_id, "T_ambient", 1, 1);
 }
 
 void

--- a/examples/heat-eqn/test/gyml/2d.gyml
+++ b/examples/heat-eqn/test/gyml/2d.gyml
@@ -14,13 +14,22 @@ ics:
     type: ConstantIC
     value: [ 300 ]
 
+auxs:
+  htc:
+    type: FunctionAuxiliaryField
+    value: '100'
+
+  T_ambient:
+    type: FunctionAuxiliaryField
+    value: '400'
+
 bcs:
   left:
     type: DirichletBC
     boundary: 'left'
     value: [ '300' ]
   right:
-    type: ConvectiveHeatFluxConstBC
+    type: ConvectiveHeatFluxBC
     boundary: 'right'
     htc: 100
     T_infinity: 400

--- a/include/AuxiliaryField.h
+++ b/include/AuxiliaryField.h
@@ -2,6 +2,7 @@
 
 #include "Object.h"
 #include "PrintInterface.h"
+#include "FunctionInterface.h"
 #include "petsc.h"
 
 namespace godzilla {
@@ -15,11 +16,9 @@ public:
     AuxiliaryField(const InputParameters & params);
     virtual ~AuxiliaryField();
 
-    /// Set up the auxiliary field
-    ///
-    /// @param dm The main DM
-    /// @param dm_aux DM for the auxiliary fields
-    virtual void set_up(DM dm, DM dm_aux) = 0;
+    virtual void create() override;
+
+    virtual DMLabel get_label() const;
 
     /// Get the ID of the field this boundary condition operates on
     ///
@@ -31,15 +30,17 @@ public:
     /// @return The number of constrained components
     virtual PetscInt get_num_components() const = 0;
 
+    virtual PetscFunc * get_func() const = 0;
+
 protected:
     /// FE problem this object is part of
     const FEProblemInterface & fepi;
 
-    /// Auxiliary vector
-    Vec a;
+    /// Region name this auxiliary field is defined on
+    const std::string & region;
 
     /// Block here the auxiliary field lives
-    DMLabel block;
+    DMLabel label;
 
 public:
     static InputParameters valid_params();

--- a/include/BoundaryCondition.h
+++ b/include/BoundaryCondition.h
@@ -12,6 +12,8 @@ class BoundaryCondition : public Object, public PrintInterface {
 public:
     BoundaryCondition(const InputParameters & params);
 
+    virtual void create() override;
+
     /// Get the boundary name this BC is active on
     ///
     /// @return The boundary name
@@ -38,9 +40,7 @@ public:
     virtual std::vector<PetscInt> get_components() const = 0;
 
     /// Set up this boundary condition
-    ///
-    /// @param dm DM of problem (should have PetscDS)
-    virtual void set_up(DM dm);
+    virtual void set_up();
 
 protected:
     /// Set up the PETSc callback

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -137,7 +137,7 @@ protected:
 
     virtual void create();
 
-    virtual void set_up_initial_guess(DM dm, Vec x);
+    virtual void set_up_initial_guess();
 
     typedef void PetscFEResidualFunc(PetscInt dim,
                                      PetscInt Nf,

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -9,7 +9,7 @@
 namespace godzilla {
 
 class Logger;
-class Mesh;
+class UnstructuredMesh;
 class Problem;
 class InitialCondition;
 class BoundaryCondition;
@@ -20,7 +20,7 @@ class AuxiliaryField;
 /// Any problem using PetscFE should inherit from this for unified API
 class FEProblemInterface {
 public:
-    FEProblemInterface(Problem & problem, const InputParameters & params);
+    FEProblemInterface(Problem * problem, const InputParameters & params);
     virtual ~FEProblemInterface();
 
     /// Get list of all field names
@@ -220,8 +220,11 @@ protected:
     /// FIXME: This needs a better name
     virtual void on_set_weak_form() = 0;
 
-    /// Reference to the the problem this interface is part of
-    Problem & problem;
+    /// Problem this interface is part of
+    Problem * problem;
+
+    /// Unstructured mesh
+    const UnstructuredMesh * unstr_mesh;
 
     /// Logger object
     Logger * logger;

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -131,9 +131,9 @@ public:
 
 protected:
     /// Initialize the FE system
-    virtual void init(DM dm);
+    virtual void init();
 
-    virtual void create(DM dm);
+    virtual void create();
 
     virtual void set_up_initial_guess(DM dm, Vec x);
 
@@ -177,10 +177,10 @@ protected:
                                      PetscScalar g3[]);
 
     /// Set up finite element objects
-    void set_up_fes(DM dm);
+    void set_up_fes();
 
     /// Inform PETSc to about all fields in this problem
-    void set_up_problem(DM dm);
+    void set_up_problem();
 
     /// Set up residual statement for a field variable
     ///
@@ -205,7 +205,7 @@ protected:
                             PetscFEJacobianFunc * g3);
 
     /// Set up boundary conditions
-    virtual void set_up_boundary_conditions(DM dm);
+    virtual void set_up_boundary_conditions();
 
     /// Set up auxiliary DM
     virtual void set_up_auxiliary_dm(DM dm);

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -130,6 +130,8 @@ public:
     virtual const PetscReal & get_time() const;
 
 protected:
+    struct FieldInfo;
+
     /// Initialize the FE system
     virtual void init();
 
@@ -175,6 +177,11 @@ protected:
                                      PetscInt numConstants,
                                      const PetscScalar constants[],
                                      PetscScalar g3[]);
+
+    /// Create FE object from FieldInfo
+    ///
+    /// @param fi Field description
+    void create_fe(FieldInfo & fi);
 
     /// Set up finite element objects
     void set_up_fes();

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -23,6 +23,11 @@ public:
     FEProblemInterface(Problem * problem, const InputParameters & params);
     virtual ~FEProblemInterface();
 
+    /// Get the unstructured mesh
+    ///
+    /// @return Pointer to the unstructured mesh this problem is using
+    virtual const UnstructuredMesh * get_mesh() const;
+
     /// Get list of all field names
     ///
     /// @return List of field names
@@ -218,6 +223,13 @@ protected:
     /// Set up boundary conditions
     virtual void set_up_boundary_conditions();
 
+    /// Compute auxiliary fields
+    ///
+    /// @param dm_aux DM for auxiliary fields
+    /// @param label Label to which the fields are restricted
+    /// @param a Auxiliary vector associate with the label
+    void compute_aux_fields(DM dm_aux, DMLabel label, Vec a);
+
     /// Set up auxiliary DM
     virtual void set_up_auxiliary_dm(DM dm);
 
@@ -293,6 +305,9 @@ protected:
 
     /// Object that manages a discrete system
     PetscDS ds;
+
+    /// Auxiliary vector
+    Vec a;
 
     /// List of constants
     std::vector<PetscReal> consts;

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -137,6 +137,10 @@ protected:
 
     virtual void create();
 
+    void set_zero_initial_guess();
+
+    void set_initial_guess_from_ics();
+
     virtual void set_up_initial_guess();
 
     typedef void PetscFEResidualFunc(PetscInt dim,

--- a/include/FunctionAuxiliaryField.h
+++ b/include/FunctionAuxiliaryField.h
@@ -12,8 +12,8 @@ public:
     FunctionAuxiliaryField(const InputParameters & params);
 
     virtual void create();
-    virtual void set_up(DM dm, DM dm_aux);
     virtual PetscInt get_num_components() const;
+    virtual PetscFunc * get_func() const;
     virtual void
     evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc, PetscScalar u[]);
 

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -29,6 +29,12 @@ public:
     /// @return true if label exists, otherwise false
     virtual bool has_label(const std::string & name) const;
 
+    /// Get label associated with a name
+    ///
+    /// @param name Label name
+    /// @return DMLabel associated with the `name`
+    virtual DMLabel get_label(const std::string & name) const;
+
 protected:
     /// Method that builds DM for the mesh
     virtual void create_dm() = 0;

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -23,6 +23,12 @@ public:
     /// Create the mesh
     virtual void create();
 
+    /// Check if mesh has label with a name
+    ///
+    /// @param name The name of the label
+    /// @return true if label exists, otherwise false
+    virtual bool has_label(const std::string & name) const;
+
 protected:
     /// Method that builds DM for the mesh
     virtual void create_dm() = 0;

--- a/include/TransientProblemInterface.h
+++ b/include/TransientProblemInterface.h
@@ -4,25 +4,29 @@
 
 namespace godzilla {
 
+class Problem;
+
 /// Interface for transient simulations
 ///
 class TransientProblemInterface {
 public:
-    TransientProblemInterface(const InputParameters & params);
+    TransientProblemInterface(Problem * problem, const InputParameters & params);
     virtual ~TransientProblemInterface();
 
 protected:
     /// Initialize
     ///
     /// @param comm MPI communicator
-    virtual void init(const MPI_Comm & comm);
+    virtual void init();
     /// Create
-    virtual void create(DM dm);
+    virtual void create();
     /// Called before the time step solve
     virtual void set_up_time_scheme();
     /// Solve
     virtual void solve(Vec x);
 
+    /// Problem this interface is part of
+    Problem * problem;
     /// PETSc TS object
     TS ts;
     /// Simulation start time

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -33,6 +33,11 @@ public:
     /// @param viewer PetscViewer to store the partitioning
     virtual void output_partitioning(PetscViewer viewer);
 
+    /// Is the first cell in the mesh a simplex?
+    ///
+    /// @return true if cell is a simplex, otherwise false
+    virtual bool is_simplex() const;
+
 protected:
     virtual void distribute() override;
 

--- a/src/BoundaryCondition.cpp
+++ b/src/BoundaryCondition.cpp
@@ -1,6 +1,7 @@
 #include "Godzilla.h"
 #include "CallStack.h"
 #include "App.h"
+#include "Mesh.h"
 #include "Problem.h"
 #include "BoundaryCondition.h"
 #include <assert.h>
@@ -36,6 +37,9 @@ BoundaryCondition::create()
     assert(problem != nullptr);
     this->dm = problem->get_dm();
     assert(this->dm != nullptr);
+
+    const Mesh * mesh = problem->get_mesh();
+    this->label = mesh->get_label(this->boundary);
 }
 
 const std::string &
@@ -55,9 +59,6 @@ BoundaryCondition::set_up()
 
     IS is;
     ierr = DMGetLabelIdIS(this->dm, this->boundary.c_str(), &is);
-    check_petsc_error(ierr);
-
-    ierr = DMGetLabel(this->dm, this->boundary.c_str(), &this->label);
     check_petsc_error(ierr);
 
     ierr = ISGetSize(is, &this->n_ids);

--- a/src/BoundaryCondition.cpp
+++ b/src/BoundaryCondition.cpp
@@ -1,6 +1,9 @@
 #include "Godzilla.h"
 #include "CallStack.h"
+#include "App.h"
+#include "Problem.h"
 #include "BoundaryCondition.h"
+#include <assert.h>
 
 namespace godzilla {
 
@@ -25,6 +28,16 @@ BoundaryCondition::BoundaryCondition(const InputParameters & params) :
     _F_;
 }
 
+void
+BoundaryCondition::create()
+{
+    _F_;
+    Problem * problem = this->app.get_problem();
+    assert(problem != nullptr);
+    this->dm = problem->get_dm();
+    assert(this->dm != nullptr);
+}
+
 const std::string &
 BoundaryCondition::get_boundary() const
 {
@@ -32,21 +45,19 @@ BoundaryCondition::get_boundary() const
 }
 
 void
-BoundaryCondition::set_up(DM dm)
+BoundaryCondition::set_up()
 {
     _F_;
     PetscErrorCode ierr;
 
-    this->dm = dm;
-
-    ierr = DMGetDS(dm, &this->ds);
+    ierr = DMGetDS(this->dm, &this->ds);
     check_petsc_error(ierr);
 
     IS is;
-    ierr = DMGetLabelIdIS(dm, this->boundary.c_str(), &is);
+    ierr = DMGetLabelIdIS(this->dm, this->boundary.c_str(), &is);
     check_petsc_error(ierr);
 
-    ierr = DMGetLabel(dm, this->boundary.c_str(), &this->label);
+    ierr = DMGetLabel(this->dm, this->boundary.c_str(), &this->label);
     check_petsc_error(ierr);
 
     ierr = ISGetSize(is, &this->n_ids);

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -134,8 +134,7 @@ BoxMesh::create_dm()
     check_petsc_error(ierr);
 
     // create user-friendly names for sides
-    DMLabel face_sets_label;
-    ierr = DMGetLabel(this->dm, "Face Sets", &face_sets_label);
+    DMLabel face_sets_label = get_label("Face Sets");
 
     const char * side_name[] = { "back", "front", "bottom", "top", "right", "left" };
     for (unsigned int i = 0; i < 6; i++) {
@@ -146,9 +145,7 @@ BoxMesh::create_dm()
         ierr = DMCreateLabel(this->dm, side_name[i]);
         check_petsc_error(ierr);
 
-        DMLabel label;
-        ierr = DMGetLabel(this->dm, side_name[i], &label);
-        check_petsc_error(ierr);
+        DMLabel label = get_label(side_name[i]);
 
         if (is) {
             ierr = DMLabelSetStratumIS(label, i + 1, is);

--- a/src/DirichletBC.cpp
+++ b/src/DirichletBC.cpp
@@ -25,6 +25,7 @@ void
 DirichletBC::create()
 {
     _F_;
+    EssentialBC::create();
     FunctionInterface::create();
 }
 

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -338,14 +338,11 @@ void
 ExodusIIOutput::write_node_sets()
 {
     _F_;
+    if (!this->mesh->has_label("Vertex Sets"))
+        return;
+
     PetscErrorCode ierr;
     DM dm = this->mesh->get_dm();
-
-    PetscBool has_label;
-    ierr = DMHasLabel(dm, "Vertex Sets", &has_label);
-    check_petsc_error(ierr);
-    if (!has_label)
-        return;
 
     PetscInt elem_first, elem_last;
     ierr = DMPlexGetHeightStratum(dm, 0, &elem_first, &elem_last);
@@ -411,14 +408,11 @@ void
 ExodusIIOutput::write_face_sets()
 {
     _F_;
+    if (!this->mesh->has_label("Face Sets"))
+        return;
+
     PetscErrorCode ierr;
     DM dm = this->mesh->get_dm();
-
-    PetscBool has_label;
-    ierr = DMHasLabel(dm, "Face Sets", &has_label);
-    check_petsc_error(ierr);
-    if (!has_label)
-        return;
 
     DMLabel face_sets_label;
     ierr = DMGetLabel(dm, "Face Sets", &face_sets_label);

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -353,9 +353,7 @@ ExodusIIOutput::write_node_sets()
     ierr = DMGetLabelSize(dm, "Vertex Sets", &n_node_sets);
     check_petsc_error(ierr);
 
-    DMLabel vertex_sets_label;
-    ierr = DMGetLabel(dm, "Vertex Sets", &vertex_sets_label);
-    check_petsc_error(ierr);
+    DMLabel vertex_sets_label = this->mesh->get_label("Vertex Sets");
 
     IS vertex_sets_is;
     ierr = DMLabelGetValueIS(vertex_sets_label, &vertex_sets_is);

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -14,7 +14,7 @@ FENonlinearProblem::valid_params()
 
 FENonlinearProblem::FENonlinearProblem(const InputParameters & parameters) :
     NonlinearProblem(parameters),
-    FEProblemInterface(*this, parameters)
+    FEProblemInterface(this, parameters)
 {
     _F_;
 }

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -25,7 +25,7 @@ void
 FENonlinearProblem::create()
 {
     _F_;
-    FEProblemInterface::create(get_dm());
+    FEProblemInterface::create();
     NonlinearProblem::create();
 }
 
@@ -34,7 +34,7 @@ FENonlinearProblem::init()
 {
     _F_;
     NonlinearProblem::init();
-    FEProblemInterface::init(get_dm());
+    FEProblemInterface::init();
 }
 
 void

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -53,7 +53,7 @@ void
 FENonlinearProblem::set_up_initial_guess()
 {
     _F_;
-    FEProblemInterface::set_up_initial_guess(get_dm(), this->x);
+    FEProblemInterface::set_up_initial_guess();
 }
 
 PetscErrorCode

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -317,30 +317,29 @@ FEProblemInterface::set_up_initial_guess(DM dm, Vec x)
 }
 
 void
-FEProblemInterface::set_up_fes()
+FEProblemInterface::create_fe(FieldInfo & fi)
 {
     _F_;
     PetscErrorCode ierr;
 
     const MPI_Comm & comm = this->unstr_mesh->get_comm();
     PetscInt dim = this->problem->get_dimension();
-    PetscBool is_simplex = this->unstr_mesh->is_simplex();
+    PetscBool is_simplex = this->unstr_mesh->is_simplex() ? PETSC_TRUE : PETSC_FALSE;
 
-    for (auto & it : this->fields) {
-        FieldInfo & fi = it.second;
-        ierr = PetscFECreateLagrange(comm, dim, fi.nc, is_simplex, fi.k, this->qorder, &fi.fe);
-        check_petsc_error(ierr);
-        ierr = PetscFESetName(fi.fe, fi.name.c_str());
-        check_petsc_error(ierr);
-    }
+    ierr = PetscFECreateLagrange(comm, dim, fi.nc, is_simplex, fi.k, this->qorder, &fi.fe);
+    check_petsc_error(ierr);
+    ierr = PetscFESetName(fi.fe, fi.name.c_str());
+    check_petsc_error(ierr);
+}
 
-    for (auto & it : this->aux_fields) {
-        FieldInfo & fi = it.second;
-        ierr = PetscFECreateLagrange(comm, dim, fi.nc, is_simplex, fi.k, this->qorder, &fi.fe);
-        check_petsc_error(ierr);
-        ierr = PetscFESetName(fi.fe, fi.name.c_str());
-        check_petsc_error(ierr);
-    }
+void
+FEProblemInterface::set_up_fes()
+{
+    _F_;
+    for (auto & it : this->fields)
+        create_fe(it.second);
+    for (auto & it : this->aux_fields)
+        create_fe(it.second);
 }
 
 void

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -252,10 +252,7 @@ FEProblemInterface::set_up_boundary_conditions()
     bool no_errors = true;
     for (auto & bc : this->bcs) {
         const std::string & bnd_name = bc->get_boundary();
-        PetscErrorCode ierr;
-        PetscBool exists = PETSC_FALSE;
-        ierr = DMHasLabel(dm, bnd_name.c_str(), &exists);
-        check_petsc_error(ierr);
+        bool exists = this->unstr_mesh->has_label(bnd_name);
         if (!exists) {
             no_errors = false;
             this->logger->error(

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -257,8 +257,8 @@ FEProblemInterface::set_up_boundary_conditions()
             no_errors = false;
             this->logger->error(
                 "Boundary condition '%s' is set on boundary '%s' which does not exist in the mesh.",
-                bc->get_name().c_str(),
-                bnd_name.c_str());
+                bc->get_name(),
+                bnd_name);
         }
     }
 

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -1,7 +1,7 @@
 #include "Godzilla.h"
 #include "CallStack.h"
 #include "FEProblemInterface.h"
-#include "Mesh.h"
+#include "UnstructuredMesh.h"
 #include "Problem.h"
 #include "InitialCondition.h"
 #include "BoundaryCondition.h"
@@ -9,6 +9,7 @@
 #include "FunctionInterface.h"
 #include "App.h"
 #include "Logger.h"
+#include <assert.h>
 
 namespace godzilla {
 
@@ -23,12 +24,15 @@ zero_fn(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nc, PetscSca
 
 } // namespace internal
 
-FEProblemInterface::FEProblemInterface(Problem & problem, const InputParameters & params) :
+FEProblemInterface::FEProblemInterface(Problem * problem, const InputParameters & params) :
     problem(problem),
+    unstr_mesh(dynamic_cast<const UnstructuredMesh *>(problem->get_mesh())),
     logger(params.get<const App *>("_app")->get_logger()),
     qorder(PETSC_DETERMINE),
     ds(nullptr)
 {
+    assert(this->problem != nullptr);
+    assert(this->unstr_mesh != nullptr);
 }
 
 FEProblemInterface::~FEProblemInterface()
@@ -324,7 +328,7 @@ FEProblemInterface::set_up_fes(DM dm)
 
     PetscErrorCode ierr;
 
-    PetscInt dim = this->problem.get_dimension();
+    PetscInt dim = this->problem->get_dimension();
 
     // FIXME: determine if the mesh is made of simplex elements
     PetscBool is_simplex = PETSC_FALSE;
@@ -470,7 +474,7 @@ FEProblemInterface::set_jacobian_block(PetscInt fid,
 const PetscReal &
 FEProblemInterface::get_time() const
 {
-    return this->problem.get_time();
+    return this->problem->get_time();
 }
 
 } // namespace godzilla

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -267,9 +267,10 @@ FEProblemInterface::set_up_boundary_conditions()
 }
 
 void
-FEProblemInterface::set_up_initial_guess(DM dm, Vec x)
+FEProblemInterface::set_up_initial_guess()
 {
     _F_;
+    DM dm = this->unstr_mesh->get_dm();
     PetscInt n_ics = this->ics.size();
     if (n_ics > 0) {
         if (n_ics != fields.size())
@@ -302,7 +303,12 @@ FEProblemInterface::set_up_initial_guess(DM dm, Vec x)
             }
 
             if (no_errors) {
-                ierr = DMProjectFunction(dm, get_time(), ic_funcs, ic_ctxs, INSERT_VALUES, x);
+                ierr = DMProjectFunction(dm,
+                                         get_time(),
+                                         ic_funcs,
+                                         ic_ctxs,
+                                         INSERT_VALUES,
+                                         this->problem->get_solution_vector());
                 check_petsc_error(ierr);
             }
         }
@@ -311,7 +317,12 @@ FEProblemInterface::set_up_initial_guess(DM dm, Vec x)
         // no initial conditions -> use zero
         PetscErrorCode ierr;
         PetscFunc * initial_guess[1] = { internal::zero_fn };
-        ierr = DMProjectFunction(dm, get_time(), initial_guess, NULL, INSERT_VALUES, x);
+        ierr = DMProjectFunction(dm,
+                                 get_time(),
+                                 initial_guess,
+                                 NULL,
+                                 INSERT_VALUES,
+                                 this->problem->get_solution_vector());
         check_petsc_error(ierr);
     }
 }

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -320,14 +320,11 @@ void
 FEProblemInterface::set_up_fes()
 {
     _F_;
-    const MPI_Comm & comm = this->unstr_mesh->get_comm();
-
     PetscErrorCode ierr;
 
+    const MPI_Comm & comm = this->unstr_mesh->get_comm();
     PetscInt dim = this->problem->get_dimension();
-
-    // FIXME: determine if the mesh is made of simplex elements
-    PetscBool is_simplex = PETSC_FALSE;
+    PetscBool is_simplex = this->unstr_mesh->is_simplex();
 
     for (auto & it : this->fields) {
         FieldInfo & fi = it.second;

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -247,7 +247,6 @@ void
 FEProblemInterface::set_up_boundary_conditions()
 {
     _F_;
-    DM dm = this->unstr_mesh->get_dm();
     /// TODO: refactor this into a method
     bool no_errors = true;
     for (auto & bc : this->bcs) {
@@ -264,7 +263,7 @@ FEProblemInterface::set_up_boundary_conditions()
 
     if (no_errors)
         for (auto & bc : this->bcs)
-            bc->set_up(dm);
+            bc->set_up();
 }
 
 void

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -49,7 +49,7 @@ FEProblemInterface::~FEProblemInterface()
 }
 
 void
-FEProblemInterface::create(DM dm)
+FEProblemInterface::create()
 {
     _F_;
     on_set_fields();
@@ -63,11 +63,11 @@ FEProblemInterface::create(DM dm)
 }
 
 void
-FEProblemInterface::init(DM dm)
+FEProblemInterface::init()
 {
     _F_;
-    set_up_fes(dm);
-    set_up_problem(dm);
+    set_up_fes();
+    set_up_problem();
 }
 
 std::vector<std::string>
@@ -244,9 +244,10 @@ FEProblemInterface::add_auxiliary_field(AuxiliaryField * aux)
 }
 
 void
-FEProblemInterface::set_up_boundary_conditions(DM dm)
+FEProblemInterface::set_up_boundary_conditions()
 {
     _F_;
+    DM dm = this->unstr_mesh->get_dm();
     /// TODO: refactor this into a method
     bool no_errors = true;
     for (auto & bc : this->bcs) {
@@ -320,11 +321,10 @@ FEProblemInterface::set_up_initial_guess(DM dm, Vec x)
 }
 
 void
-FEProblemInterface::set_up_fes(DM dm)
+FEProblemInterface::set_up_fes()
 {
     _F_;
-    MPI_Comm comm;
-    PetscObjectGetComm((PetscObject) dm, &comm);
+    const MPI_Comm & comm = this->unstr_mesh->get_comm();
 
     PetscErrorCode ierr;
 
@@ -351,10 +351,11 @@ FEProblemInterface::set_up_fes(DM dm)
 }
 
 void
-FEProblemInterface::set_up_problem(DM dm)
+FEProblemInterface::set_up_problem()
 {
     _F_;
     PetscErrorCode ierr;
+    DM dm = this->unstr_mesh->get_dm();
 
     for (auto & it : this->fields) {
         FieldInfo & fi = it.second;
@@ -369,7 +370,7 @@ FEProblemInterface::set_up_problem(DM dm)
     check_petsc_error(ierr);
 
     on_set_weak_form();
-    set_up_boundary_conditions(dm);
+    set_up_boundary_conditions();
     set_up_constants();
 
     DM cdm = dm;

--- a/src/FileOutput.cpp
+++ b/src/FileOutput.cpp
@@ -5,8 +5,6 @@
 
 namespace godzilla {
 
-static const int MAX_PATH = 1024;
-
 InputParameters
 FileOutput::valid_params()
 {
@@ -42,23 +40,18 @@ void
 FileOutput::set_file_name()
 {
     _F_;
-    char fn[MAX_PATH];
-    snprintf(fn, MAX_PATH, "%s.%s", this->file_base.c_str(), this->get_file_ext().c_str());
-    this->file_name = std::string(fn);
+    std::ostringstream oss;
+    internal::fprintf(oss, "%s.%s", this->file_base, this->get_file_ext());
+    this->file_name = oss.str();
 }
 
 void
 FileOutput::set_sequence_file_name(unsigned int stepi)
 {
     _F_;
-    char fn[MAX_PATH];
-    snprintf(fn,
-             MAX_PATH,
-             "%s.%d.%s",
-             this->file_base.c_str(),
-             stepi,
-             this->get_file_ext().c_str());
-    this->file_name = std::string(fn);
+    std::ostringstream oss;
+    internal::fprintf(oss, "%s.%d.%s", this->file_base, stepi, this->get_file_ext());
+    this->file_name = oss.str();
 }
 
 void

--- a/src/FunctionAuxiliaryField.cpp
+++ b/src/FunctionAuxiliaryField.cpp
@@ -39,6 +39,7 @@ void
 FunctionAuxiliaryField::create()
 {
     _F_;
+    AuxiliaryField::create();
     FunctionInterface::create();
 }
 
@@ -48,27 +49,10 @@ FunctionAuxiliaryField::get_num_components() const
     return this->num_comps;
 }
 
-void
-FunctionAuxiliaryField::set_up(DM dm, DM dm_aux)
+PetscFunc *
+FunctionAuxiliaryField::get_func() const
 {
-    _F_;
-    PetscErrorCode ierr;
-    PetscFunc * func[1] = { __function_auxiliary_field };
-    void * ctxs[1] = { this };
-
-    ierr = DMCreateLocalVector(dm_aux, &this->a);
-    check_petsc_error(ierr);
-
-    ierr = DMProjectFunctionLocal(dm_aux,
-                                  this->fepi.get_time(),
-                                  func,
-                                  ctxs,
-                                  INSERT_ALL_VALUES,
-                                  this->a);
-    check_petsc_error(ierr);
-
-    ierr = DMSetAuxiliaryVec(dm, this->block, 0, 0, this->a);
-    check_petsc_error(ierr);
+    return __function_auxiliary_field;
 }
 
 void

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -65,7 +65,7 @@ ImplicitFENonlinearProblem::init()
     ierr = TSGetSNES(this->ts, &this->snes);
     check_petsc_error(ierr);
 
-    FEProblemInterface::init(get_dm());
+    FEProblemInterface::init();
 }
 
 void

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -44,7 +44,7 @@ ImplicitFENonlinearProblem::valid_params()
 
 ImplicitFENonlinearProblem::ImplicitFENonlinearProblem(const InputParameters & params) :
     FENonlinearProblem(params),
-    TransientProblemInterface(params)
+    TransientProblemInterface(this, params)
 {
     _F_;
 }
@@ -59,7 +59,7 @@ ImplicitFENonlinearProblem::init()
 {
     _F_;
     PetscErrorCode ierr;
-    TransientProblemInterface::init(get_comm());
+    TransientProblemInterface::init();
     ierr = TSSetApplicationContext(this->ts, this);
     check_petsc_error(ierr);
     ierr = TSGetSNES(this->ts, &this->snes);
@@ -73,7 +73,7 @@ ImplicitFENonlinearProblem::create()
 {
     _F_;
     FENonlinearProblem::create();
-    TransientProblemInterface::create(get_dm());
+    TransientProblemInterface::create();
 }
 
 PetscErrorCode

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -74,8 +74,7 @@ LineMesh::create_dm()
     check_petsc_error(ierr);
 
     // create user-friendly names for sides
-    DMLabel face_sets_label;
-    ierr = DMGetLabel(this->dm, "Face Sets", &face_sets_label);
+    DMLabel face_sets_label = get_label("Face Sets");
 
     const char * side_name[] = { "left", "right" };
     for (unsigned int i = 0; i < 2; i++) {
@@ -86,9 +85,7 @@ LineMesh::create_dm()
         ierr = DMCreateLabel(this->dm, side_name[i]);
         check_petsc_error(ierr);
 
-        DMLabel label;
-        ierr = DMGetLabel(this->dm, side_name[i], &label);
-        check_petsc_error(ierr);
+        DMLabel label = get_label(side_name[i]);
 
         if (is != nullptr) {
             ierr = DMLabelSetStratumIS(label, i + 1, is);

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -68,4 +68,14 @@ Mesh::has_label(const std::string & name) const
     return exists == PETSC_TRUE;
 }
 
+DMLabel
+Mesh::get_label(const std::string & name) const
+{
+    _F_;
+    DMLabel label;
+    PetscErrorCode ierr = DMGetLabel(this->dm, name.c_str(), &label);
+    check_petsc_error(ierr);
+    return label;
+}
+
 } // namespace godzilla

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -57,4 +57,15 @@ Mesh::create()
     distribute();
 }
 
+bool
+Mesh::has_label(const std::string & name) const
+{
+    _F_;
+    PetscErrorCode ierr;
+    PetscBool exists = PETSC_FALSE;
+    ierr = DMHasLabel(this->dm, name.c_str(), &exists);
+    check_petsc_error(ierr);
+    return exists == PETSC_TRUE;
+}
+
 } // namespace godzilla

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -103,8 +103,7 @@ RectangleMesh::create_dm()
     check_petsc_error(ierr);
 
     // create user-friendly names for sides
-    DMLabel face_sets_label;
-    ierr = DMGetLabel(this->dm, "Face Sets", &face_sets_label);
+    DMLabel face_sets_label = get_label("Face Sets");
 
     const char * side_name[] = { "bottom", "right", "top", "left" };
     for (unsigned int i = 0; i < 4; i++) {
@@ -115,9 +114,7 @@ RectangleMesh::create_dm()
         ierr = DMCreateLabel(this->dm, side_name[i]);
         check_petsc_error(ierr);
 
-        DMLabel label;
-        ierr = DMGetLabel(this->dm, side_name[i], &label);
-        check_petsc_error(ierr);
+        DMLabel label = get_label(side_name[i]);
 
         if (is) {
             ierr = DMLabelSetStratumIS(label, i + 1, is);

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -89,6 +89,16 @@ UnstructuredMesh::distribute()
     }
 }
 
+bool
+UnstructuredMesh::is_simplex() const
+{
+    _F_;
+    PetscBool simplex;
+    PetscErrorCode ierr = DMPlexIsSimplex(this->dm, &simplex);
+    check_petsc_error(ierr);
+    return simplex == PETSC_TRUE;
+}
+
 void
 UnstructuredMesh::output_partitioning(PetscViewer viewer)
 {

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -33,14 +33,15 @@ TEST(AuxiliaryFieldTest, non_existent_id)
         {
             return 1;
         }
-        virtual void
-        set_up(DM dm, DM dm_aux)
-        {
-        }
         virtual PetscInt
         get_num_components() const
         {
             return 2;
+        }
+        virtual PetscFunc *
+        get_func() const
+        {
+            return nullptr;
         }
     };
 
@@ -85,14 +86,15 @@ TEST(AuxiliaryFieldTest, inconsistent_comp_number)
         {
             return 0;
         }
-        virtual void
-        set_up(DM dm, DM dm_aux)
-        {
-        }
         virtual PetscInt
         get_num_components() const
         {
             return 2;
+        }
+        virtual PetscFunc *
+        get_func() const
+        {
+            return nullptr;
         }
     };
 

--- a/test/src/DirichletBC_test.cpp
+++ b/test/src/DirichletBC_test.cpp
@@ -12,6 +12,11 @@ TEST(DirichletBCTest, api)
 {
     TestApp app;
 
+    InputParameters prob_pars = GTestProblem::valid_params();
+    prob_pars.set<const App *>("_app") = &app;
+    GTestProblem problem(prob_pars);
+    app.problem = &problem;
+
     InputParameters params = DirichletBC::valid_params();
     params.set<const App *>("_app") = &app;
     params.set<std::vector<std::string>>("value") = { "t * (x + y + z)" };

--- a/test/src/DirichletBC_test.cpp
+++ b/test/src/DirichletBC_test.cpp
@@ -12,8 +12,14 @@ TEST(DirichletBCTest, api)
 {
     TestApp app;
 
+    InputParameters mesh_pars = LineMesh::valid_params();
+    mesh_pars.set<const App *>("_app") = &app;
+    mesh_pars.set<PetscInt>("nx") = 2;
+    LineMesh mesh(mesh_pars);
+
     InputParameters prob_pars = GTestProblem::valid_params();
     prob_pars.set<const App *>("_app") = &app;
+    prob_pars.set<const Mesh *>("_mesh") = &mesh;
     GTestProblem problem(prob_pars);
     app.problem = &problem;
 
@@ -21,6 +27,9 @@ TEST(DirichletBCTest, api)
     params.set<const App *>("_app") = &app;
     params.set<std::vector<std::string>>("value") = { "t * (x + y + z)" };
     DirichletBC obj(params);
+
+    mesh.create();
+    problem.create();
     obj.create();
 
     EXPECT_EQ(obj.get_field_id(), 0);
@@ -48,6 +57,7 @@ TEST(DirichletBCTest, with_user_defined_fn)
 
     InputParameters prob_pars = GTestProblem::valid_params();
     prob_pars.set<const App *>("_app") = &app;
+    prob_pars.set<const Mesh *>("_mesh") = &mesh;
     GTestProblem problem(prob_pars);
     app.problem = &problem;
 
@@ -63,6 +73,9 @@ TEST(DirichletBCTest, with_user_defined_fn)
     bc_pars->set<const App *>("_app") = &app;
     bc_pars->set<std::vector<std::string>>("value") = { "ipol(x)" };
     DirichletBC * bc = app.build_object<DirichletBC>("DirichletBC", "name", bc_pars);
+
+    mesh.create();
+    problem.create();
     bc->create();
 
     PetscInt dim = 1;

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -116,6 +116,7 @@ TEST_F(ImplicitFENonlinearProblemTest, run)
 {
     auto mesh = gMesh1d();
     auto prob = gProblem1d(mesh);
+    this->app->problem = prob;
 
     {
         const std::string class_name = "ConstantIC";

--- a/test/src/L2Diff_test.cpp
+++ b/test/src/L2Diff_test.cpp
@@ -18,6 +18,7 @@ TEST(L2DiffTest, compute)
     prob_params.set<const App *>("_app") = &app;
     prob_params.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
+    app.problem = &prob;
 
     InputParameters bc_params = DirichletBC::valid_params();
     bc_params.set<const App *>("_app") = &app;

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -7,7 +7,18 @@ using namespace godzilla;
 
 TEST(NaturalBCTest, api)
 {
-    App app("test", MPI_COMM_WORLD);
+    TestApp app;
+
+    InputParameters mesh_params = LineMesh::valid_params();
+    mesh_params.set<const App *>("_app") = &app;
+    mesh_params.set<PetscInt>("nx") = 2;
+    LineMesh mesh(mesh_params);
+
+    InputParameters prob_params = GTestFENonlinearProblem::valid_params();
+    prob_params.set<const App *>("_app") = &app;
+    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    GTestFENonlinearProblem prob(prob_params);
+    app.problem = &prob;
 
     class MockNaturalBC : public NaturalBC {
     public:
@@ -42,6 +53,9 @@ TEST(NaturalBCTest, api)
     params.set<const App *>("_app") = &app;
     params.set<std::string>("boundary") = "left";
     MockNaturalBC bc(params);
+
+    mesh.create();
+    prob.create();
     bc.create();
 
     EXPECT_EQ(bc.get_field_id(), 0);
@@ -152,6 +166,7 @@ TEST(NaturalBCTest, fe)
     prob_params.set<const App *>("_app") = &app;
     prob_params.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
+    app.problem = &prob;
     prob.add_aux_fe(0, "aux1", 1, 1);
 
     InputParameters bc_params = TestNaturalBC::valid_params();


### PR DESCRIPTION
- FEProblemInterface changes
- Removing DM from FEProblemInterface API where not needed
- TransientProblemInterface gets pointer to Problem
- Wrapping DMHasLabel in Mesh::has_label
- No need to call c_str() when logging an error
- Replacing snprintf with our safe fprintf
- Cleaning up API in BoundaryCondition class
- Adding UnstructuredMesh::is_simplex
- More decomposition!
- Cleaning FEProblemInterface::set_up_initial_guess
- Improve decomposition in FEProblemInterface::set_up_initial_guess
- Adding Mesh::get_label()
- BoundaryCondition is using Mesh::get_label()
- Adding support for multiple auxiliary fields given by point defined functions
- Example heat-eqn: Working convective heat flux BC
