### PR TITLE
Refactoring FileOutput

### DIFF
--- a/include/FileOutput.h
+++ b/include/FileOutput.h
@@ -10,7 +10,6 @@ namespace godzilla {
 class FileOutput : public Output {
 public:
     FileOutput(const InputParameters & params);
-    virtual ~FileOutput();
 
     virtual void create() override;
 
@@ -32,27 +31,12 @@ public:
     /// @return File extension
     virtual std::string get_file_ext() const = 0;
 
-    virtual void output_step() override;
-
 protected:
-    /// Store the mesh
-    ///
-    /// @param dm DM holding the mesh to store into the file
-    virtual void output_mesh(DM dm);
-
-    /// Store the solution vector
-    ///
-    /// @param vec Solution vector to store into the file
-    virtual void output_solution(Vec vec);
-
     /// The file base of the output file
     std::string file_base;
 
     /// The file name of the output file
     std::string file_name;
-
-    /// Viewer for the output
-    PetscViewer viewer;
 
 public:
     static InputParameters valid_params();

--- a/include/HDF5Output.h
+++ b/include/HDF5Output.h
@@ -28,10 +28,16 @@ namespace godzilla {
 class HDF5Output : public FileOutput {
 public:
     HDF5Output(const InputParameters & params);
+    virtual ~HDF5Output();
 
     virtual std::string get_file_ext() const override;
     virtual void create() override;
     virtual void check() override;
+    virtual void output_step() override;
+
+protected:
+    /// Viewer for the output
+    PetscViewer viewer;
 
 public:
     static InputParameters valid_params();

--- a/include/VTKOutput.h
+++ b/include/VTKOutput.h
@@ -18,10 +18,16 @@ namespace godzilla {
 class VTKOutput : public FileOutput {
 public:
     VTKOutput(const InputParameters & params);
+    virtual ~VTKOutput();
 
     virtual std::string get_file_ext() const override;
     virtual void create() override;
     virtual void check() override;
+    virtual void output_step() override;
+
+protected:
+    /// Viewer for the output
+    PetscViewer viewer;
 
 public:
     static InputParameters valid_params();

--- a/src/FileOutput.cpp
+++ b/src/FileOutput.cpp
@@ -17,18 +17,9 @@ FileOutput::valid_params()
 
 FileOutput::FileOutput(const InputParameters & params) :
     Output(params),
-    file_base(get_param<std::string>("file")),
-    viewer(nullptr)
+    file_base(get_param<std::string>("file"))
 {
     _F_;
-}
-
-FileOutput::~FileOutput()
-{
-    _F_;
-    PetscErrorCode ierr;
-    ierr = PetscViewerDestroy(&this->viewer);
-    check_petsc_error(ierr);
 }
 
 void
@@ -65,41 +56,6 @@ FileOutput::set_sequence_file_name(unsigned int stepi)
     std::ostringstream oss;
     internal::fprintf(oss, "%s.%d.%s", this->file_base, stepi, this->get_file_ext());
     this->file_name = oss.str();
-}
-
-void
-FileOutput::output_mesh(DM dm)
-{
-    _F_;
-    PetscErrorCode ierr;
-    ierr = DMView(dm, this->viewer);
-    check_petsc_error(ierr);
-}
-
-void
-FileOutput::output_solution(Vec vec)
-{
-    _F_;
-    PetscErrorCode ierr;
-    ierr = VecView(vec, this->viewer);
-    check_petsc_error(ierr);
-}
-
-void
-FileOutput::output_step()
-{
-    _F_;
-    PetscErrorCode ierr;
-
-    set_sequence_file_name(this->problem->get_step_num());
-    ierr = PetscViewerFileSetName(this->viewer, this->file_name.c_str());
-    check_petsc_error(ierr);
-
-    lprintf(9, "Output to file: %s", this->file_name);
-    DM dm = this->problem->get_dm();
-    output_mesh(dm);
-    Vec vec = this->problem->get_solution_vector();
-    output_solution(vec);
 }
 
 } // namespace godzilla


### PR DESCRIPTION
FileOutput does not assume PetscViewer anymore, since some file outputs
are just not using it.  This created minor code duplication in VTKOutput
and HDF5Output which are PetscViewer-based.  But, VTKOutput is mainly
just for trivial testing and HDF5Output is not being used that much
either (which may change in future) - so this is not a big problem.

Anyway, if the code duplication is a burning problem, we can add an
intermediate class and move the common code there.
