### PR TITLE
ExodusII: save sideset names

### DIFF
--- a/include/ExodusIIMesh.h
+++ b/include/ExodusIIMesh.h
@@ -14,6 +14,7 @@ public:
 
 protected:
     virtual void create_dm() override;
+    void read_side_sets(int exoid, int n_side_sets);
 
     /// File name with the ExodusII mesh
     const std::string & file_name;

--- a/include/ExodusIIOutput.h
+++ b/include/ExodusIIOutput.h
@@ -38,6 +38,7 @@ protected:
     const char * get_elem_type(DMPolytopeType elem_type) const;
     int get_num_elem_nodes(DMPolytopeType elem_type) const;
     const PetscInt * get_elem_node_ordering(DMPolytopeType elem_type) const;
+    const PetscInt * get_elem_side_ordering(DMPolytopeType elem_type) const;
     void write_elements();
     void write_node_sets();
     void write_face_sets();

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -42,6 +42,8 @@ public:
 protected:
     virtual void distribute() override;
 
+    void create_face_set(PetscInt id, const std::string & name);
+
     /// Mesh partitioner
     PetscPartitioner partitioner;
 

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -39,6 +39,12 @@ public:
     /// @return true if cell is a simplex, otherwise false
     virtual bool is_simplex() const;
 
+    /// Get face set name
+    ///
+    /// @param id The id of the face set
+    /// @return Facet name
+    const std::string & get_face_set_name(PetscInt id) const;
+
 protected:
     virtual void distribute() override;
 
@@ -49,6 +55,9 @@ protected:
 
     /// Partition overlap for mesh partitioning
     PetscInt partition_overlap;
+
+    /// Face set names
+    std::map<PetscInt, std::string> face_set_names;
 
 public:
     static InputParameters valid_params();

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -131,19 +131,9 @@ BoxMesh::create_dm()
                                     &this->dm));
 
     // create user-friendly names for sides
-    DMLabel face_sets_label = get_label("Face Sets");
-
     const char * side_name[] = { "back", "front", "bottom", "top", "right", "left" };
-    for (unsigned int i = 0; i < 6; i++) {
-        IS is;
-        PETSC_CHECK(DMLabelGetStratumIS(face_sets_label, i + 1, &is));
-        PETSC_CHECK(DMCreateLabel(this->dm, side_name[i]));
-        DMLabel label = get_label(side_name[i]);
-        if (is)
-            PETSC_CHECK(DMLabelSetStratumIS(label, i + 1, is));
-        PETSC_CHECK(ISDestroy(&is));
-        PETSC_CHECK(DMPlexLabelComplete(this->dm, label));
-    }
+    for (unsigned int i = 0; i < 6; i++)
+        create_face_set(i + 1, side_name[i]);
 }
 
 } // namespace godzilla

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -374,7 +374,7 @@ ExodusIIOutput::write_elements()
     int n_cells_sets = 0;
     PETSC_CHECK(DMGetLabelSize(dm, "Cell Sets", &n_cells_sets));
 
-    if (n_cells_sets > 0) {
+    if (n_cells_sets > 1) {
         // TODO: write element blocks
         error("Support for mesh blocks is not implemented yet.");
     }

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -71,24 +71,9 @@ LineMesh::create_dm()
                                     &this->dm));
 
     // create user-friendly names for sides
-    DMLabel face_sets_label = get_label("Face Sets");
-
     const char * side_name[] = { "left", "right" };
-    for (unsigned int i = 0; i < 2; i++) {
-        IS is;
-        PETSC_CHECK(DMLabelGetStratumIS(face_sets_label, i + 1, &is));
-
-        PETSC_CHECK(DMCreateLabel(this->dm, side_name[i]));
-
-        DMLabel label = get_label(side_name[i]);
-
-        if (is != nullptr)
-            PETSC_CHECK(DMLabelSetStratumIS(label, i + 1, is));
-
-        PETSC_CHECK(ISDestroy(&is));
-
-        PETSC_CHECK(DMPlexLabelComplete(this->dm, label));
-    }
+    for (unsigned int i = 0; i < 2; i++)
+        create_face_set(i + 1, side_name[i]);
 }
 
 } // namespace godzilla

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -102,24 +102,9 @@ RectangleMesh::create_dm()
                                     &this->dm));
 
     // create user-friendly names for sides
-    DMLabel face_sets_label = get_label("Face Sets");
-
     const char * side_name[] = { "bottom", "right", "top", "left" };
-    for (unsigned int i = 0; i < 4; i++) {
-        IS is;
-        PETSC_CHECK(DMLabelGetStratumIS(face_sets_label, i + 1, &is));
-
-        PETSC_CHECK(DMCreateLabel(this->dm, side_name[i]));
-
-        DMLabel label = get_label(side_name[i]);
-
-        if (is)
-            PETSC_CHECK(DMLabelSetStratumIS(label, i + 1, is));
-
-        PETSC_CHECK(ISDestroy(&is));
-
-        PETSC_CHECK(DMPlexLabelComplete(this->dm, label));
-    }
+    for (unsigned int i = 0; i < 4; i++)
+        create_face_set(i + 1, side_name[i]);
 }
 
 } // namespace godzilla

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -103,6 +103,18 @@ UnstructuredMesh::create_face_set(PetscInt id, const std::string & name)
         PETSC_CHECK(DMLabelSetStratumIS(label, id, is));
     PETSC_CHECK(ISDestroy(&is));
     PETSC_CHECK(DMPlexLabelComplete(this->dm, label));
+    this->face_set_names[id] = name;
+}
+
+const std::string &
+UnstructuredMesh::get_face_set_name(PetscInt id) const
+{
+    _F_;
+    const auto & it = this->face_set_names.find(id);
+    if (it != this->face_set_names.end())
+        return it->second;
+    else
+        error("Face id '%d' does not exist.", id);
 }
 
 } // namespace godzilla

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -90,4 +90,19 @@ UnstructuredMesh::is_simplex() const
     return simplex == PETSC_TRUE;
 }
 
+void
+UnstructuredMesh::create_face_set(PetscInt id, const std::string & name)
+{
+    _F_;
+    DMLabel face_sets_label = get_label("Face Sets");
+    IS is;
+    PETSC_CHECK(DMLabelGetStratumIS(face_sets_label, id, &is));
+    PETSC_CHECK(DMCreateLabel(this->dm, name.c_str()));
+    DMLabel label = get_label(name);
+    if (is)
+        PETSC_CHECK(DMLabelSetStratumIS(label, id, is));
+    PETSC_CHECK(ISDestroy(&is));
+    PETSC_CHECK(DMPlexLabelComplete(this->dm, label));
+}
+
 } // namespace godzilla


### PR DESCRIPTION
- Decomposition in generated meshes
- ExodusII: save face set names
- Properly store side set in ExodsuIIOutput for hexahedra
- ExodusIIOutput fix for meshes read from exodusII files
