### PR TITLE
DM abstract

### DIFF
--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -106,6 +106,11 @@ public:
     /// @return The offset
     virtual PetscInt get_field_dof(PetscInt point, PetscInt fid) const = 0;
 
+    /// Gets a local vector with the coordinates associated with this problem's mesh
+    ///
+    /// @return coordinate vector
+    Vec get_coordinates_local() const;
+
 protected:
     virtual void init();
     virtual void create();

--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -99,6 +99,13 @@ public:
     /// @param bc Boundary condition object to add
     virtual void add_boundary_condition(BoundaryCondition * bc);
 
+    /// Return the offset into an array or local Vec for the dof associated with the given point
+    ///
+    /// @param point Point
+    /// @param fid Field ID
+    /// @return The offset
+    virtual PetscInt get_field_dof(PetscInt point, PetscInt fid) const = 0;
+
 protected:
     virtual void init();
     virtual void create();

--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -111,6 +111,11 @@ public:
     /// @return coordinate vector
     Vec get_coordinates_local() const;
 
+    /// Get local solution vector
+    ///
+    /// @return Local solution vector
+    virtual Vec get_solution_vector_local() const = 0;
+
 protected:
     virtual void init();
     virtual void create();
@@ -134,6 +139,11 @@ protected:
 
     /// Set up constants
     void set_up_constants();
+
+    /// Build local solution vector
+    ///
+    /// @param sln Global solution vector
+    void build_local_solution_vector(Vec sln) const;
 
     /// Problem this interface is part of
     Problem * problem;

--- a/include/Error.h
+++ b/include/Error.h
@@ -20,6 +20,7 @@ error_printf(const char * s, Args... args)
     fmt::fprintf(stderr, "[ERROR] ");
     fmt::fprintf(stderr, s, std::forward<Args>(args)...);
     fmt::fprintf(stderr, "%s", Terminal::Color::normal);
+    fmt::fprintf(stderr, "\n");
 }
 
 /// Terminate the run

--- a/include/FENonlinearProblem.h
+++ b/include/FENonlinearProblem.h
@@ -20,6 +20,7 @@ protected:
     virtual void init() override;
     virtual void set_up_callbacks() override;
     virtual void set_up_initial_guess() override;
+    virtual void allocate_objects() override;
     virtual PetscErrorCode compute_residual_callback(Vec x, Vec f) override;
     virtual PetscErrorCode compute_jacobian_callback(Vec x, Mat J, Mat Jp) override;
 

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -31,6 +31,7 @@ public:
     virtual void
     set_field_component_name(PetscInt fid, PetscInt component, const std::string name) override;
     virtual PetscInt get_field_dof(PetscInt point, PetscInt fid) const override;
+    virtual Vec get_solution_vector_local() const override;
 
     /// Get auxiliary field name
     ///
@@ -82,6 +83,7 @@ protected:
 
     virtual void create() override;
     virtual void init() override;
+    virtual void allocate_objects();
 
     /// Create FE object from FieldInfo
     ///
@@ -167,6 +169,9 @@ protected:
 
     /// Vector for auxiliary fields
     Vec a;
+
+    /// Local solution vector
+    Vec sln;
 };
 
 } // namespace godzilla

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -30,6 +30,7 @@ public:
     virtual std::string get_field_component_name(PetscInt fid, PetscInt component) const override;
     virtual void
     set_field_component_name(PetscInt fid, PetscInt component, const std::string name) override;
+    virtual PetscInt get_field_dof(PetscInt point, PetscInt fid) const override;
 
     /// Get auxiliary field name
     ///
@@ -112,6 +113,9 @@ protected:
 
     /// Setup volumetric weak form terms
     virtual void set_up_weak_form() = 0;
+
+    /// PETSc section
+    PetscSection section;
 
     /// Quadrature order
     PetscInt qorder;

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -24,6 +24,7 @@ public:
     virtual void
     set_field_component_name(PetscInt fid, PetscInt component, const std::string name) override;
     virtual PetscInt get_field_dof(PetscInt point, PetscInt fid) const override;
+    virtual Vec get_solution_vector_local() const override;
 
     /// Adds a volumetric field
     ///
@@ -36,6 +37,7 @@ public:
 protected:
     virtual void init() override;
     virtual void create() override;
+    virtual void allocate_objects();
     virtual void set_up_ds() override;
 
     /// Compute flux
@@ -85,6 +87,9 @@ protected:
 
     /// PETSc finite volume object
     PetscFV fvm;
+
+    /// Local solution vector
+    Vec sln;
 
     friend void __compute_flux(PetscInt dim,
                                PetscInt nf,

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -23,6 +23,7 @@ public:
     virtual std::string get_field_component_name(PetscInt fid, PetscInt component) const override;
     virtual void
     set_field_component_name(PetscInt fid, PetscInt component, const std::string name) override;
+    virtual PetscInt get_field_dof(PetscInt point, PetscInt fid) const override;
 
     /// Adds a volumetric field
     ///
@@ -33,6 +34,7 @@ public:
     virtual void add_field(PetscInt id, const std::string & name, PetscInt nc);
 
 protected:
+    virtual void init() override;
     virtual void create() override;
     virtual void set_up_ds() override;
 
@@ -56,6 +58,9 @@ protected:
                               PetscInt n_consts,
                               const PetscScalar constants[],
                               PetscScalar flux[]) = 0;
+
+    /// PETSc section
+    PetscSection section;
 
     /// Field information
     struct FieldInfo {

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -13,38 +13,17 @@ public:
     Mesh(const Parameters & parameters);
     virtual ~Mesh();
 
-    DM get_dm() const;
+    virtual DM get_dm() const = 0;
 
     /// Get the mesh spatial dimension
     ///
     /// @return Mesh spatial dimension
     PetscInt get_dimension() const;
 
-    /// Create the mesh
-    virtual void create();
-
-    /// Check if mesh has label with a name
-    ///
-    /// @param name The name of the label
-    /// @return true if label exists, otherwise false
-    virtual bool has_label(const std::string & name) const;
-
-    /// Get label associated with a name
-    ///
-    /// @param name Label name
-    /// @return DMLabel associated with the `name`
-    virtual DMLabel get_label(const std::string & name) const;
-
     /// Distribute mesh over processes
     virtual void distribute() = 0;
 
 protected:
-    /// Method that builds DM for the mesh
-    virtual void create_dm() = 0;
-
-    /// DM object
-    DM dm;
-
     /// Spatial dimension of the mesh
     PetscInt dim;
 

--- a/include/MeshPartitioningOutput.h
+++ b/include/MeshPartitioningOutput.h
@@ -10,6 +10,7 @@ class MeshPartitioningOutput : public FileOutput {
 public:
     MeshPartitioningOutput(const Parameters & params);
 
+    virtual void check() override;
     virtual std::string get_file_ext() const override;
     virtual void output_step() override;
 

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -73,6 +73,11 @@ public:
     /// @return Facet name
     const std::string & get_face_set_name(PetscInt id) const;
 
+    /// Get number of face sets
+    ///
+    /// @return Number of face sets
+    PetscInt get_num_face_sets() const;
+
     /// Set face set name
     ///
     /// @param id The ID of the face set

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -54,6 +54,12 @@ public:
     /// @param last Last element index plus one
     void get_all_element_idx_range(PetscInt & first, PetscInt & last) const;
 
+    /// Get cell type
+    ///
+    /// @param el Element index
+    /// @return Cell type
+    virtual DMPolytopeType get_cell_type(PetscInt el) const;
+
     /// Set partitioner type
     ///
     /// @param type Type of the partitioner

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -91,6 +91,11 @@ public:
     /// @return DMLabel associated with face set name
     DMLabel get_face_set_label(const std::string & name) const;
 
+    /// Get number of vertex sets
+    ///
+    /// @return Number of vertex sets
+    PetscInt get_num_vertex_sets() const;
+
     virtual void distribute() override;
 
     /// Construct ghost cells which connect to every boundary face

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -62,6 +62,11 @@ public:
     /// @return Cell set name
     const std::string & get_cell_set_name(PetscInt id) const;
 
+    /// Get number of cell sets
+    ///
+    /// @return Number of cell sets
+    PetscInt get_num_cell_sets() const;
+
     /// Get face set name
     ///
     /// @param id The ID of the face set

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -12,7 +12,20 @@ public:
     UnstructuredMesh(const Parameters & parameters);
     virtual ~UnstructuredMesh();
 
+    DM get_dm() const override;
     virtual void create() override;
+
+    /// Check if mesh has label with a name
+    ///
+    /// @param name The name of the label
+    /// @return true if label exists, otherwise false
+    virtual bool has_label(const std::string & name) const;
+
+    /// Get label associated with a name
+    ///
+    /// @param name Label name
+    /// @return DMLabel associated with the `name`
+    virtual DMLabel get_label(const std::string & name) const;
 
     /// Return the number of mesh vertices
     virtual PetscInt get_num_vertices() const;
@@ -108,11 +121,17 @@ public:
     virtual void construct_ghost_cells();
 
 protected:
+    /// Method that builds DM for the mesh
+    virtual void create_dm() = 0;
+
     void create_cell_set(PetscInt id, const std::string & name);
 
     void create_face_set_labels(const std::map<int, std::string> & names);
 
     void create_face_set(PetscInt id);
+
+    /// DM object
+    DM dm;
 
     /// Mesh partitioner
     PetscPartitioner partitioner;

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -209,4 +209,14 @@ DiscreteProblemInterface::set_up_constants()
     PETSC_CHECK(PetscDSSetConstants(this->ds, this->consts.size(), this->consts.data()));
 }
 
+Vec
+DiscreteProblemInterface::get_coordinates_local() const
+{
+    _F_;
+    DM dm = this->unstr_mesh->get_dm();
+    Vec coord;
+    PETSC_CHECK(DMGetCoordinatesLocal(dm, &coord));
+    return coord;
+}
+
 } // namespace godzilla

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -219,4 +219,13 @@ DiscreteProblemInterface::get_coordinates_local() const
     return coord;
 }
 
+void
+DiscreteProblemInterface::build_local_solution_vector(Vec sln) const
+{
+    DM dm = this->unstr_mesh->get_dm();
+    PetscReal time = this->problem->get_time();
+    PETSC_CHECK(DMGlobalToLocal(dm, this->problem->get_solution_vector(), INSERT_VALUES, sln));
+    PETSC_CHECK(DMPlexInsertBoundaryValues(dm, PETSC_TRUE, sln, time, NULL, NULL, NULL));
+}
+
 } // namespace godzilla

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -627,10 +627,9 @@ ExodusIIOutput::write_nodal_variables(const PetscScalar * sln)
 {
     _F_;
 
-    DM dm = this->problem->get_dm();
     PetscInt n_all_elems = this->mesh->get_num_all_elements();
     PetscInt first, last;
-    PETSC_CHECK(DMPlexGetHeightStratum(dm, this->mesh->get_dimension(), &first, &last));
+    this->mesh->get_vertex_idx_range(first, last);
 
     for (PetscInt n = first; n < last; n++) {
         int exo_var_id = 1;

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -603,12 +603,8 @@ void
 ExodusIIOutput::write_field_variables()
 {
     _F_;
-    PetscReal time = this->problem->get_time();
     DM dm = this->problem->get_dm();
-    Vec sln;
-    PETSC_CHECK(DMGetLocalVector(dm, &sln));
-    PETSC_CHECK(DMGlobalToLocal(dm, this->problem->get_solution_vector(), INSERT_VALUES, sln));
-    PETSC_CHECK(DMPlexInsertBoundaryValues(dm, PETSC_TRUE, sln, time, NULL, NULL, NULL));
+    Vec sln = this->dpi->get_solution_vector_local();
 
     const PetscScalar * sln_vals;
     PETSC_CHECK(VecGetArrayRead(sln, &sln_vals));
@@ -617,8 +613,6 @@ ExodusIIOutput::write_field_variables()
     write_elem_variables(sln_vals);
 
     PETSC_CHECK(VecRestoreArrayRead(sln, &sln_vals));
-
-    PETSC_CHECK(DMRestoreLocalVector(dm, &sln));
 }
 
 void

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -186,8 +186,6 @@ void
 ExodusIIOutput::write_mesh()
 {
     _F_;
-    DM dm = this->mesh->get_dm();
-
     int n_nodes = this->mesh->get_num_vertices();
     int n_elems = this->mesh->get_num_elements();
 
@@ -198,9 +196,7 @@ ExodusIIOutput::write_mesh()
         n_elem_blk = 1;
 
     PetscInt n_node_sets = this->mesh->get_num_vertex_sets();
-
-    PetscInt n_side_sets;
-    PETSC_CHECK(DMGetLabelSize(dm, "Face Sets", &n_side_sets));
+    PetscInt n_side_sets = this->mesh->get_num_face_sets();
 
     int exo_dim = this->mesh->get_dimension();
     // Visualization SW based on VTK have problems showing 1D, so we cast it like a 2D problem with
@@ -470,8 +466,7 @@ ExodusIIOutput::write_face_sets()
     DMLabel face_sets_label;
     PETSC_CHECK(DMGetLabel(dm, "Face Sets", &face_sets_label));
 
-    PetscInt n_side_sets;
-    PETSC_CHECK(DMGetLabelSize(dm, "Face Sets", &n_side_sets));
+    PetscInt n_side_sets = this->mesh->get_num_face_sets();
     fs_names.resize(n_side_sets);
 
     IS face_sets_is;

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -499,8 +499,7 @@ ExodusIIOutput::write_face_sets()
                 DMPlexGetTransitiveClosure(dm, faces[i], PETSC_FALSE, &num_points, &points));
 
             PetscInt el = points[2];
-            DMPolytopeType polytope_type;
-            PETSC_CHECK(DMPlexGetCellType(dm, el, &polytope_type));
+            DMPolytopeType polytope_type = this->mesh->get_cell_type(el);
             const PetscInt * side_ordering = get_elem_side_ordering(polytope_type);
             elem_list[i] = el + 1;
 
@@ -745,10 +744,10 @@ ExodusIIOutput::write_block_connectivity(int blk_id, int n_elems_in_block, const
     if (cells == nullptr) {
         this->mesh->get_element_idx_range(elem_first, elem_last);
         n_elems_in_block = this->mesh->get_num_elements();
-        PETSC_CHECK(DMPlexGetCellType(dm, elem_first, &polytope_type));
+        polytope_type = this->mesh->get_cell_type(elem_first);
     }
     else
-        PETSC_CHECK(DMPlexGetCellType(dm, cells[0], &polytope_type));
+        polytope_type = this->mesh->get_cell_type(cells[0]);
 
     const char * elem_type = get_elem_type(polytope_type);
     int n_nodes_per_elem = get_num_elem_nodes(polytope_type);

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -217,10 +217,8 @@ void
 ExodusIIOutput::write_coords(int exo_dim)
 {
     _F_;
-    DM dm = this->mesh->get_dm();
     PetscInt dim = this->mesh->get_dimension();
-    Vec coord;
-    PETSC_CHECK(DMGetCoordinatesLocal(dm, &coord));
+    Vec coord = this->dpi->get_coordinates_local();
     PetscInt coord_size;
     PETSC_CHECK(VecGetSize(coord, &coord_size));
     PetscScalar * xyz;

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -197,8 +197,7 @@ ExodusIIOutput::write_mesh()
     if (n_elem_blk == 0)
         n_elem_blk = 1;
 
-    PetscInt n_node_sets;
-    PETSC_CHECK(DMGetLabelSize(dm, "Vertex Sets", &n_node_sets));
+    PetscInt n_node_sets = this->mesh->get_num_vertex_sets();
 
     PetscInt n_side_sets;
     PETSC_CHECK(DMGetLabelSize(dm, "Face Sets", &n_side_sets));
@@ -416,8 +415,7 @@ ExodusIIOutput::write_node_sets()
     this->mesh->get_element_idx_range(elem_first, elem_last);
     int n_elems_in_block = elem_last - elem_first;
 
-    PetscInt n_node_sets;
-    PETSC_CHECK(DMGetLabelSize(dm, "Vertex Sets", &n_node_sets));
+    PetscInt n_node_sets = this->mesh->get_num_vertex_sets();
 
     DMLabel vertex_sets_label = this->mesh->get_label("Vertex Sets");
 

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -192,8 +192,7 @@ ExodusIIOutput::write_mesh()
     int n_elems = this->mesh->get_num_elements();
 
     // number of element blocks
-    PetscInt n_elem_blk = 0;
-    PETSC_CHECK(DMGetLabelSize(dm, "Cell Sets", &n_elem_blk));
+    PetscInt n_elem_blk = this->mesh->get_num_cell_sets();
     // no cell sets defined, therefore we have one element block
     if (n_elem_blk == 0)
         n_elem_blk = 1;
@@ -366,8 +365,7 @@ ExodusIIOutput::write_elements()
     DM dm = this->mesh->get_dm();
     std::vector<std::string> block_names;
 
-    PetscInt n_cells_sets = 0;
-    PETSC_CHECK(DMGetLabelSize(dm, "Cell Sets", &n_cells_sets));
+    PetscInt n_cells_sets = this->mesh->get_num_cell_sets();
 
     if (n_cells_sets > 1) {
         block_names.resize(n_cells_sets);
@@ -674,9 +672,7 @@ void
 ExodusIIOutput::write_elem_variables(const PetscScalar * sln)
 {
     _F_;
-    DM dm = this->problem->get_dm();
-    PetscInt n_cells_sets = 0;
-    PETSC_CHECK(DMGetLabelSize(dm, "Cell Sets", &n_cells_sets));
+    PetscInt n_cells_sets = this->mesh->get_num_cell_sets();
     if (n_cells_sets > 1) {
         // TODO: go block by block and save the elemental variables
         error("Block-restricted elemental variable output is not implemented, yet.");

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -634,17 +634,12 @@ ExodusIIOutput::write_nodal_variables(const PetscScalar * sln)
     PetscInt first, last;
     PETSC_CHECK(DMPlexGetHeightStratum(dm, this->mesh->get_dimension(), &first, &last));
 
-    PetscSection section;
-    PETSC_CHECK(DMGetLocalSection(dm, &section));
-
     for (PetscInt n = first; n < last; n++) {
         int exo_var_id = 1;
         for (std::size_t i = 0; i < this->nodal_var_fids.size(); i++) {
             PetscInt fid = this->nodal_var_fids[i];
 
-            PetscInt offset;
-            PETSC_CHECK(PetscSectionGetFieldOffset(section, n, fid, &offset));
-
+            PetscInt offset = this->dpi->get_field_dof(n, fid);
             PetscInt nc = this->dpi->get_field_num_components(fid);
             for (PetscInt c = 0; c <= nc; c++, exo_var_id++) {
                 int exo_idx = n - n_all_elems + 1;
@@ -678,21 +673,15 @@ void
 ExodusIIOutput::write_block_elem_variables(int blk_id, const PetscScalar * sln)
 {
     _F_;
-    DM dm = this->problem->get_dm();
     PetscInt first, last;
     this->mesh->get_element_idx_range(first, last);
-
-    PetscSection section;
-    PETSC_CHECK(DMGetLocalSection(dm, &section));
 
     for (PetscInt n = first; n < last; n++) {
         int exo_var_id = 1;
         for (std::size_t i = 0; i < this->elem_var_fids.size(); i++) {
             PetscInt fid = this->elem_var_fids[i];
 
-            PetscInt offset;
-            PETSC_CHECK(PetscSectionGetFieldOffset(section, n, fid, &offset));
-
+            PetscInt offset = this->dpi->get_field_dof(n, fid);
             PetscInt nc = this->dpi->get_field_num_components(fid);
             for (PetscInt c = 0; c < nc; c++, exo_var_id++) {
                 int exo_idx = n - first + 1;

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -89,6 +89,7 @@ ExplicitFVLinearProblem::allocate_objects()
     DM dm = get_dm();
     PETSC_CHECK(DMCreateGlobalVector(dm, &this->x));
     PETSC_CHECK(PetscObjectSetName((PetscObject) this->x, "sln"));
+    FVProblemInterface::allocate_objects();
 }
 
 void

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -74,6 +74,13 @@ FENonlinearProblem::set_up_initial_guess()
     FEProblemInterface::set_up_initial_guess();
 }
 
+void
+FENonlinearProblem::allocate_objects()
+{
+    NonlinearProblem::allocate_objects();
+    FEProblemInterface::allocate_objects();
+}
+
 PetscErrorCode
 FENonlinearProblem::compute_residual_callback(Vec x, Vec f)
 {

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -16,7 +16,8 @@ FEProblemInterface::FEProblemInterface(Problem * problem, const Parameters & par
     section(nullptr),
     qorder(PETSC_DETERMINE),
     dm_aux(nullptr),
-    a(nullptr)
+    a(nullptr),
+    sln(nullptr)
 {
 }
 
@@ -34,6 +35,8 @@ FEProblemInterface::~FEProblemInterface()
 
     VecDestroy(&this->a);
     DMDestroy(&this->dm_aux);
+
+    VecDestroy(&this->sln);
 }
 
 void
@@ -61,6 +64,13 @@ FEProblemInterface::init()
         PETSC_CHECK(DMCopyDisc(dm, cdm));
         PETSC_CHECK(DMGetCoarseDM(cdm, &cdm));
     }
+}
+
+void
+FEProblemInterface::allocate_objects()
+{
+    DM dm = this->unstr_mesh->get_dm();
+    PETSC_CHECK(DMCreateLocalVector(dm, &this->sln));
 }
 
 PetscInt
@@ -123,6 +133,14 @@ FEProblemInterface::get_field_id(const std::string & name) const
         return it->second;
     else
         error("Field '%s' does not exist. Typo?", name);
+}
+
+Vec
+FEProblemInterface::get_solution_vector_local() const
+{
+    _F_;
+    build_local_solution_vector(this->sln);
+    return this->sln;
 }
 
 bool

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -13,6 +13,7 @@ namespace godzilla {
 
 FEProblemInterface::FEProblemInterface(Problem * problem, const Parameters & params) :
     DiscreteProblemInterface(problem, params),
+    section(nullptr),
     qorder(PETSC_DETERMINE),
     dm_aux(nullptr),
     a(nullptr)
@@ -51,6 +52,7 @@ FEProblemInterface::init()
     DiscreteProblemInterface::init();
 
     DM dm = this->unstr_mesh->get_dm();
+    PETSC_CHECK(DMGetLocalSection(dm, &this->section));
     DM cdm = dm;
     while (cdm) {
         set_up_auxiliary_dm(cdm);
@@ -174,6 +176,15 @@ FEProblemInterface::set_field_component_name(PetscInt fid,
     }
     else
         error("Field with ID = '%d' does not exist.", fid);
+}
+
+PetscInt
+FEProblemInterface::get_field_dof(PetscInt point, PetscInt fid) const
+{
+    _F_;
+    PetscInt offset;
+    PETSC_CHECK(PetscSectionGetFieldOffset(this->section, point, fid, &offset));
+    return offset;
 }
 
 const std::string &

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -30,12 +30,16 @@ __compute_flux(PetscInt dim,
 FVProblemInterface::FVProblemInterface(Problem * problem, const Parameters & params) :
     DiscreteProblemInterface(problem, params),
     section(nullptr),
-    fvm(nullptr)
+    fvm(nullptr),
+    sln(nullptr)
 {
     _F_;
 }
 
-FVProblemInterface::~FVProblemInterface() {}
+FVProblemInterface::~FVProblemInterface()
+{
+    VecDestroy(&this->sln);
+}
 
 void
 FVProblemInterface::init()
@@ -168,6 +172,14 @@ FVProblemInterface::get_field_dof(PetscInt point, PetscInt fid) const
     return offset;
 }
 
+Vec
+FVProblemInterface::get_solution_vector_local() const
+{
+    _F_;
+    build_local_solution_vector(this->sln);
+    return this->sln;
+}
+
 void
 FVProblemInterface::add_field(PetscInt id, const std::string & name, PetscInt nc)
 {
@@ -193,6 +205,13 @@ FVProblemInterface::create()
     _F_;
     const_cast<UnstructuredMesh *>(this->unstr_mesh)->construct_ghost_cells();
     DiscreteProblemInterface::create();
+}
+
+void
+FVProblemInterface::allocate_objects()
+{
+    DM dm = this->unstr_mesh->get_dm();
+    PETSC_CHECK(DMCreateLocalVector(dm, &this->sln));
 }
 
 void

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -29,12 +29,22 @@ __compute_flux(PetscInt dim,
 
 FVProblemInterface::FVProblemInterface(Problem * problem, const Parameters & params) :
     DiscreteProblemInterface(problem, params),
+    section(nullptr),
     fvm(nullptr)
 {
     _F_;
 }
 
 FVProblemInterface::~FVProblemInterface() {}
+
+void
+FVProblemInterface::init()
+{
+    DiscreteProblemInterface::init();
+
+    DM dm = this->unstr_mesh->get_dm();
+    PETSC_CHECK(DMGetLocalSection(dm, &this->section));
+}
 
 PetscInt
 FVProblemInterface::get_num_fields() const
@@ -147,6 +157,15 @@ FVProblemInterface::set_field_component_name(PetscInt fid,
     }
     else
         error("Field with ID = '%d' does not exist.", fid);
+}
+
+PetscInt
+FVProblemInterface::get_field_dof(PetscInt point, PetscInt fid) const
+{
+    _F_;
+    PetscInt offset;
+    PETSC_CHECK(PetscSectionGetFieldOffset(this->section, point, fid, &offset));
+    return offset;
 }
 
 void

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -11,62 +11,15 @@ Mesh::parameters()
     return params;
 }
 
-Mesh::Mesh(const Parameters & parameters) :
-    Object(parameters),
-    PrintInterface(this),
-    dm(NULL),
-    dim(-1)
-{
-}
+Mesh::Mesh(const Parameters & parameters) : Object(parameters), PrintInterface(this), dim(-1) {}
 
-Mesh::~Mesh()
-{
-    _F_;
-    if (this->dm)
-        PETSC_CHECK(DMDestroy(&this->dm));
-}
-
-DM
-Mesh::get_dm() const
-{
-    _F_;
-    return this->dm;
-}
+Mesh::~Mesh() {}
 
 PetscInt
 Mesh::get_dimension() const
 {
     _F_;
     return this->dim;
-}
-
-void
-Mesh::create()
-{
-    _F_;
-    create_dm();
-    PETSC_CHECK(DMSetFromOptions(this->dm));
-    PETSC_CHECK(DMViewFromOptions(dm, NULL, "-dm_view"));
-    PETSC_CHECK(DMSetUp(this->dm));
-    PETSC_CHECK(DMGetDimension(this->dm, &this->dim));
-}
-
-bool
-Mesh::has_label(const std::string & name) const
-{
-    _F_;
-    PetscBool exists = PETSC_FALSE;
-    PETSC_CHECK(DMHasLabel(this->dm, name.c_str(), &exists));
-    return exists == PETSC_TRUE;
-}
-
-DMLabel
-Mesh::get_label(const std::string & name) const
-{
-    _F_;
-    DMLabel label;
-    PETSC_CHECK(DMGetLabel(this->dm, name.c_str(), &label));
-    return label;
 }
 
 } // namespace godzilla

--- a/src/MeshPartitioningOutput.cpp
+++ b/src/MeshPartitioningOutput.cpp
@@ -22,6 +22,15 @@ MeshPartitioningOutput::MeshPartitioningOutput(const Parameters & params) : File
     this->file_base = "part";
 }
 
+void
+MeshPartitioningOutput::check()
+{
+    _F_;
+    DM dm = this->problem->get_dm();
+    if (dm == nullptr)
+        log_error("Mesh partitioning output works only with problems that provide DM.");
+}
+
 std::string
 MeshPartitioningOutput::get_file_ext() const
 {

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -133,8 +133,7 @@ UnstructuredMesh::create_face_set_labels(const std::map<int, std::string> & name
     _F_;
     DMLabel fs_label;
     PETSC_CHECK(DMGetLabel(dm, "Face Sets", &fs_label));
-    PetscInt n_fs;
-    PETSC_CHECK(DMGetLabelSize(dm, "Face Sets", &n_fs));
+    PetscInt n_fs = get_num_face_sets();
     IS fs_is;
     PETSC_CHECK(DMLabelGetValueIS(fs_label, &fs_is));
     const PetscInt * fs_ids;
@@ -245,6 +244,14 @@ UnstructuredMesh::get_num_cell_sets() const
     PetscInt n_cells_sets;
     PETSC_CHECK(DMGetLabelSize(this->dm, "Cell Sets", &n_cells_sets));
     return n_cells_sets;
+}
+
+PetscInt
+UnstructuredMesh::get_num_face_sets() const
+{
+    PetscInt n_face_sets;
+    PETSC_CHECK(DMGetLabelSize(this->dm, "Face Sets", &n_face_sets));
+    return n_face_sets;
 }
 
 PetscInt

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -121,6 +121,14 @@ UnstructuredMesh::get_all_element_idx_range(PetscInt & first, PetscInt & last) c
     PETSC_CHECK(DMPlexGetHeightStratum(this->dm, 0, &first, &last));
 }
 
+DMPolytopeType
+UnstructuredMesh::get_cell_type(PetscInt el) const
+{
+    DMPolytopeType polytope_type;
+    PETSC_CHECK(DMPlexGetCellType(this->dm, el, &polytope_type));
+    return polytope_type;
+}
+
 void
 UnstructuredMesh::set_partitioner_type(const std::string & type)
 {

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -14,6 +14,7 @@ UnstructuredMesh::parameters()
 
 UnstructuredMesh::UnstructuredMesh(const Parameters & parameters) :
     Mesh(parameters),
+    dm(nullptr),
     partition_overlap(0)
 {
     _F_;
@@ -24,16 +25,48 @@ UnstructuredMesh::~UnstructuredMesh()
 {
     _F_;
     PETSC_CHECK(PetscPartitionerDestroy(&this->partitioner));
+    if (this->dm)
+        PETSC_CHECK(DMDestroy(&this->dm));
+}
+
+DM
+UnstructuredMesh::get_dm() const
+{
+    _F_;
+    return this->dm;
 }
 
 void
 UnstructuredMesh::create()
 {
     _F_;
-    Mesh::create();
+    create_dm();
+    PETSC_CHECK(DMSetFromOptions(this->dm));
+    PETSC_CHECK(DMViewFromOptions(dm, NULL, "-dm_view"));
+    PETSC_CHECK(DMSetUp(this->dm));
+    PETSC_CHECK(DMGetDimension(this->dm, &this->dim));
+
     lprintf(9, "Information:");
     lprintf(9, "- vertices: %d", get_num_vertices());
     lprintf(9, "- elements: %d", get_num_elements());
+}
+
+bool
+UnstructuredMesh::has_label(const std::string & name) const
+{
+    _F_;
+    PetscBool exists = PETSC_FALSE;
+    PETSC_CHECK(DMHasLabel(this->dm, name.c_str(), &exists));
+    return exists == PETSC_TRUE;
+}
+
+DMLabel
+UnstructuredMesh::get_label(const std::string & name) const
+{
+    _F_;
+    DMLabel label;
+    PETSC_CHECK(DMGetLabel(this->dm, name.c_str(), &label));
+    return label;
 }
 
 PetscInt

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -247,6 +247,15 @@ UnstructuredMesh::get_num_cell_sets() const
     return n_cells_sets;
 }
 
+PetscInt
+UnstructuredMesh::get_num_vertex_sets() const
+{
+    _F_;
+    PetscInt n_vertex_sets;
+    PETSC_CHECK(DMGetLabelSize(this->dm, "Vertex Sets", &n_vertex_sets));
+    return n_vertex_sets;
+}
+
 void
 UnstructuredMesh::construct_ghost_cells()
 {

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -238,6 +238,15 @@ UnstructuredMesh::get_cell_set_name(PetscInt id) const
         error("Cell set ID '%d' does not exist.", id);
 }
 
+PetscInt
+UnstructuredMesh::get_num_cell_sets() const
+{
+    _F_;
+    PetscInt n_cells_sets;
+    PETSC_CHECK(DMGetLabelSize(this->dm, "Cell Sets", &n_cells_sets));
+    return n_cells_sets;
+}
+
 void
 UnstructuredMesh::construct_ghost_cells()
 {

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -74,17 +74,25 @@ TEST_F(ExodusIIOutputTest, fe_check)
     public:
         explicit TestMesh(const Parameters & params) : Mesh(params) {}
 
-    protected:
-        virtual void
-        create_dm()
+        DM
+        get_dm() const override
+        {
+            return this->dm;
+        }
+
+        void
+        create() override
         {
             DMCreate(get_comm(), &this->dm);
         }
 
+    protected:
         virtual void
-        distribute()
+        distribute() override
         {
         }
+
+        DM dm;
     };
 
     class TestLinearProblem : public Problem {

--- a/test/src/GodzillaApp_test.cpp
+++ b/test/src/GodzillaApp_test.cpp
@@ -14,13 +14,15 @@ class MockMesh : public Mesh {
 public:
     explicit MockMesh(const Parameters & params) : Mesh(params) {}
 
+    virtual DM
+    get_dm() const
+    {
+        return nullptr;
+    }
+
 protected:
     virtual void
     distribute()
-    {
-    }
-    virtual void
-    create_dm()
     {
     }
 };

--- a/test/src/HDF5Output_test.cpp
+++ b/test/src/HDF5Output_test.cpp
@@ -69,18 +69,26 @@ TEST_F(HDF5OutputTest, wrong_mesh_type)
     public:
         explicit TestMesh(const Parameters & params) : Mesh(params) {}
 
-    protected:
-        virtual void
-        create_dm()
+        DM
+        get_dm() const override
+        {
+            return this->dm;
+        }
+
+        void
+        create() override
         {
             DMDACreate1d(get_comm(), DM_BOUNDARY_NONE, 1, 1, 1, nullptr, &this->dm);
             DMSetUp(this->dm);
         }
 
+    protected:
         virtual void
-        distribute()
+        distribute() override
         {
         }
+
+        DM dm;
     };
 
     class TestProblem : public LinearProblem {

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -69,18 +69,26 @@ TEST_F(VTKOutputTest, wrong_mesh_type)
     public:
         explicit TestMesh(const Parameters & params) : Mesh(params) {}
 
-    protected:
-        virtual void
-        create_dm()
+        DM
+        get_dm() const override
+        {
+            return this->dm;
+        }
+
+        void
+        create() override
         {
             DMDACreate1d(get_comm(), DM_BOUNDARY_NONE, 1, 1, 1, nullptr, &this->dm);
             DMSetUp(this->dm);
         }
 
+    protected:
         virtual void
-        distribute()
+        distribute() override
         {
         }
+
+        DM dm;
     };
 
     class TestProblem : public LinearProblem {


### PR DESCRIPTION
- MeshPartitioningOutput check that the problem is it linked to provides DM
- Adding UnstructuredMesh::get_num_cell_sets() API
- Adding UnstructuredMesh::get_num_vertex_sets() API
- Adding UnstructuredMesh::get_num_face_sets() API
- Adding DiscreteProblemInterface::get_field_dof API
- Adding DiscreteProblemInterface::get_coordinates_local() API
- Refactoring Mesh classes
- Replacing DM call with UnstructuredMesh call
- Adding UnstructuredMesh::get_cell_type API
- Fixing missing new-line character
- Hiding local solution vector behind an API
