### PR TITLE
CMake imps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,12 @@ if (NOT ${HDF5_FOUND})
     message(STATUS "HDF5 was not found.")
 endif()
 
+# NetCDF
+find_package(NetCDF)
+if (NOT ${NETCDF_FOUND})
+    message(STATUS "Try to set environemnt variable NETCDF_DIR to point to your NetCDF installation.")
+endif()
+
 # ExodusII
 find_package(ExodusII)
 if (NOT ${EXODUSII_FOUND})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,9 +115,9 @@ install(
     RUNTIME DESTINATION
         bin
     INCLUDES DESTINATION
-        ${CMAKE_INSTALL_INCLUDEDIR}/godzilla
+        ${CMAKE_INSTALL_INCLUDEDIR}
     PUBLIC_HEADER DESTINATION
-        ${CMAKE_INSTALL_INCLUDEDIR}/godzilla
+        ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 install(
@@ -133,7 +133,7 @@ install(
     DIRECTORY
         contrib/tclap
     DESTINATION
-        ${CMAKE_INSTALL_INCLUDEDIR}/godzilla
+        ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING
         PATTERN "*.h"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(
     VERSION 0.1
     LANGUAGES CXX)
 
+enable_language(C)
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
@@ -21,6 +23,11 @@ option(GODZILLA_BUILD_TESTS "Build tests" NO)
 find_package(PETSc)
 if (NOT ${PETSC_FOUND})
     message(STATUS "Try to set environemnt variable PETSC_DIR to point to your PETSc installation.")
+endif()
+
+find_package(HDF5 COMPONENTS C)
+if (NOT ${HDF5_FOUND})
+    message(STATUS "HDF5 was not found.")
 endif()
 
 # ExodusII
@@ -67,7 +74,7 @@ set(YAML_CPP_INCLUDE_DIR ${yaml_cpp_SOURCE_DIR}/include)
 
 set(GODZILLA_LIBRARIES
     ${NETCDF_LIBRARY}
-    ${HDF5_LIBRARY}
+    ${HDF5_LIBRARIES}
     ${EXODUSII_LIBRARY}
     ${PETSC_LIBRARY}
     godzilla

--- a/cmake/FindExodusII.cmake
+++ b/cmake/FindExodusII.cmake
@@ -21,31 +21,6 @@ find_library(
         $ENV{PETSC_DIR}/lib
 )
 
-# The HDF5 bit may be moved into its own FindHDF5.cmake
-find_path(
-    HDF5_INCLUDE_DIR
-        hdf5.h
-    PATHS
-        $ENV{HDF5_DIR}/include
-        $ENV{PETSC_DIR}/include
-    PATH_SUFFIXES
-        hdf5/openmpi
-        hdf5/mpich
-        hdf5/serial
-)
-
-find_library(
-    HDF5_LIBRARY
-        hdf5
-    PATHS
-        $ENV{HDF5_DIR}/lib
-        $ENV{PETSC_DIR}/lib
-    PATH_SUFFIXES
-        hdf5/openmpi
-        hdf5/mpich
-        hdf5/serial
-)
-
 find_path(
     EXODUSII_INCLUDE_DIR
         exodusII.h

--- a/cmake/FindExodusII.cmake
+++ b/cmake/FindExodusII.cmake
@@ -6,22 +6,6 @@
 #  EXODUSII_LIBRARY - The ExodusII library
 
 find_path(
-    NETCDF_INCLUDE_DIR
-        netcdf.h
-    PATHS
-        $ENV{NETCDF_DIR}/include
-        $ENV{PETSC_DIR}/include
-)
-
-find_library(
-    NETCDF_LIBRARY
-        netcdf
-    PATHS
-        $ENV{NETCDF_DIR}/lib
-        $ENV{PETSC_DIR}/lib
-)
-
-find_path(
     EXODUSII_INCLUDE_DIR
         exodusII.h
     PATHS

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -1,0 +1,30 @@
+# Find NetCDF
+#
+# Once done this will define
+#  NETCDF_FOUND - System has ExodusII
+#  NETCDF_INCLUDE_DIR - The ExodusII include directory
+#  NETCDF_LIBRARY - The ExodusII library
+
+find_path(
+    NETCDF_INCLUDE_DIR
+        netcdf.h
+    PATHS
+        $ENV{NETCDF_DIR}/include
+        $ENV{PETSC_DIR}/include
+)
+
+find_library(
+    NETCDF_LIBRARY
+        netcdf
+    PATHS
+        $ENV{NETCDF_DIR}/lib
+        $ENV{PETSC_DIR}/lib
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    NetCDF
+    DEFAULT_MSG
+    NETCDF_LIBRARY
+    NETCDF_INCLUDE_DIR
+)

--- a/cmake/GodzillaConfig.cmake
+++ b/cmake/GodzillaConfig.cmake
@@ -1,5 +1,5 @@
 include(CMakeFindDependencyMacro)
 
-find_dependency(PETSc REQUIRED)
+find_dependency(HDF5 REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/GodzillaTargets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ target_include_directories(
     godzilla
     PRIVATE
         ${CONDA_INCLUDE_DIR}
-        ${HDF5_INCLUDE_DIR}
+        ${HDF5_INCLUDE_DIRS}
         ${PETSC_INCLUDE_DIR}
         ${PROJECT_BINARY_DIR}
         ${MUPARSER_INCLUDE_DIR}
@@ -86,7 +86,7 @@ target_link_libraries(
         muparser
         yaml-cpp
         ${NETCDF_LIBRARY}
-        ${HDF5_LIBRARY}
+        ${HDF5_LIBRARIES}
         ${EXODUSII_LIBRARY}
         ${PETSC_LIBRARY}
 )


### PR DESCRIPTION
- Use HDF5 discovery form cmake
- NetCDF discovery moved into its own module
- Fixing up deps in GodzillaConfig.cmake
