### PR TITLE
Stuff

### DIFF
--- a/include/App.h
+++ b/include/App.h
@@ -34,7 +34,7 @@ public:
     /// Parse command line arguments
     ///
     /// @param argc Number of command line arguments
-    /// @param argv Command line argumnts
+    /// @param argv Command line arguments
     virtual void parse_command_line(int argc, char * argv[]);
 
     /// Run the application
@@ -105,7 +105,7 @@ protected:
 
     /// Run the input file
     ///
-    /// This is the method that will be called wehn user specify -i command line parameter
+    /// This is the method that will be called when user specifies -i command line parameter
     virtual void run_input_file();
 
     /// Run the problem build via `build_from_yml`

--- a/include/App.h
+++ b/include/App.h
@@ -26,7 +26,7 @@ public:
     /// Get Application name
     ///
     /// @return Application name
-    virtual const std::string & get_name() const;
+    const std::string & get_name() const;
 
     /// @return Get problem this application is representing
     virtual Problem * get_problem() const;

--- a/include/AuxiliaryField.h
+++ b/include/AuxiliaryField.h
@@ -13,7 +13,7 @@ class FEProblemInterface;
 ///
 class AuxiliaryField : public Object, public PrintInterface {
 public:
-    AuxiliaryField(const Parameters & params);
+    explicit AuxiliaryField(const Parameters & params);
     virtual ~AuxiliaryField();
 
     void create() override;

--- a/include/AuxiliaryField.h
+++ b/include/AuxiliaryField.h
@@ -14,7 +14,6 @@ class FEProblemInterface;
 class AuxiliaryField : public Object, public PrintInterface {
 public:
     explicit AuxiliaryField(const Parameters & params);
-    virtual ~AuxiliaryField();
 
     void create() override;
 

--- a/include/AuxiliaryField.h
+++ b/include/AuxiliaryField.h
@@ -16,7 +16,7 @@ public:
     AuxiliaryField(const Parameters & params);
     virtual ~AuxiliaryField();
 
-    virtual void create() override;
+    void create() override;
 
     virtual DMLabel get_label() const;
 

--- a/include/BasicTSAdapt.h
+++ b/include/BasicTSAdapt.h
@@ -11,7 +11,7 @@ public:
     BasicTSAdapt(const Parameters & params);
 
 protected:
-    virtual void set_type();
+    void set_type() override;
 
 public:
     static Parameters parameters();

--- a/include/BasicTSAdapt.h
+++ b/include/BasicTSAdapt.h
@@ -8,7 +8,7 @@ namespace godzilla {
 ///
 class BasicTSAdapt : public TimeSteppingAdaptor {
 public:
-    BasicTSAdapt(const Parameters & params);
+    explicit BasicTSAdapt(const Parameters & params);
 
 protected:
     void set_type() override;

--- a/include/BndJacobianFunc.h
+++ b/include/BndJacobianFunc.h
@@ -10,7 +10,7 @@ class NaturalBC;
 
 class BndJacobianFunc {
 public:
-    BndJacobianFunc(const NaturalBC * nbc);
+    explicit BndJacobianFunc(const NaturalBC * nbc);
 
     /// Evaluate this Jacobian function
     ///

--- a/include/BndResidualFunc.h
+++ b/include/BndResidualFunc.h
@@ -10,7 +10,7 @@ class FEProblemInterface;
 
 class BndResidualFunc {
 public:
-    BndResidualFunc(const NaturalBC * nbc);
+    explicit BndResidualFunc(const NaturalBC * nbc);
 
     /// Evaluate this residual function
     ///

--- a/include/BoundaryCondition.h
+++ b/include/BoundaryCondition.h
@@ -12,7 +12,7 @@ class DiscreteProblemInterface;
 ///
 class BoundaryCondition : public Object, public PrintInterface {
 public:
-    BoundaryCondition(const Parameters & params);
+    explicit BoundaryCondition(const Parameters & params);
     virtual ~BoundaryCondition();
 
     void create() override;

--- a/include/BoundaryCondition.h
+++ b/include/BoundaryCondition.h
@@ -15,7 +15,7 @@ public:
     BoundaryCondition(const Parameters & params);
     virtual ~BoundaryCondition();
 
-    virtual void create() override;
+    void create() override;
 
     /// Get the boundary name this BC is active on
     ///

--- a/include/BoundaryCondition.h
+++ b/include/BoundaryCondition.h
@@ -13,7 +13,7 @@ class DiscreteProblemInterface;
 class BoundaryCondition : public Object, public PrintInterface {
 public:
     explicit BoundaryCondition(const Parameters & params);
-    virtual ~BoundaryCondition();
+    ~BoundaryCondition() override;
 
     void create() override;
 

--- a/include/BoxMesh.h
+++ b/include/BoxMesh.h
@@ -39,7 +39,7 @@ public:
     PetscInt get_nz() const;
 
 protected:
-    virtual void create_dm() override;
+    void create_dm() override;
 
     /// Minimum in the x direction
     const PetscReal & xmin;

--- a/include/BoxMesh.h
+++ b/include/BoxMesh.h
@@ -12,28 +12,28 @@ public:
     explicit BoxMesh(const Parameters & parameters);
 
     /// Get lower limit in x-direction
-    PetscInt get_x_min() const;
+    PetscReal get_x_min() const;
 
     /// Get upper limit in x-direction
-    PetscInt get_x_max() const;
+    PetscReal get_x_max() const;
 
     /// Get the number of mesh points in x direction
     PetscInt get_nx() const;
 
     /// Get lower limit in y-direction
-    PetscInt get_y_min() const;
+    PetscReal get_y_min() const;
 
     /// Get upper limit in y-direction
-    PetscInt get_y_max() const;
+    PetscReal get_y_max() const;
 
     /// Get the number of mesh points in y-direction
     PetscInt get_ny() const;
 
     /// Get lower limit in z-direction
-    PetscInt get_z_min() const;
+    PetscReal get_z_min() const;
 
     /// Get upper limit in z-direction
-    PetscInt get_z_max() const;
+    PetscReal get_z_max() const;
 
     /// Get the number of mesh points in z direction
     PetscInt get_nz() const;

--- a/include/BoxMesh.h
+++ b/include/BoxMesh.h
@@ -9,7 +9,7 @@ namespace godzilla {
 class BoxMesh : public UnstructuredMesh {
 public:
     /// Constructor for building the object via Factory
-    BoxMesh(const Parameters & parameters);
+    explicit BoxMesh(const Parameters & parameters);
 
     /// Get lower limit in x-direction
     PetscInt get_x_min() const;

--- a/include/CSVOutput.h
+++ b/include/CSVOutput.h
@@ -10,7 +10,7 @@ namespace godzilla {
 class CSVOutput : public FileOutput {
 public:
     explicit CSVOutput(const Parameters & params);
-    virtual ~CSVOutput();
+    ~CSVOutput() override;
 
     void create() override;
     std::string get_file_ext() const override;

--- a/include/CSVOutput.h
+++ b/include/CSVOutput.h
@@ -9,7 +9,7 @@ namespace godzilla {
 ///
 class CSVOutput : public FileOutput {
 public:
-    CSVOutput(const Parameters & params);
+    explicit CSVOutput(const Parameters & params);
     virtual ~CSVOutput();
 
     void create() override;

--- a/include/CSVOutput.h
+++ b/include/CSVOutput.h
@@ -12,9 +12,9 @@ public:
     CSVOutput(const Parameters & params);
     virtual ~CSVOutput();
 
-    virtual void create() override;
-    virtual std::string get_file_ext() const override;
-    virtual void output_step() override;
+    void create() override;
+    std::string get_file_ext() const override;
+    void output_step() override;
 
 protected:
     void open_file();

--- a/include/CallStack.h
+++ b/include/CallStack.h
@@ -24,7 +24,7 @@ public:
     /// Build the call stack object with defined size
     ///
     /// @param max_size The maximum number of call stack objects to handle
-    CallStack(int max_size = 32);
+    explicit CallStack(int max_size = 32);
     virtual ~CallStack();
 
     /// Dump the call stack objects to standard error

--- a/include/CallStack.h
+++ b/include/CallStack.h
@@ -3,17 +3,17 @@
 namespace godzilla {
 namespace internal {
 
-/// Place at the begining of a method/function
+/// Place at the beginning of a method/function
 ///
 /// @code
 /// void Class::method()
 /// {
-///   _F_
+///   _F_;
 ///  ...your code here...
 /// }
 /// @endcode
 #define _F_ \
-    godzilla::internal::CallStack::Obj __call_stack_obj(__LINE__, __PRETTY_FUNCTION__, __FILE__);
+    godzilla::internal::CallStack::Obj __call_stack_obj(__LINE__, __PRETTY_FUNCTION__, __FILE__)
 
 /// Call stack object
 ///

--- a/include/CmdLineArgParser.h
+++ b/include/CmdLineArgParser.h
@@ -27,7 +27,7 @@ public:
     void parse(int argc, const char * const * argv);
 
 protected:
-    /// TCALP command line object
+    /// TCLAP command line object
     TCLAP::CmdLine cmd;
 };
 

--- a/include/CmdLineArgParser.h
+++ b/include/CmdLineArgParser.h
@@ -13,7 +13,7 @@ public:
     ///
     /// @param prog_name The name of the binary (shown when printing usage)
     /// @param version The version of the binary
-    CmdLineArgParser(const std::string & prog_name, const std::string & version = "none");
+    explicit CmdLineArgParser(const std::string & prog_name, const std::string & version = "none");
 
     /// Adds an argument
     ///

--- a/include/ConstantAuxiliaryField.h
+++ b/include/ConstantAuxiliaryField.h
@@ -11,11 +11,10 @@ class ConstantAuxiliaryField : public AuxiliaryField {
 public:
     ConstantAuxiliaryField(const Parameters & params);
 
-    virtual void create();
-    virtual PetscInt get_num_components() const;
-    virtual PetscFunc * get_func() const;
-    virtual void
-    evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc, PetscScalar u[]);
+    void create() override;
+    PetscInt get_num_components() const override;
+    PetscFunc * get_func() const override;
+    void evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc, PetscScalar u[]);
 
 protected:
     const std::vector<PetscReal> & values;

--- a/include/ConstantAuxiliaryField.h
+++ b/include/ConstantAuxiliaryField.h
@@ -9,7 +9,7 @@ namespace godzilla {
 ///
 class ConstantAuxiliaryField : public AuxiliaryField {
 public:
-    ConstantAuxiliaryField(const Parameters & params);
+    explicit ConstantAuxiliaryField(const Parameters & params);
 
     void create() override;
     PetscInt get_num_components() const override;

--- a/include/ConstantIC.h
+++ b/include/ConstantIC.h
@@ -14,13 +14,13 @@ class ConstantIC : public InitialCondition {
 public:
     ConstantIC(const Parameters & params);
 
-    virtual PetscInt get_num_components() const override;
+    PetscInt get_num_components() const override;
 
-    virtual void evaluate(PetscInt dim,
-                          PetscReal time,
-                          const PetscReal x[],
-                          PetscInt Nc,
-                          PetscScalar u[]) override;
+    void evaluate(PetscInt dim,
+                  PetscReal time,
+                  const PetscReal x[],
+                  PetscInt Nc,
+                  PetscScalar u[]) override;
 
 protected:
     /// Constant values -- one for each component

--- a/include/ConstantIC.h
+++ b/include/ConstantIC.h
@@ -12,7 +12,7 @@ namespace godzilla {
 /// value for each component
 class ConstantIC : public InitialCondition {
 public:
-    ConstantIC(const Parameters & params);
+    explicit ConstantIC(const Parameters & params);
 
     PetscInt get_num_components() const override;
 

--- a/include/DirichletBC.h
+++ b/include/DirichletBC.h
@@ -12,14 +12,20 @@ class DirichletBC : public EssentialBC, public FunctionInterface {
 public:
     DirichletBC(const Parameters & params);
 
-    virtual void create();
-    virtual PetscInt get_num_components() const;
-    virtual std::vector<PetscInt> get_components() const;
-    virtual PetscFunc * get_function_t();
-    virtual void
-    evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc, PetscScalar u[]);
-    virtual void
-    evaluate_t(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc, PetscScalar u[]);
+    void create() override;
+    PetscInt get_num_components() const override;
+    std::vector<PetscInt> get_components() const override;
+    PetscFunc * get_function_t() override;
+    void evaluate(PetscInt dim,
+                  PetscReal time,
+                  const PetscReal x[],
+                  PetscInt nc,
+                  PetscScalar u[]) override;
+    void evaluate_t(PetscInt dim,
+                    PetscReal time,
+                    const PetscReal x[],
+                    PetscInt nc,
+                    PetscScalar u[]) override;
 
 public:
     static Parameters parameters();

--- a/include/DirichletBC.h
+++ b/include/DirichletBC.h
@@ -10,7 +10,7 @@ namespace godzilla {
 /// Can be used only on single-field problems
 class DirichletBC : public EssentialBC, public FunctionInterface {
 public:
-    DirichletBC(const Parameters & params);
+    explicit DirichletBC(const Parameters & params);
 
     void create() override;
     PetscInt get_num_components() const override;

--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -18,7 +18,7 @@ class BoundaryCondition;
 class DiscreteProblemInterface {
 public:
     DiscreteProblemInterface(Problem * problem, const Parameters & params);
-    virtual ~DiscreteProblemInterface();
+    virtual ~DiscreteProblemInterface() = default;
 
     /// Get the unstructured mesh
     ///

--- a/include/Error.h
+++ b/include/Error.h
@@ -16,10 +16,10 @@ template <typename... Args>
 void
 error_printf(const char * s, Args... args)
 {
-    fmt::fprintf(stderr, "%s", Terminal::Color::red);
+    fmt::fprintf(stderr, "%s", (const char *) Terminal::Color::red);
     fmt::fprintf(stderr, "[ERROR] ");
     fmt::fprintf(stderr, s, std::forward<Args>(args)...);
-    fmt::fprintf(stderr, "%s", Terminal::Color::normal);
+    fmt::fprintf(stderr, "%s", (const char *) Terminal::Color::normal);
     fmt::fprintf(stderr, "\n");
 }
 

--- a/include/EssentialBC.h
+++ b/include/EssentialBC.h
@@ -41,7 +41,7 @@ public:
     virtual void * get_context();
 
 protected:
-    virtual void add_boundary();
+    void add_boundary() override;
 
 public:
     static Parameters parameters();

--- a/include/EssentialBC.h
+++ b/include/EssentialBC.h
@@ -9,7 +9,7 @@ namespace godzilla {
 ///
 class EssentialBC : public BoundaryCondition {
 public:
-    EssentialBC(const Parameters & params);
+    explicit EssentialBC(const Parameters & params);
 
     /// Evaluate the boundary condition
     ///

--- a/include/ExodusIIMesh.h
+++ b/include/ExodusIIMesh.h
@@ -13,7 +13,7 @@ public:
     const std::string get_file_name() const;
 
 protected:
-    virtual void create_dm() override;
+    void create_dm() override;
 
     /// File name with the ExodusII mesh
     const std::string & file_name;

--- a/include/ExodusIIMesh.h
+++ b/include/ExodusIIMesh.h
@@ -8,7 +8,7 @@ namespace godzilla {
 ///
 class ExodusIIMesh : public UnstructuredMesh {
 public:
-    ExodusIIMesh(const Parameters & parameters);
+    explicit ExodusIIMesh(const Parameters & parameters);
 
     const std::string get_file_name() const;
 

--- a/include/ExodusIIOutput.h
+++ b/include/ExodusIIOutput.h
@@ -80,7 +80,7 @@ protected:
     /// List of nodal elemental variable field IDs
     std::vector<PetscInt> elem_var_fids;
 
-    /// Block ID used in ExodusII file whne there are not cell sets
+    /// Block ID used in ExodusII file when there are not cell sets
     static const int SINGLE_BLK_ID;
 
 public:

--- a/include/ExodusIIOutput.h
+++ b/include/ExodusIIOutput.h
@@ -29,11 +29,11 @@ public:
     ExodusIIOutput(const Parameters & params);
     virtual ~ExodusIIOutput();
 
-    virtual std::string get_file_ext() const override;
-    virtual void set_file_name() override;
-    virtual void create() override;
-    virtual void check() override;
-    virtual void output_step() override;
+    std::string get_file_ext() const override;
+    void set_file_name() override;
+    void create() override;
+    void check() override;
+    void output_step() override;
 
 protected:
     void open_file();

--- a/include/ExodusIIOutput.h
+++ b/include/ExodusIIOutput.h
@@ -26,7 +26,7 @@ class UnstructuredMesh;
 /// This output works only with finite element problems
 class ExodusIIOutput : public FileOutput {
 public:
-    ExodusIIOutput(const Parameters & params);
+    explicit ExodusIIOutput(const Parameters & params);
     virtual ~ExodusIIOutput();
 
     std::string get_file_ext() const override;

--- a/include/ExodusIIOutput.h
+++ b/include/ExodusIIOutput.h
@@ -27,7 +27,7 @@ class UnstructuredMesh;
 class ExodusIIOutput : public FileOutput {
 public:
     explicit ExodusIIOutput(const Parameters & params);
-    virtual ~ExodusIIOutput();
+    ~ExodusIIOutput() override;
 
     std::string get_file_ext() const override;
     void set_file_name() override;

--- a/include/ExplicitFELinearProblem.h
+++ b/include/ExplicitFELinearProblem.h
@@ -10,7 +10,7 @@ class ResidualFunc;
 class ExplicitFELinearProblem : public FENonlinearProblem, public TransientProblemInterface {
 public:
     explicit ExplicitFELinearProblem(const Parameters & params);
-    virtual ~ExplicitFELinearProblem();
+    ~ExplicitFELinearProblem() override;
 
     void create() override;
     void check() override;

--- a/include/ExplicitFELinearProblem.h
+++ b/include/ExplicitFELinearProblem.h
@@ -12,18 +12,17 @@ public:
     ExplicitFELinearProblem(const Parameters & params);
     virtual ~ExplicitFELinearProblem();
 
-    virtual void create() override;
-    virtual void check() override;
-    virtual bool converged() override;
-    virtual void solve() override;
+    void create() override;
+    void check() override;
+    bool converged() override;
+    void solve() override;
 
 protected:
-    virtual void init() override;
-    virtual void set_up_callbacks() override;
-    virtual void set_up_time_scheme() override;
-    virtual void set_up_monitors() override;
-    virtual void
-    set_residual_block(PetscInt field_id, ResidualFunc * f0, ResidualFunc * f1) override;
+    void init() override;
+    void set_up_callbacks() override;
+    void set_up_time_scheme() override;
+    void set_up_monitors() override;
+    void set_residual_block(PetscInt field_id, ResidualFunc * f0, ResidualFunc * f1) override;
 
     /// Time stepping scheme
     const std::string & scheme;

--- a/include/ExplicitFELinearProblem.h
+++ b/include/ExplicitFELinearProblem.h
@@ -9,7 +9,7 @@ class ResidualFunc;
 
 class ExplicitFELinearProblem : public FENonlinearProblem, public TransientProblemInterface {
 public:
-    ExplicitFELinearProblem(const Parameters & params);
+    explicit ExplicitFELinearProblem(const Parameters & params);
     virtual ~ExplicitFELinearProblem();
 
     void create() override;

--- a/include/ExplicitFVLinearProblem.h
+++ b/include/ExplicitFVLinearProblem.h
@@ -11,7 +11,7 @@ class ExplicitFVLinearProblem :
     public FVProblemInterface,
     public TransientProblemInterface {
 public:
-    ExplicitFVLinearProblem(const Parameters & params);
+    explicit ExplicitFVLinearProblem(const Parameters & params);
     virtual ~ExplicitFVLinearProblem();
 
     void create() override;

--- a/include/ExplicitFVLinearProblem.h
+++ b/include/ExplicitFVLinearProblem.h
@@ -14,21 +14,21 @@ public:
     ExplicitFVLinearProblem(const Parameters & params);
     virtual ~ExplicitFVLinearProblem();
 
-    virtual void create() override;
-    virtual void check() override;
-    virtual bool converged() override;
-    virtual void solve() override;
+    void create() override;
+    void check() override;
+    bool converged() override;
+    void solve() override;
 
 protected:
-    virtual void init() override;
-    virtual void allocate_objects() override;
-    virtual void set_up_callbacks() override;
-    virtual void set_up_initial_guess() override;
-    virtual void set_up_time_scheme() override;
-    virtual void set_up_monitors() override;
+    void init() override;
+    void allocate_objects() override;
+    void set_up_callbacks() override;
+    void set_up_initial_guess() override;
+    void set_up_time_scheme() override;
+    void set_up_monitors() override;
 
-    virtual PetscErrorCode compute_residual_callback(Vec x, Vec f) override;
-    virtual PetscErrorCode compute_jacobian_callback(Vec x, Mat J, Mat Jp) override;
+    PetscErrorCode compute_residual_callback(Vec x, Vec f) override;
+    PetscErrorCode compute_jacobian_callback(Vec x, Mat J, Mat Jp) override;
 
     /// Time stepping scheme
     const std::string & scheme;

--- a/include/ExplicitFVLinearProblem.h
+++ b/include/ExplicitFVLinearProblem.h
@@ -12,7 +12,7 @@ class ExplicitFVLinearProblem :
     public TransientProblemInterface {
 public:
     explicit ExplicitFVLinearProblem(const Parameters & params);
-    virtual ~ExplicitFVLinearProblem();
+    ~ExplicitFVLinearProblem() override;
 
     void create() override;
     void check() override;

--- a/include/FENonlinearProblem.h
+++ b/include/FENonlinearProblem.h
@@ -17,15 +17,15 @@ public:
     FENonlinearProblem(const Parameters & parameters);
     virtual ~FENonlinearProblem();
 
-    virtual void create() override;
+    void create() override;
 
 protected:
-    virtual void init() override;
-    virtual void set_up_callbacks() override;
-    virtual void set_up_initial_guess() override;
-    virtual void allocate_objects() override;
-    virtual PetscErrorCode compute_residual_callback(Vec x, Vec f) override;
-    virtual PetscErrorCode compute_jacobian_callback(Vec x, Mat J, Mat Jp) override;
+    void init() override;
+    void set_up_callbacks() override;
+    void set_up_initial_guess() override;
+    void allocate_objects() override;
+    PetscErrorCode compute_residual_callback(Vec x, Vec f) override;
+    PetscErrorCode compute_jacobian_callback(Vec x, Mat J, Mat Jp) override;
 
     /// Set up residual statement for a field variable
     ///
@@ -49,7 +49,7 @@ protected:
                                     JacobianFunc * g2,
                                     JacobianFunc * g3);
 
-    virtual void on_initial() override;
+    void on_initial() override;
 
 public:
     static Parameters parameters();

--- a/include/FENonlinearProblem.h
+++ b/include/FENonlinearProblem.h
@@ -15,7 +15,6 @@ class JacobianFunc;
 class FENonlinearProblem : public NonlinearProblem, public FEProblemInterface {
 public:
     explicit FENonlinearProblem(const Parameters & parameters);
-    virtual ~FENonlinearProblem();
 
     void create() override;
 

--- a/include/FENonlinearProblem.h
+++ b/include/FENonlinearProblem.h
@@ -14,7 +14,7 @@ class JacobianFunc;
 ///
 class FENonlinearProblem : public NonlinearProblem, public FEProblemInterface {
 public:
-    FENonlinearProblem(const Parameters & parameters);
+    explicit FENonlinearProblem(const Parameters & parameters);
     virtual ~FENonlinearProblem();
 
     void create() override;

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -21,20 +21,20 @@ public:
     FEProblemInterface(Problem * problem, const Parameters & params);
     virtual ~FEProblemInterface();
 
-    virtual PetscInt get_num_fields() const override;
-    virtual std::vector<std::string> get_field_names() const override;
-    virtual const std::string & get_field_name(PetscInt fid) const override;
-    virtual PetscInt get_field_num_components(PetscInt fid) const override;
-    virtual PetscInt get_field_id(const std::string & name) const override;
-    virtual bool has_field_by_id(PetscInt fid) const override;
-    virtual bool has_field_by_name(const std::string & name) const override;
-    virtual PetscInt get_field_order(PetscInt fid) const override;
-    virtual std::string get_field_component_name(PetscInt fid, PetscInt component) const override;
-    virtual void
+    PetscInt get_num_fields() const override;
+    std::vector<std::string> get_field_names() const override;
+    const std::string & get_field_name(PetscInt fid) const override;
+    PetscInt get_field_num_components(PetscInt fid) const override;
+    PetscInt get_field_id(const std::string & name) const override;
+    bool has_field_by_id(PetscInt fid) const override;
+    bool has_field_by_name(const std::string & name) const override;
+    PetscInt get_field_order(PetscInt fid) const override;
+    std::string get_field_component_name(PetscInt fid, PetscInt component) const override;
+    void
     set_field_component_name(PetscInt fid, PetscInt component, const std::string name) override;
-    virtual PetscInt get_field_dof(PetscInt point, PetscInt fid) const override;
-    virtual Vec get_solution_vector_local() const override;
-    virtual WeakForm * get_weak_form() const override;
+    PetscInt get_field_dof(PetscInt point, PetscInt fid) const override;
+    Vec get_solution_vector_local() const override;
+    WeakForm * get_weak_form() const override;
 
     /// Get number of auxiliary fields
     ///
@@ -177,8 +177,8 @@ public:
 protected:
     struct FieldInfo;
 
-    virtual void create() override;
-    virtual void init() override;
+    void create() override;
+    void init() override;
     virtual void allocate_objects();
 
     /// Create FE object from FieldInfo
@@ -187,7 +187,7 @@ protected:
     void create_fe(FieldInfo & fi);
 
     /// Set up discretization system
-    virtual void set_up_ds() override;
+    void set_up_ds() override;
 
     /// Set up quadrature
     virtual void set_up_quadrature();

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -19,7 +19,7 @@ class WeakForm;
 class FEProblemInterface : public DiscreteProblemInterface {
 public:
     FEProblemInterface(Problem * problem, const Parameters & params);
-    virtual ~FEProblemInterface();
+    ~FEProblemInterface() override;
 
     PetscInt get_num_fields() const override;
     std::vector<std::string> get_field_names() const override;

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -10,7 +10,7 @@ namespace godzilla {
 class FVProblemInterface : public DiscreteProblemInterface {
 public:
     FVProblemInterface(Problem * problem, const Parameters & params);
-    virtual ~FVProblemInterface();
+    ~FVProblemInterface() override;
 
     PetscInt get_num_fields() const override;
     std::vector<std::string> get_field_names() const override;

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -12,20 +12,20 @@ public:
     FVProblemInterface(Problem * problem, const Parameters & params);
     virtual ~FVProblemInterface();
 
-    virtual PetscInt get_num_fields() const override;
-    virtual std::vector<std::string> get_field_names() const override;
-    virtual const std::string & get_field_name(PetscInt fid) const override;
-    virtual PetscInt get_field_num_components(PetscInt fid) const override;
-    virtual PetscInt get_field_id(const std::string & name) const override;
-    virtual bool has_field_by_id(PetscInt fid) const override;
-    virtual bool has_field_by_name(const std::string & name) const override;
-    virtual PetscInt get_field_order(PetscInt fid) const override;
-    virtual std::string get_field_component_name(PetscInt fid, PetscInt component) const override;
-    virtual void
+    PetscInt get_num_fields() const override;
+    std::vector<std::string> get_field_names() const override;
+    const std::string & get_field_name(PetscInt fid) const override;
+    PetscInt get_field_num_components(PetscInt fid) const override;
+    PetscInt get_field_id(const std::string & name) const override;
+    bool has_field_by_id(PetscInt fid) const override;
+    bool has_field_by_name(const std::string & name) const override;
+    PetscInt get_field_order(PetscInt fid) const override;
+    std::string get_field_component_name(PetscInt fid, PetscInt component) const override;
+    void
     set_field_component_name(PetscInt fid, PetscInt component, const std::string name) override;
-    virtual PetscInt get_field_dof(PetscInt point, PetscInt fid) const override;
-    virtual Vec get_solution_vector_local() const override;
-    virtual WeakForm * get_weak_form() const override;
+    PetscInt get_field_dof(PetscInt point, PetscInt fid) const override;
+    Vec get_solution_vector_local() const override;
+    WeakForm * get_weak_form() const override;
 
     /// Adds a volumetric field
     ///
@@ -36,10 +36,10 @@ public:
     virtual void add_field(PetscInt id, const std::string & name, PetscInt nc);
 
 protected:
-    virtual void init() override;
-    virtual void create() override;
+    void init() override;
+    void create() override;
     virtual void allocate_objects();
-    virtual void set_up_ds() override;
+    void set_up_ds() override;
 
     /// Compute flux
     ///

--- a/include/Factory.h
+++ b/include/Factory.h
@@ -75,7 +75,7 @@ public:
                   class_name);
 
         Entry & entry = it->second;
-        Parameters * ips = new Parameters((*entry.params_ptr)());
+        auto * ips = new Parameters((*entry.params_ptr)());
         params.push_back(ips);
         return ips;
     }

--- a/include/Factory.h
+++ b/include/Factory.h
@@ -71,7 +71,7 @@ public:
     {
         auto it = classes.find(class_name);
         if (it == classes.end())
-            error("Getting valid_params for object '%s' failed.  Object is not registred.",
+            error("Getting valid_params for object '%s' failed.  Object is not registered.",
                   class_name);
 
         Entry & entry = it->second;

--- a/include/FileOutput.h
+++ b/include/FileOutput.h
@@ -11,7 +11,7 @@ class FileOutput : public Output {
 public:
     FileOutput(const Parameters & params);
 
-    virtual void create() override;
+    void create() override;
 
     /// Get the file name with the output file produced by this outputter
     ///

--- a/include/FileOutput.h
+++ b/include/FileOutput.h
@@ -9,7 +9,7 @@ namespace godzilla {
 ///
 class FileOutput : public Output {
 public:
-    FileOutput(const Parameters & params);
+    explicit FileOutput(const Parameters & params);
 
     void create() override;
 

--- a/include/Function.h
+++ b/include/Function.h
@@ -9,7 +9,7 @@ namespace godzilla {
 ///
 class Function : public Object {
 public:
-    Function(const Parameters & params);
+    explicit Function(const Parameters & params);
 
     /// Register this function with the function parser
     ///

--- a/include/FunctionAuxiliaryField.h
+++ b/include/FunctionAuxiliaryField.h
@@ -12,11 +12,10 @@ class FunctionAuxiliaryField : public AuxiliaryField, public FunctionInterface {
 public:
     FunctionAuxiliaryField(const Parameters & params);
 
-    virtual void create();
-    virtual PetscInt get_num_components() const;
-    virtual PetscFunc * get_func() const;
-    virtual void
-    evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc, PetscScalar u[]);
+    void create() override;
+    PetscInt get_num_components() const override;
+    PetscFunc * get_func() const override;
+    void evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc, PetscScalar u[]);
 
 public:
     static Parameters parameters();

--- a/include/FunctionAuxiliaryField.h
+++ b/include/FunctionAuxiliaryField.h
@@ -10,7 +10,7 @@ namespace godzilla {
 ///
 class FunctionAuxiliaryField : public AuxiliaryField, public FunctionInterface {
 public:
-    FunctionAuxiliaryField(const Parameters & params);
+    explicit FunctionAuxiliaryField(const Parameters & params);
 
     void create() override;
     PetscInt get_num_components() const override;

--- a/include/FunctionEvaluator.h
+++ b/include/FunctionEvaluator.h
@@ -31,7 +31,7 @@ public:
 
     /// Register user function with function evaluator
     ///
-    /// @param fn Fuction to register
+    /// @param fn Function to register
     void register_function(Function * fn);
 
     /// Evaluate the function expression at time `time` and spatial position `x`

--- a/include/FunctionIC.h
+++ b/include/FunctionIC.h
@@ -9,7 +9,7 @@ namespace godzilla {
 ///
 class FunctionIC : public InitialCondition, public FunctionInterface {
 public:
-    FunctionIC(const Parameters & params);
+    explicit FunctionIC(const Parameters & params);
 
     void create() override;
     PetscInt get_num_components() const override;

--- a/include/FunctionIC.h
+++ b/include/FunctionIC.h
@@ -11,14 +11,14 @@ class FunctionIC : public InitialCondition, public FunctionInterface {
 public:
     FunctionIC(const Parameters & params);
 
-    virtual void create() override;
-    virtual PetscInt get_num_components() const override;
+    void create() override;
+    PetscInt get_num_components() const override;
 
-    virtual void evaluate(PetscInt dim,
-                          PetscReal time,
-                          const PetscReal x[],
-                          PetscInt Nc,
-                          PetscScalar u[]) override;
+    void evaluate(PetscInt dim,
+                  PetscReal time,
+                  const PetscReal x[],
+                  PetscInt Nc,
+                  PetscScalar u[]) override;
 
 public:
     static Parameters parameters();

--- a/include/FunctionInterface.h
+++ b/include/FunctionInterface.h
@@ -12,7 +12,7 @@ class App;
 ///
 class FunctionInterface {
 public:
-    FunctionInterface(const Parameters & params);
+    explicit FunctionInterface(const Parameters & params);
 
     /// Build the evaluator
     void create();

--- a/include/GYMLFile.h
+++ b/include/GYMLFile.h
@@ -11,7 +11,7 @@ class App;
 ///
 class GYMLFile : public InputFile {
 public:
-    GYMLFile(const App * app);
+    explicit GYMLFile(const App * app);
 
     void build() override;
 

--- a/include/GYMLFile.h
+++ b/include/GYMLFile.h
@@ -13,7 +13,7 @@ class GYMLFile : public InputFile {
 public:
     GYMLFile(const App * app);
 
-    virtual void build() override;
+    void build() override;
 
 protected:
     void build_functions();

--- a/include/HDF5Output.h
+++ b/include/HDF5Output.h
@@ -28,7 +28,7 @@ namespace godzilla {
 class HDF5Output : public FileOutput {
 public:
     explicit HDF5Output(const Parameters & params);
-    virtual ~HDF5Output();
+    ~HDF5Output() override;
 
     std::string get_file_ext() const override;
     void create() override;

--- a/include/HDF5Output.h
+++ b/include/HDF5Output.h
@@ -27,7 +27,7 @@ namespace godzilla {
 ///
 class HDF5Output : public FileOutput {
 public:
-    HDF5Output(const Parameters & params);
+    explicit HDF5Output(const Parameters & params);
     virtual ~HDF5Output();
 
     std::string get_file_ext() const override;

--- a/include/HDF5Output.h
+++ b/include/HDF5Output.h
@@ -30,10 +30,10 @@ public:
     HDF5Output(const Parameters & params);
     virtual ~HDF5Output();
 
-    virtual std::string get_file_ext() const override;
-    virtual void create() override;
-    virtual void check() override;
-    virtual void output_step() override;
+    std::string get_file_ext() const override;
+    void create() override;
+    void check() override;
+    void output_step() override;
 
 protected:
     /// Viewer for the output

--- a/include/ImplicitFENonlinearProblem.h
+++ b/include/ImplicitFENonlinearProblem.h
@@ -7,7 +7,7 @@ namespace godzilla {
 
 class ImplicitFENonlinearProblem : public FENonlinearProblem, public TransientProblemInterface {
 public:
-    ImplicitFENonlinearProblem(const Parameters & params);
+    explicit ImplicitFENonlinearProblem(const Parameters & params);
     virtual ~ImplicitFENonlinearProblem();
 
     void create() override;

--- a/include/ImplicitFENonlinearProblem.h
+++ b/include/ImplicitFENonlinearProblem.h
@@ -8,7 +8,7 @@ namespace godzilla {
 class ImplicitFENonlinearProblem : public FENonlinearProblem, public TransientProblemInterface {
 public:
     explicit ImplicitFENonlinearProblem(const Parameters & params);
-    virtual ~ImplicitFENonlinearProblem();
+    ~ImplicitFENonlinearProblem() override;
 
     void create() override;
     void check() override;

--- a/include/ImplicitFENonlinearProblem.h
+++ b/include/ImplicitFENonlinearProblem.h
@@ -10,16 +10,16 @@ public:
     ImplicitFENonlinearProblem(const Parameters & params);
     virtual ~ImplicitFENonlinearProblem();
 
-    virtual void create() override;
-    virtual void check() override;
-    virtual bool converged() override;
-    virtual void solve() override;
+    void create() override;
+    void check() override;
+    bool converged() override;
+    void solve() override;
 
 protected:
-    virtual void init() override;
-    virtual void set_up_callbacks() override;
-    virtual void set_up_time_scheme() override;
-    virtual void set_up_monitors() override;
+    void init() override;
+    void set_up_callbacks() override;
+    void set_up_time_scheme() override;
+    void set_up_monitors() override;
 
     /// Time stepping scheme
     const std::string & scheme;

--- a/include/InitialCondition.h
+++ b/include/InitialCondition.h
@@ -14,7 +14,7 @@ class InitialCondition : public Object, public PrintInterface {
 public:
     explicit InitialCondition(const Parameters & params);
 
-    virtual void create();
+    void create() override;
     virtual PetscInt get_field_id() const;
     virtual PetscInt get_num_components() const = 0;
 

--- a/include/InitialCondition.h
+++ b/include/InitialCondition.h
@@ -12,7 +12,7 @@ class DiscreteProblemInterface;
 ///
 class InitialCondition : public Object, public PrintInterface {
 public:
-    InitialCondition(const Parameters & params);
+    explicit InitialCondition(const Parameters & params);
 
     virtual void create();
     virtual PetscInt get_field_id() const;

--- a/include/InputFile.h
+++ b/include/InputFile.h
@@ -19,7 +19,7 @@ class Function;
 ///
 class InputFile : public PrintInterface, public LoggingInterface {
 public:
-    InputFile(const App * app);
+    explicit InputFile(const App * app);
     virtual ~InputFile();
 
     /// Parse the YML file

--- a/include/InputFile.h
+++ b/include/InputFile.h
@@ -20,7 +20,7 @@ class Function;
 class InputFile : public PrintInterface, public LoggingInterface {
 public:
     explicit InputFile(const App * app);
-    virtual ~InputFile();
+    virtual ~InputFile() = default;
 
     /// Parse the YML file
     ///

--- a/include/JacobianFunc.h
+++ b/include/JacobianFunc.h
@@ -9,7 +9,7 @@ class FEProblemInterface;
 
 class JacobianFunc {
 public:
-    JacobianFunc(const FEProblemInterface * fepi);
+    explicit JacobianFunc(const FEProblemInterface * fepi);
 
     /// Evaluate this Jacobian function
     ///

--- a/include/L2Diff.h
+++ b/include/L2Diff.h
@@ -9,7 +9,7 @@ namespace godzilla {
 ///
 class L2Diff : public Postprocessor, public FunctionInterface {
 public:
-    L2Diff(const Parameters & params);
+    explicit L2Diff(const Parameters & params);
 
     void create() override;
     void compute() override;

--- a/include/L2Diff.h
+++ b/include/L2Diff.h
@@ -11,9 +11,9 @@ class L2Diff : public Postprocessor, public FunctionInterface {
 public:
     L2Diff(const Parameters & params);
 
-    virtual void create() override;
-    virtual void compute() override;
-    virtual PetscReal get_value() override;
+    void create() override;
+    void compute() override;
+    PetscReal get_value() override;
 
     /// Evaluate the function 'u'
     ///
@@ -22,8 +22,7 @@ public:
     /// @param x The coordinates
     /// @param Nc The number of components
     /// @param u  The output field values
-    virtual void
-    evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc, PetscScalar u[]);
+    void evaluate(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt nc, PetscScalar u[]);
 
 protected:
     /// Computed L_2 error

--- a/include/L2FieldDiff.h
+++ b/include/L2FieldDiff.h
@@ -13,7 +13,7 @@ class ParsedFunction;
 ///
 class L2FieldDiff : public Postprocessor {
 public:
-    L2FieldDiff(const Parameters & params);
+    explicit L2FieldDiff(const Parameters & params);
 
     void create() override;
     void compute() override;

--- a/include/L2FieldDiff.h
+++ b/include/L2FieldDiff.h
@@ -15,9 +15,9 @@ class L2FieldDiff : public Postprocessor {
 public:
     L2FieldDiff(const Parameters & params);
 
-    virtual void create() override;
-    virtual void compute() override;
-    virtual PetscReal get_value() override;
+    void create() override;
+    void compute() override;
+    PetscReal get_value() override;
 
 protected:
     /// FE problem

--- a/include/LineMesh.h
+++ b/include/LineMesh.h
@@ -13,17 +13,17 @@ public:
     /// Get the lower bound in x-direction
     ///
     /// @return Lower bound in x-direction
-    PetscReal get_x_min();
+    PetscReal get_x_min() const;
 
     /// Get the upper bound in x-direction
     ///
     /// @return Upper bound in x-direction
-    PetscReal get_x_max();
+    PetscReal get_x_max() const;
 
     /// Get the number of divisions in the x-direction
     ///
     /// @return Number of divisions in the x-direction
-    PetscInt get_nx();
+    PetscInt get_nx() const;
 
 protected:
     void create_dm() override;

--- a/include/LineMesh.h
+++ b/include/LineMesh.h
@@ -26,7 +26,7 @@ public:
     PetscInt get_nx();
 
 protected:
-    virtual void create_dm() override;
+    void create_dm() override;
 
     /// Minimum in the x direction
     const PetscReal & xmin;

--- a/include/LineMesh.h
+++ b/include/LineMesh.h
@@ -34,8 +34,6 @@ protected:
     const PetscReal & xmax;
     /// Number of mesh point in the x direction
     const PetscInt & nx;
-    /// True for simplices, False for tensor cells
-    PetscBool simplex;
     /// create intermediate mesh pieces (edges, faces)
     PetscBool interpolate;
 

--- a/include/LineMesh.h
+++ b/include/LineMesh.h
@@ -8,7 +8,7 @@ namespace godzilla {
 ///
 class LineMesh : public UnstructuredMesh {
 public:
-    LineMesh(const Parameters & parameters);
+    explicit LineMesh(const Parameters & parameters);
 
     /// Get the lower bound in x-direction
     ///

--- a/include/LinearInterpolation.h
+++ b/include/LinearInterpolation.h
@@ -11,13 +11,13 @@ class LinearInterpolation {
 public:
     /// Construct an empty linear interpolation object
     LinearInterpolation();
-    /// COnstruct interpolation object by providing independent and dependent values
+    /// Construct interpolation object by providing independent and dependent values
     ///
     /// @param x Independent values
     /// @param y Dependent values
     LinearInterpolation(const std::vector<PetscReal> & x, const std::vector<PetscReal> & y);
 
-    /// Create the interpolation object by providin independent and dependent values
+    /// Create the interpolation object by providing independent and dependent values
     ///
     /// @param x Independent values
     /// @param y Dependent values

--- a/include/LinearProblem.h
+++ b/include/LinearProblem.h
@@ -9,7 +9,7 @@ namespace godzilla {
 ///
 class LinearProblem : public Problem {
 public:
-    LinearProblem(const Parameters & parameters);
+    explicit LinearProblem(const Parameters & parameters);
     virtual ~LinearProblem();
 
     void create() override;

--- a/include/LinearProblem.h
+++ b/include/LinearProblem.h
@@ -12,15 +12,15 @@ public:
     LinearProblem(const Parameters & parameters);
     virtual ~LinearProblem();
 
-    virtual void create() override;
-    virtual void solve() override;
-    virtual void run() override;
-    virtual bool converged() override;
-    virtual Vec get_solution_vector() const override;
+    void create() override;
+    void solve() override;
+    void run() override;
+    bool converged() override;
+    Vec get_solution_vector() const override;
 
 protected:
     /// provide DM for the underlying KSP object
-    virtual DM get_dm() const override;
+    DM get_dm() const override;
     /// Initialize the problem
     virtual void init();
     /// Allocate Jacobian/residual objects

--- a/include/LinearProblem.h
+++ b/include/LinearProblem.h
@@ -10,7 +10,7 @@ namespace godzilla {
 class LinearProblem : public Problem {
 public:
     explicit LinearProblem(const Parameters & parameters);
-    virtual ~LinearProblem();
+    ~LinearProblem() override;
 
     void create() override;
     void solve() override;

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -11,7 +11,6 @@ namespace godzilla {
 class Mesh : public Object, public PrintInterface {
 public:
     explicit Mesh(const Parameters & parameters);
-    virtual ~Mesh();
 
     virtual DM get_dm() const = 0;
 

--- a/include/Mesh.h
+++ b/include/Mesh.h
@@ -10,7 +10,7 @@ namespace godzilla {
 ///
 class Mesh : public Object, public PrintInterface {
 public:
-    Mesh(const Parameters & parameters);
+    explicit Mesh(const Parameters & parameters);
     virtual ~Mesh();
 
     virtual DM get_dm() const = 0;

--- a/include/MeshPartitioningOutput.h
+++ b/include/MeshPartitioningOutput.h
@@ -10,9 +10,9 @@ class MeshPartitioningOutput : public FileOutput {
 public:
     MeshPartitioningOutput(const Parameters & params);
 
-    virtual void check() override;
-    virtual std::string get_file_ext() const override;
-    virtual void output_step() override;
+    void check() override;
+    std::string get_file_ext() const override;
+    void output_step() override;
 
 public:
     static Parameters parameters();

--- a/include/MeshPartitioningOutput.h
+++ b/include/MeshPartitioningOutput.h
@@ -8,7 +8,7 @@ namespace godzilla {
 ///
 class MeshPartitioningOutput : public FileOutput {
 public:
-    MeshPartitioningOutput(const Parameters & params);
+    explicit MeshPartitioningOutput(const Parameters & params);
 
     void check() override;
     std::string get_file_ext() const override;

--- a/include/NaturalBC.h
+++ b/include/NaturalBC.h
@@ -12,7 +12,7 @@ class BndJacobianFunc;
 /// Base class for natural boundary conditions
 class NaturalBC : public BoundaryCondition {
 public:
-    NaturalBC(const Parameters & params);
+    explicit NaturalBC(const Parameters & params);
 
     /// Set up the weak form for the boundary integral of this boundary condition
     virtual void set_up_weak_form() = 0;

--- a/include/NaturalBC.h
+++ b/include/NaturalBC.h
@@ -37,7 +37,7 @@ protected:
                             BndJacobianFunc * g2,
                             BndJacobianFunc * g3);
 
-    virtual void add_boundary() override;
+    void add_boundary() override;
 
     /// WeakForm object
     WeakForm * wf;

--- a/include/NaturalRiemannBC.h
+++ b/include/NaturalRiemannBC.h
@@ -24,7 +24,7 @@ public:
                           PetscScalar * xG) = 0;
 
 protected:
-    virtual void add_boundary() override;
+    void add_boundary() override;
 
     /// Boundary number
     PetscInt bd;

--- a/include/NaturalRiemannBC.h
+++ b/include/NaturalRiemannBC.h
@@ -8,7 +8,7 @@ namespace godzilla {
 /// Base class for natural Riemann boundary conditions
 class NaturalRiemannBC : public BoundaryCondition {
 public:
-    NaturalRiemannBC(const Parameters & params);
+    explicit NaturalRiemannBC(const Parameters & params);
 
     /// Evaluate the boundary condition
     ///

--- a/include/NonlinearProblem.h
+++ b/include/NonlinearProblem.h
@@ -10,7 +10,7 @@ namespace godzilla {
 class NonlinearProblem : public Problem {
 public:
     explicit NonlinearProblem(const Parameters & parameters);
-    virtual ~NonlinearProblem();
+    ~NonlinearProblem() override;
 
     void create() override;
     void check() override;

--- a/include/NonlinearProblem.h
+++ b/include/NonlinearProblem.h
@@ -12,16 +12,16 @@ public:
     NonlinearProblem(const Parameters & parameters);
     virtual ~NonlinearProblem();
 
-    virtual void create() override;
-    virtual void check() override;
-    virtual void run() override;
-    virtual void solve() override;
-    virtual bool converged() override;
+    void create() override;
+    void check() override;
+    void run() override;
+    void solve() override;
+    bool converged() override;
     Vec get_solution_vector() const override;
 
 protected:
     /// provide DM for the underlying SNES object
-    virtual DM get_dm() const override;
+    DM get_dm() const override;
     /// Initialize the problem
     virtual void init();
     /// Set up initial guess

--- a/include/NonlinearProblem.h
+++ b/include/NonlinearProblem.h
@@ -9,7 +9,7 @@ namespace godzilla {
 ///
 class NonlinearProblem : public Problem {
 public:
-    NonlinearProblem(const Parameters & parameters);
+    explicit NonlinearProblem(const Parameters & parameters);
     virtual ~NonlinearProblem();
 
     void create() override;

--- a/include/Object.h
+++ b/include/Object.h
@@ -23,7 +23,7 @@ public:
 
     /// Get the name of the object
     /// @return The name of the object
-    virtual const std::string & get_name() const;
+    const std::string & get_name() const;
 
     /// Get the parameters of the object
     /// @return The parameters of the object

--- a/include/Object.h
+++ b/include/Object.h
@@ -14,7 +14,7 @@ class App;
 class Object : public LoggingInterface {
 public:
     /// Constructor for building the object via Factory
-    Object(const Parameters & parameters);
+    explicit Object(const Parameters & parameters);
     virtual ~Object();
 
     /// Get the type of this object.

--- a/include/Output.h
+++ b/include/Output.h
@@ -12,7 +12,7 @@ class Problem;
 ///
 class Output : public Object, public PrintInterface {
 public:
-    Output(const Parameters & params);
+    explicit Output(const Parameters & params);
 
     void create() override;
 

--- a/include/Output.h
+++ b/include/Output.h
@@ -14,7 +14,7 @@ class Output : public Object, public PrintInterface {
 public:
     Output(const Parameters & params);
 
-    virtual void create() override;
+    void create() override;
 
     /// Set execute mask
     ///

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -20,7 +20,7 @@ protected:
     /// Base class for parameter values
     class Value {
     public:
-        virtual ~Value() {}
+        virtual ~Value() = default;
 
         /// Return the type of this value as a string
         virtual std::string type() const = 0;
@@ -64,7 +64,7 @@ protected:
             return std::string(typeid(T).name());
         }
 
-        virtual Value *
+        Value *
         copy() const override
         {
             auto * copy = new Parameter<T>;

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -67,7 +67,7 @@ protected:
         virtual Value *
         copy() const override
         {
-            Parameter<T> * copy = new Parameter<T>;
+            auto * copy = new Parameter<T>;
             copy->value = this->value;
             copy->required = this->required;
             copy->doc_string = this->doc_string;
@@ -260,7 +260,7 @@ void
 Parameters::add_required_param(const std::string & name, const std::string & doc_string)
 {
     if (!this->has<T>(name)) {
-        Parameter<T> * param = new Parameter<T>;
+        auto * param = new Parameter<T>;
         param->required = true;
         param->is_private = false;
         param->doc_string = doc_string;
@@ -275,7 +275,7 @@ void
 Parameters::add_param(const std::string & name, const std::string & doc_string)
 {
     if (!this->has<T>(name)) {
-        Parameter<T> * param = new Parameter<T>;
+        auto * param = new Parameter<T>;
         param->required = false;
         param->is_private = false;
         param->doc_string = doc_string;
@@ -290,7 +290,7 @@ void
 Parameters::add_param(const std::string & name, const S & value, const std::string & doc_string)
 {
     if (!this->has<T>(name)) {
-        Parameter<T> * param = new Parameter<T>;
+        auto * param = new Parameter<T>;
         param->required = false;
         param->value = value;
         param->is_private = false;
@@ -305,7 +305,7 @@ template <typename T>
 void
 Parameters::add_private_param(const std::string & name, const T & value)
 {
-    Parameter<T> * param = new Parameter<T>;
+    auto * param = new Parameter<T>;
     param->value = value;
     param->required = false;
     param->is_private = true;

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -183,7 +183,7 @@ public:
         if (it != this->params.end())
             return it->second->doc_string;
         else
-            return std::string();
+            return {};
     }
 
     /// Parameter map iterator.

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -245,11 +245,6 @@ public:
     }
 
 private:
-    /// This method is called when adding a Parameter with a default value, can be specialized for
-    /// non-matching types.
-    template <typename T, typename S>
-    void set_param_helper(const std::string & name, T & l_value, const S & r_value);
-
     /// The actual parameter data. Each Metadata object contains attributes for the corresponding
     /// parameter.
     std::map<std::string, Value *> params;

--- a/include/ParsedFunction.h
+++ b/include/ParsedFunction.h
@@ -16,7 +16,7 @@ public:
     /// Register this function with the function parser
     ///
     /// @param parser The mu::Parser object we register this function with
-    virtual void register_callback(mu::Parser & parser);
+    void register_callback(mu::Parser & parser) override;
 
     /// Evaluate the function
     ///

--- a/include/ParsedFunction.h
+++ b/include/ParsedFunction.h
@@ -35,7 +35,7 @@ public:
     void * get_context();
 
 protected:
-    /// Text representation of the function to evaluate (one per compoent)
+    /// Text representation of the function to evaluate (one per component)
     const std::vector<std::string> & function;
     /// User defined constants
     const std::map<std::string, PetscReal> & constants;

--- a/include/ParsedFunction.h
+++ b/include/ParsedFunction.h
@@ -11,7 +11,7 @@ namespace godzilla {
 ///
 class ParsedFunction : public Function {
 public:
-    ParsedFunction(const Parameters & params);
+    explicit ParsedFunction(const Parameters & params);
 
     /// Register this function with the function parser
     ///

--- a/include/PiecewiseLinear.h
+++ b/include/PiecewiseLinear.h
@@ -11,7 +11,7 @@ namespace godzilla {
 /// User have to specify at least 2 points
 class PiecewiseLinear : public Function {
 public:
-    PiecewiseLinear(const Parameters & params);
+    explicit PiecewiseLinear(const Parameters & params);
 
     void register_callback(mu::Parser & parser) override;
 

--- a/include/PiecewiseLinear.h
+++ b/include/PiecewiseLinear.h
@@ -13,7 +13,7 @@ class PiecewiseLinear : public Function {
 public:
     PiecewiseLinear(const Parameters & params);
 
-    virtual void register_callback(mu::Parser & parser);
+    void register_callback(mu::Parser & parser) override;
 
     /// Evaluate this function at point 'x'
     PetscReal evaluate(PetscReal x);

--- a/include/Postprocessor.h
+++ b/include/Postprocessor.h
@@ -13,7 +13,7 @@ class Problem;
 ///
 class Postprocessor : public Object, public PrintInterface {
 public:
-    Postprocessor(const Parameters & params);
+    explicit Postprocessor(const Parameters & params);
     virtual ~Postprocessor();
 
     /// Compute the postprocessor value

--- a/include/Postprocessor.h
+++ b/include/Postprocessor.h
@@ -14,7 +14,6 @@ class Problem;
 class Postprocessor : public Object, public PrintInterface {
 public:
     explicit Postprocessor(const Parameters & params);
-    virtual ~Postprocessor();
 
     /// Compute the postprocessor value
     ///

--- a/include/PrintInterface.h
+++ b/include/PrintInterface.h
@@ -14,8 +14,8 @@ class App;
 ///
 class PrintInterface {
 public:
-    PrintInterface(const Object * obj);
-    PrintInterface(const App * app);
+    explicit PrintInterface(const Object * obj);
+    explicit PrintInterface(const App * app);
     PrintInterface(MPI_Comm comm, const unsigned int & verbosity_level, const std::string & prefix);
 
 protected:

--- a/include/Problem.h
+++ b/include/Problem.h
@@ -108,7 +108,7 @@ protected:
     /// List of postprocessor objects
     std::map<std::string, Postprocessor *> pps;
 
-    /// List of postprocesso names
+    /// List of postprocessor names
     std::vector<std::string> pps_names;
 
     /// Simulation time

--- a/include/Problem.h
+++ b/include/Problem.h
@@ -16,7 +16,7 @@ class Output;
 ///
 class Problem : public Object, public PrintInterface {
 public:
-    Problem(const Parameters & parameters);
+    explicit Problem(const Parameters & parameters);
     virtual ~Problem();
 
     void check() override;

--- a/include/Problem.h
+++ b/include/Problem.h
@@ -17,7 +17,6 @@ class Output;
 class Problem : public Object, public PrintInterface {
 public:
     explicit Problem(const Parameters & parameters);
-    virtual ~Problem();
 
     void check() override;
 
@@ -108,7 +107,8 @@ protected:
     /// List of postprocessor objects
     std::map<std::string, Postprocessor *> pps;
 
-    /// List of postprocessor names
+    /// List of
+    /// postprocessor names
     std::vector<std::string> pps_names;
 
     /// Simulation time

--- a/include/Problem.h
+++ b/include/Problem.h
@@ -19,10 +19,10 @@ public:
     Problem(const Parameters & parameters);
     virtual ~Problem();
 
-    virtual void check() override;
+    void check() override;
 
     /// Build the problem to solve
-    virtual void create() override;
+    void create() override;
     /// Run the problem
     virtual void run() = 0;
     /// Solve the problem

--- a/include/RectangleMesh.h
+++ b/include/RectangleMesh.h
@@ -22,7 +22,7 @@ public:
     PetscInt get_ny() const;
 
 protected:
-    virtual void create_dm() override;
+    void create_dm() override;
 
     /// Minimum in the x direction
     const PetscReal & xmin;

--- a/include/RectangleMesh.h
+++ b/include/RectangleMesh.h
@@ -8,7 +8,7 @@ namespace godzilla {
 ///
 class RectangleMesh : public UnstructuredMesh {
 public:
-    RectangleMesh(const Parameters & parameters);
+    explicit RectangleMesh(const Parameters & parameters);
 
     ///
     PetscInt get_x_min() const;

--- a/include/RectangleMesh.h
+++ b/include/RectangleMesh.h
@@ -11,13 +11,13 @@ public:
     explicit RectangleMesh(const Parameters & parameters);
 
     ///
-    PetscInt get_x_min() const;
-    PetscInt get_x_max() const;
+    PetscReal get_x_min() const;
+    PetscReal get_x_max() const;
     /// Get the number of mesh points in x direction
     PetscInt get_nx() const;
     ///
-    PetscInt get_y_min() const;
-    PetscInt get_y_max() const;
+    PetscReal get_y_min() const;
+    PetscReal get_y_max() const;
     /// Get the number of mesh points in y direction
     PetscInt get_ny() const;
 

--- a/include/ResidualFunc.h
+++ b/include/ResidualFunc.h
@@ -9,7 +9,7 @@ class FEProblemInterface;
 
 class ResidualFunc {
 public:
-    ResidualFunc(const FEProblemInterface * fepi);
+    explicit ResidualFunc(const FEProblemInterface * fepi);
 
     /// Evaluate this residual function
     ///

--- a/include/Terminal.h
+++ b/include/Terminal.h
@@ -16,7 +16,7 @@ public:
     ///
     /// @param aclr Control characters representing the color
     struct Color {
-        Color(const char * aclr) : str(nullptr)
+        explicit Color(const char * aclr) : str(nullptr)
         {
             if (has_colors())
                 this->str = aclr;

--- a/include/TimeSteppingAdaptor.h
+++ b/include/TimeSteppingAdaptor.h
@@ -11,7 +11,7 @@ class TransientProblemInterface;
 ///
 class TimeSteppingAdaptor : public Object {
 public:
-    TimeSteppingAdaptor(const Parameters & params);
+    explicit TimeSteppingAdaptor(const Parameters & params);
 
     void create() override;
 

--- a/include/TimeSteppingAdaptor.h
+++ b/include/TimeSteppingAdaptor.h
@@ -13,7 +13,7 @@ class TimeSteppingAdaptor : public Object {
 public:
     TimeSteppingAdaptor(const Parameters & params);
 
-    virtual void create() override;
+    void create() override;
 
     /// Get TSAdapt object
     ///

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -10,7 +10,7 @@ namespace godzilla {
 class UnstructuredMesh : public Mesh {
 public:
     explicit UnstructuredMesh(const Parameters & parameters);
-    virtual ~UnstructuredMesh();
+    ~UnstructuredMesh() override;
 
     DM get_dm() const override;
     void create() override;

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -9,7 +9,7 @@ namespace godzilla {
 ///
 class UnstructuredMesh : public Mesh {
 public:
-    UnstructuredMesh(const Parameters & parameters);
+    explicit UnstructuredMesh(const Parameters & parameters);
     virtual ~UnstructuredMesh();
 
     DM get_dm() const override;

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -13,7 +13,7 @@ public:
     virtual ~UnstructuredMesh();
 
     DM get_dm() const override;
-    virtual void create() override;
+    void create() override;
 
     /// Check if mesh has label with a name
     ///
@@ -120,7 +120,7 @@ public:
     /// @return Number of vertex sets
     PetscInt get_num_vertex_sets() const;
 
-    virtual void distribute() override;
+    void distribute() override;
 
     /// Construct ghost cells which connect to every boundary face
     ///

--- a/include/VTKOutput.h
+++ b/include/VTKOutput.h
@@ -17,7 +17,7 @@ namespace godzilla {
 /// ```
 class VTKOutput : public FileOutput {
 public:
-    VTKOutput(const Parameters & params);
+    explicit VTKOutput(const Parameters & params);
     virtual ~VTKOutput();
 
     std::string get_file_ext() const override;

--- a/include/VTKOutput.h
+++ b/include/VTKOutput.h
@@ -20,10 +20,10 @@ public:
     VTKOutput(const Parameters & params);
     virtual ~VTKOutput();
 
-    virtual std::string get_file_ext() const override;
-    virtual void create() override;
-    virtual void check() override;
-    virtual void output_step() override;
+    std::string get_file_ext() const override;
+    void create() override;
+    void check() override;
+    void output_step() override;
 
 protected:
     /// Viewer for the output

--- a/include/VTKOutput.h
+++ b/include/VTKOutput.h
@@ -18,7 +18,7 @@ namespace godzilla {
 class VTKOutput : public FileOutput {
 public:
     explicit VTKOutput(const Parameters & params);
-    virtual ~VTKOutput();
+    ~VTKOutput() override;
 
     std::string get_file_ext() const override;
     void create() override;

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -15,6 +15,8 @@ App::App(const std::string & app_name, MPI_Comm comm) :
     PrintInterface(comm, this->verbosity_level, app_name),
     name(app_name),
     comm(comm),
+    comm_size(0),
+    comm_rank(0),
     args(app_name),
     input_file_arg("i", "input-file", "Input file to execute", false, "", "string"),
     verbose_arg("", "verbose", "Verbosity level", false, 1, "number"),

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -7,7 +7,7 @@
 #include "Error.h"
 #include "Utils.h"
 #include "Terminal.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -28,11 +28,6 @@ AuxiliaryField::AuxiliaryField(const Parameters & params) :
 {
 }
 
-AuxiliaryField::~AuxiliaryField()
-{
-    _F_;
-}
-
 void
 AuxiliaryField::create()
 {

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -23,6 +23,7 @@ AuxiliaryField::AuxiliaryField(const Parameters & params) :
     fepi(get_param<FEProblemInterface *>("_fepi")),
     field(get_param<std::string>("field")),
     region(get_param<std::string>("region")),
+    fid(-1),
     label(nullptr)
 {
 }

--- a/src/BndResidualFunc.cpp
+++ b/src/BndResidualFunc.cpp
@@ -10,6 +10,12 @@ BndResidualFunc::BndResidualFunc(const NaturalBC * nbc) :
 {
 }
 
+const FEProblemInterface *
+BndResidualFunc::get_fe_problem() const
+{
+    return this->fepi;
+}
+
 const PetscInt &
 BndResidualFunc::get_spatial_dimension() const
 {

--- a/src/BoundaryCondition.cpp
+++ b/src/BoundaryCondition.cpp
@@ -5,7 +5,7 @@
 #include "Problem.h"
 #include "DiscreteProblemInterface.h"
 #include "BoundaryCondition.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/BoundaryCondition.cpp
+++ b/src/BoundaryCondition.cpp
@@ -62,7 +62,7 @@ BoundaryCondition::create()
         this->fid = this->dpi->get_field_id(field_names[0]);
     }
     else if (field_names.size() > 1) {
-        const std::string & field_name = get_param<std::string>("field");
+        const auto & field_name = get_param<std::string>("field");
         if (field_name.length() > 0) {
             if (this->dpi->has_field_by_name(field_name))
                 this->fid = this->dpi->get_field_id(field_name);

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -47,14 +47,14 @@ BoxMesh::BoxMesh(const Parameters & parameters) :
         log_error("Parameter 'zmax' must be larger than 'zmin'.");
 }
 
-PetscInt
+PetscReal
 BoxMesh::get_x_min() const
 {
     _F_;
     return this->xmin;
 }
 
-PetscInt
+PetscReal
 BoxMesh::get_x_max() const
 {
     _F_;
@@ -68,14 +68,14 @@ BoxMesh::get_nx() const
     return this->nx;
 }
 
-PetscInt
+PetscReal
 BoxMesh::get_y_min() const
 {
     _F_;
     return this->ymin;
 }
 
-PetscInt
+PetscReal
 BoxMesh::get_y_max() const
 {
     _F_;
@@ -89,14 +89,14 @@ BoxMesh::get_ny() const
     return this->ny;
 }
 
-PetscInt
+PetscReal
 BoxMesh::get_z_min() const
 {
     _F_;
     return this->zmin;
 }
 
-PetscInt
+PetscReal
 BoxMesh::get_z_max() const
 {
     _F_;

--- a/src/CSVOutput.cpp
+++ b/src/CSVOutput.cpp
@@ -38,7 +38,7 @@ CSVOutput::create()
 
     this->pps_names = this->problem->get_postprocessor_names();
 
-    if (this->pps_names.size() > 0)
+    if (!this->pps_names.empty())
         open_file();
 }
 
@@ -53,7 +53,7 @@ void
 CSVOutput::output_step()
 {
     _F_;
-    if (this->pps_names.size() == 0)
+    if (this->pps_names.empty())
         return;
 
     lprintf(9, "Output to file: %s", this->file_name);

--- a/src/CSVOutput.cpp
+++ b/src/CSVOutput.cpp
@@ -5,8 +5,8 @@
 #include "Postprocessor.h"
 #include "Error.h"
 #include "fmt/printf.h"
-#include <string.h>
-#include <errno.h>
+#include <cstring>
+#include <cerrno>
 
 namespace godzilla {
 

--- a/src/CallStack.cpp
+++ b/src/CallStack.cpp
@@ -1,5 +1,5 @@
 #include "CallStack.h"
-#include <signal.h>
+#include <csignal>
 #include "petscsys.h"
 
 namespace godzilla {

--- a/src/CallStack.cpp
+++ b/src/CallStack.cpp
@@ -28,7 +28,7 @@ CallStack::Obj::~Obj()
     // remove the object only if it is on the top of the call stack
     if (callstack.size > 0 && callstack.stack[callstack.size - 1] == this) {
         callstack.size--;
-        callstack.stack[callstack.size] = NULL;
+        callstack.stack[callstack.size] = nullptr;
     }
 }
 

--- a/src/ConstantAuxiliaryField.cpp
+++ b/src/ConstantAuxiliaryField.cpp
@@ -16,7 +16,7 @@ constant_auxiliary_field(PetscInt dim,
                          PetscScalar u[],
                          void * ctx)
 {
-    ConstantAuxiliaryField * aux_fld = static_cast<ConstantAuxiliaryField *>(ctx);
+    auto * aux_fld = static_cast<ConstantAuxiliaryField *>(ctx);
     aux_fld->evaluate(dim, time, x, nc, u);
     return 0;
 }

--- a/src/ConstantAuxiliaryField.cpp
+++ b/src/ConstantAuxiliaryField.cpp
@@ -59,9 +59,9 @@ ConstantAuxiliaryField::get_func() const
 }
 
 void
-ConstantAuxiliaryField::evaluate(PetscInt dim,
-                                 PetscReal time,
-                                 const PetscReal x[],
+ConstantAuxiliaryField::evaluate(PetscInt,
+                                 PetscReal,
+                                 const PetscReal[],
                                  PetscInt nc,
                                  PetscScalar u[])
 {

--- a/src/ConstantAuxiliaryField.cpp
+++ b/src/ConstantAuxiliaryField.cpp
@@ -8,13 +8,13 @@ namespace godzilla {
 
 REGISTER_OBJECT(ConstantAuxiliaryField);
 
-PetscErrorCode
-__constant_auxiliary_field(PetscInt dim,
-                           PetscReal time,
-                           const PetscReal x[],
-                           PetscInt nc,
-                           PetscScalar u[],
-                           void * ctx)
+static PetscErrorCode
+constant_auxiliary_field(PetscInt dim,
+                         PetscReal time,
+                         const PetscReal x[],
+                         PetscInt nc,
+                         PetscScalar u[],
+                         void * ctx)
 {
     ConstantAuxiliaryField * aux_fld = static_cast<ConstantAuxiliaryField *>(ctx);
     aux_fld->evaluate(dim, time, x, nc, u);
@@ -55,7 +55,7 @@ ConstantAuxiliaryField::get_num_components() const
 PetscFunc *
 ConstantAuxiliaryField::get_func() const
 {
-    return __constant_auxiliary_field;
+    return constant_auxiliary_field;
 }
 
 void

--- a/src/ConstantAuxiliaryField.cpp
+++ b/src/ConstantAuxiliaryField.cpp
@@ -2,7 +2,7 @@
 #include "ConstantAuxiliaryField.h"
 #include "CallStack.h"
 #include "FEProblemInterface.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/DirichletBC.cpp
+++ b/src/DirichletBC.cpp
@@ -48,7 +48,7 @@ DirichletBC::get_components() const
 PetscFunc *
 DirichletBC::get_function_t()
 {
-    if (this->expression_t.size() > 0)
+    if (!this->expression_t.empty())
         return EssentialBC::get_function_t();
     else
         return nullptr;

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -185,7 +185,7 @@ void
 DiscreteProblemInterface::set_up_initial_guess()
 {
     _F_;
-    if (this->ics.size() > 0)
+    if (!this->ics.empty())
         set_initial_guess_from_ics();
     else
         set_zero_initial_guess();

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -207,7 +207,7 @@ DiscreteProblemInterface::build_local_solution_vector(Vec sln) const
     DM dm = this->unstr_mesh->get_dm();
     PetscReal time = this->problem->get_time();
     PETSC_CHECK(DMGlobalToLocal(dm, this->problem->get_solution_vector(), INSERT_VALUES, sln));
-    PETSC_CHECK(DMPlexInsertBoundaryValues(dm, PETSC_TRUE, sln, time, NULL, NULL, NULL));
+    PETSC_CHECK(DMPlexInsertBoundaryValues(dm, PETSC_TRUE, sln, time, nullptr, nullptr, nullptr));
 }
 
 } // namespace godzilla

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -32,8 +32,6 @@ DiscreteProblemInterface::DiscreteProblemInterface(Problem * problem, const Para
 {
 }
 
-DiscreteProblemInterface::~DiscreteProblemInterface() {}
-
 const UnstructuredMesh *
 DiscreteProblemInterface::get_mesh() const
 {

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -15,7 +15,7 @@ namespace godzilla {
 namespace internal {
 
 static PetscErrorCode
-zero_fn(PetscInt dim, PetscReal time, const PetscReal x[], PetscInt Nc, PetscScalar * u, void * ctx)
+zero_fn(PetscInt, PetscReal, const PetscReal[], PetscInt, PetscScalar * u, void *)
 {
     u[0] = 0.0;
     return 0;

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -8,7 +8,7 @@
 #include "Logger.h"
 #include "InitialCondition.h"
 #include "BoundaryCondition.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -22,7 +22,7 @@ terminate(int status)
 }
 
 void
-mem_check(int line, const char * func, const char * file, void * var)
+mem_check(int line, const char *, const char * file, void * var)
 {
     if (var == nullptr) {
         error_printf("Out of memory");

--- a/src/EssentialBC.cpp
+++ b/src/EssentialBC.cpp
@@ -13,7 +13,7 @@ essential_boundary_condition_function(PetscInt dim,
                                       void * ctx)
 {
     _F_;
-    EssentialBC * bc = static_cast<EssentialBC *>(ctx);
+    auto * bc = static_cast<EssentialBC *>(ctx);
     assert(bc != nullptr);
     bc->evaluate(dim, time, x, nc, u);
     return 0;
@@ -28,7 +28,7 @@ essential_boundary_condition_function_t(PetscInt dim,
                                         void * ctx)
 {
     _F_;
-    EssentialBC * bc = static_cast<EssentialBC *>(ctx);
+    auto * bc = static_cast<EssentialBC *>(ctx);
     assert(bc != nullptr);
     bc->evaluate_t(dim, time, x, nc, u);
     return 0;

--- a/src/EssentialBC.cpp
+++ b/src/EssentialBC.cpp
@@ -1,6 +1,6 @@
 #include "EssentialBC.h"
 #include "CallStack.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/EssentialBC.cpp
+++ b/src/EssentialBC.cpp
@@ -5,12 +5,12 @@
 namespace godzilla {
 
 static PetscErrorCode
-__essential_boundary_condition_function(PetscInt dim,
-                                        PetscReal time,
-                                        const PetscReal x[],
-                                        PetscInt nc,
-                                        PetscScalar u[],
-                                        void * ctx)
+essential_boundary_condition_function(PetscInt dim,
+                                      PetscReal time,
+                                      const PetscReal x[],
+                                      PetscInt nc,
+                                      PetscScalar u[],
+                                      void * ctx)
 {
     _F_;
     EssentialBC * bc = static_cast<EssentialBC *>(ctx);
@@ -20,12 +20,12 @@ __essential_boundary_condition_function(PetscInt dim,
 }
 
 static PetscErrorCode
-__essential_boundary_condition_function_t(PetscInt dim,
-                                          PetscReal time,
-                                          const PetscReal x[],
-                                          PetscInt nc,
-                                          PetscScalar u[],
-                                          void * ctx)
+essential_boundary_condition_function_t(PetscInt dim,
+                                        PetscReal time,
+                                        const PetscReal x[],
+                                        PetscInt nc,
+                                        PetscScalar u[],
+                                        void * ctx)
 {
     _F_;
     EssentialBC * bc = static_cast<EssentialBC *>(ctx);
@@ -50,14 +50,14 @@ PetscFunc *
 EssentialBC::get_function()
 {
     _F_;
-    return __essential_boundary_condition_function;
+    return essential_boundary_condition_function;
 }
 
 PetscFunc *
 EssentialBC::get_function_t()
 {
     _F_;
-    return __essential_boundary_condition_function_t;
+    return essential_boundary_condition_function_t;
 }
 
 void *

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -78,7 +78,7 @@ ExodusIIOutput::create()
     auto flds = this->dpi->get_field_names();
     auto & pps = this->problem->get_postprocessor_names();
 
-    if (this->variable_names.size() == 0) {
+    if (this->variable_names.empty()) {
         this->field_var_names = flds;
         this->global_var_names = pps;
     }

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -429,7 +429,7 @@ ExodusIIOutput::write_face_sets()
         for (PetscInt i = 0; i < face_set_size; ++i) {
             // Element
             PetscInt num_points;
-            PetscInt * points = NULL;
+            PetscInt * points = nullptr;
             PETSC_CHECK(
                 DMPlexGetTransitiveClosure(dm, faces[i], PETSC_FALSE, &num_points, &points));
 
@@ -442,7 +442,7 @@ ExodusIIOutput::write_face_sets()
                 DMPlexRestoreTransitiveClosure(dm, faces[i], PETSC_FALSE, &num_points, &points));
 
             // Side
-            points = NULL;
+            points = nullptr;
             PETSC_CHECK(DMPlexGetTransitiveClosure(dm, el, PETSC_TRUE, &num_points, &points));
 
             for (PetscInt j = 1; j < num_points; ++j) {
@@ -669,7 +669,7 @@ ExodusIIOutput::write_block_connectivity(int blk_id, int n_elems_in_block, const
         else
             elem_id = cells[i];
         PetscInt closure_size;
-        PetscInt * closure = NULL;
+        PetscInt * closure = nullptr;
         PETSC_CHECK(DMPlexGetTransitiveClosure(dm, elem_id, PETSC_TRUE, &closure_size, &closure));
         for (PetscInt k = 0; k < n_nodes_per_elem; k++, j++) {
             PetscInt l = 2 * (closure_size - n_nodes_per_elem + ordering[k]);

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -10,7 +10,7 @@
 #include "fmt/printf.h"
 #include "fmt/format.h"
 #include "fmt/chrono.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -52,7 +52,7 @@ std::string
 ExodusIIOutput::get_file_ext() const
 {
     _F_;
-    return std::string("exo");
+    return { "exo" };
 }
 
 void

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -128,11 +128,11 @@ ExplicitFELinearProblem::set_up_time_scheme()
 {
     _F_;
     std::string sch = utils::to_lower(this->scheme);
-    if (sch.compare("euler") == 0)
+    if (sch == "euler")
         PETSC_CHECK(TSSetType(this->ts, TSEULER));
-    else if (sch.compare("ssp") == 0)
+    else if (sch == "ssp")
         PETSC_CHECK(TSSetType(this->ts, TSSSP));
-    else if (sch.compare("rk") == 0)
+    else if (sch == "rk")
         PETSC_CHECK(TSSetType(this->ts, TSRK));
 }
 

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -114,11 +114,11 @@ ExplicitFVLinearProblem::set_up_time_scheme()
 {
     _F_;
     std::string sch = utils::to_lower(this->scheme);
-    if (sch.compare("euler") == 0)
+    if (sch == "euler")
         PETSC_CHECK(TSSetType(this->ts, TSEULER));
-    else if (sch.compare("ssp") == 0)
+    else if (sch == "ssp")
         PETSC_CHECK(TSSetType(this->ts, TSSSP));
-    else if (sch.compare("rk") == 0)
+    else if (sch == "rk")
         PETSC_CHECK(TSSetType(this->ts, TSRK));
 }
 

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -37,7 +37,7 @@ PetscErrorCode
 __fep_compute_residual(DM dm, Vec x, Vec F, void * user)
 {
     _F_;
-    FENonlinearProblem * fep = static_cast<FENonlinearProblem *>(user);
+    auto * fep = static_cast<FENonlinearProblem *>(user);
     fep->compute_residual_callback(x, F);
     return 0;
 }
@@ -46,7 +46,7 @@ PetscErrorCode
 __fep_compute_jacobian(DM dm, Vec x, Mat J, Mat Jp, void * user)
 {
     _F_;
-    FENonlinearProblem * fep = static_cast<FENonlinearProblem *>(user);
+    auto * fep = static_cast<FENonlinearProblem *>(user);
     fep->compute_jacobian_callback(x, J, Jp);
     return 0;
 }

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -65,8 +65,6 @@ FENonlinearProblem::FENonlinearProblem(const Parameters & parameters) :
     _F_;
 }
 
-FENonlinearProblem::~FENonlinearProblem() {}
-
 void
 FENonlinearProblem::create()
 {

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -34,7 +34,7 @@ __dummy_jacobian_func(PetscInt,
 } // namespace internal
 
 PetscErrorCode
-__fep_compute_residual(DM dm, Vec x, Vec F, void * user)
+__fep_compute_residual(DM, Vec x, Vec F, void * user)
 {
     _F_;
     auto * fep = static_cast<FENonlinearProblem *>(user);
@@ -43,7 +43,7 @@ __fep_compute_residual(DM dm, Vec x, Vec F, void * user)
 }
 
 PetscErrorCode
-__fep_compute_jacobian(DM dm, Vec x, Mat J, Mat Jp, void * user)
+__fep_compute_jacobian(DM, Vec x, Mat J, Mat Jp, void * user)
 {
     _F_;
     auto * fep = static_cast<FENonlinearProblem *>(user);

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -92,7 +92,7 @@ FEProblemInterface::init()
 
     set_up_weak_form();
     for (auto & bc : this->bcs) {
-        NaturalBC * nbc = dynamic_cast<NaturalBC *>(bc);
+        auto * nbc = dynamic_cast<NaturalBC *>(bc);
         if (nbc)
             nbc->set_up_weak_form();
     }
@@ -405,7 +405,7 @@ FEProblemInterface::compute_global_aux_fields(DM dm,
 {
     _F_;
     PetscInt n_auxs = this->aux_fields.size();
-    PetscFunc ** func = new PetscFunc *[n_auxs];
+    auto ** func = new PetscFunc *[n_auxs];
     void ** ctxs = new void *[n_auxs];
     for (PetscInt i = 0; i < n_auxs; i++) {
         func[i] = nullptr;
@@ -433,7 +433,7 @@ FEProblemInterface::compute_label_aux_fields(DM dm,
 {
     _F_;
     PetscInt n_auxs = this->aux_fields.size();
-    PetscFunc ** func = new PetscFunc *[n_auxs];
+    auto ** func = new PetscFunc *[n_auxs];
     void ** ctxs = new void *[n_auxs];
     for (PetscInt i = 0; i < n_auxs; i++) {
         func[i] = nullptr;

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -14,7 +14,7 @@
 #include "BndResidualFunc.h"
 #include "JacobianFunc.h"
 #include "BndJacobianFunc.h"
-#include <assert.h>
+#include <cassert>
 #include <petsc/private/petscfeimpl.h>
 
 namespace godzilla {

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -385,7 +385,7 @@ void
 FEProblemInterface::set_up_quadrature()
 {
     _F_;
-    assert(this->fields.size() > 0);
+    assert(!this->fields.empty());
     auto first = this->fields.begin();
     FieldInfo & first_fi = first->second;
     for (auto it = ++first; it != this->fields.end(); ++it) {
@@ -492,7 +492,7 @@ void
 FEProblemInterface::set_up_auxiliary_dm(DM dm)
 {
     _F_;
-    if (this->aux_fields.size() == 0)
+    if (this->aux_fields.empty())
         return;
 
     PETSC_CHECK(DMClone(dm, &this->dm_aux));
@@ -671,7 +671,7 @@ FEProblemInterface::integrate_residual(PetscDS ds,
     PetscInt field = key.field;
     const auto & f0_res_fns = this->wf->get(PETSC_WF_F0, key.label, key.value, field, key.part);
     const auto & f1_res_fns = this->wf->get(PETSC_WF_F1, key.label, key.value, field, key.part);
-    if ((f0_res_fns.size() == 0) && (f1_res_fns.size() == 0))
+    if (f0_res_fns.empty() && f1_res_fns.empty())
         return 0;
 
     PetscFE & fe = this->fields[field].fe;
@@ -812,7 +812,7 @@ FEProblemInterface::integrate_bnd_residual(PetscDS ds,
         this->wf->get_bnd(PETSC_WF_BDF0, key.label, key.value, field, key.part);
     const auto & f1_res_fns =
         this->wf->get_bnd(PETSC_WF_BDF1, key.label, key.value, field, key.part);
-    if ((f0_res_fns.size() == 0) && (f1_res_fns.size() == 0))
+    if (f0_res_fns.empty() && f1_res_fns.empty())
         return 0;
 
     PetscFE & fe = this->fields[field].fe;
@@ -997,8 +997,7 @@ FEProblemInterface::integrate_jacobian(PetscDS ds,
         this->wf->get(kind2, key.label, key.value, field_i, field_j, key.part);
     const auto & g3_jac_fns =
         this->wf->get(kind3, key.label, key.value, field_i, field_j, key.part);
-    if ((g0_jac_fns.size() == 0) && (g1_jac_fns.size() == 0) && (g2_jac_fns.size() == 0) &&
-        (g3_jac_fns.size() == 0))
+    if (g0_jac_fns.empty() && g1_jac_fns.empty() && g2_jac_fns.empty() && g3_jac_fns.empty())
         return 0;
 
     PetscFE & fe_i = this->fields[field_i].fe;
@@ -1120,28 +1119,28 @@ FEProblemInterface::integrate_jacobian(PetscDS ds,
                                                 this->au,
                                                 this->au_x,
                                                 nullptr));
-            if (g0_jac_fns.size() > 0) {
+            if (!g0_jac_fns.empty()) {
                 PETSC_CHECK(PetscArrayzero(g0, n_comp_i * n_comp_j));
                 for (auto & func : g0_jac_fns)
                     func->evaluate(g0);
                 for (PetscInt c = 0; c < n_comp_i * n_comp_j; ++c)
                     g0[c] *= w;
             }
-            if (g1_jac_fns.size() > 0) {
+            if (!g1_jac_fns.empty()) {
                 PETSC_CHECK(PetscArrayzero(g1, n_comp_i * n_comp_j * dim_embed));
                 for (auto & func : g1_jac_fns)
                     func->evaluate(g1);
                 for (PetscInt c = 0; c < n_comp_i * n_comp_j * dim; ++c)
                     g1[c] *= w;
             }
-            if (g2_jac_fns.size() > 0) {
+            if (!g2_jac_fns.empty()) {
                 PETSC_CHECK(PetscArrayzero(g2, n_comp_i * n_comp_j * dim_embed));
                 for (auto & func : g2_jac_fns)
                     func->evaluate(g2);
                 for (PetscInt c = 0; c < n_comp_i * n_comp_j * dim; ++c)
                     g2[c] *= w;
             }
-            if (g3_jac_fns.size() > 0) {
+            if (!g3_jac_fns.empty()) {
                 PETSC_CHECK(PetscArrayzero(g3, n_comp_i * n_comp_j * dim_embed * dim_embed));
                 for (auto & func : g3_jac_fns)
                     func->evaluate(g3);
@@ -1206,8 +1205,7 @@ FEProblemInterface::integrate_bnd_jacobian(PetscDS ds,
         this->wf->get_bnd(PETSC_WF_BDG2, key.label, key.value, field_i, field_j, key.part);
     const auto & g3_jac_fns =
         this->wf->get_bnd(PETSC_WF_BDG3, key.label, key.value, field_i, field_j, key.part);
-    if ((g0_jac_fns.size() == 0) && (g1_jac_fns.size() == 0) && (g2_jac_fns.size() == 0) &&
-        (g3_jac_fns.size() == 0))
+    if (g0_jac_fns.empty() && g1_jac_fns.empty() && g2_jac_fns.empty() && g3_jac_fns.empty())
         return 0;
 
     PetscFE & fe_i = this->fields[field_i].fe;
@@ -1342,28 +1340,28 @@ FEProblemInterface::integrate_bnd_jacobian(PetscDS ds,
                                                 this->au_x,
                                                 nullptr));
 
-            if (g0_jac_fns.size() > 0) {
+            if (!g0_jac_fns.empty()) {
                 PETSC_CHECK(PetscArrayzero(g0, n_comp_i * n_comp_j));
                 for (auto & func : g0_jac_fns)
                     func->evaluate(g0);
                 for (PetscInt c = 0; c < n_comp_i * n_comp_j; ++c)
                     g0[c] *= w;
             }
-            if (g1_jac_fns.size() > 0) {
+            if (!g1_jac_fns.empty()) {
                 PETSC_CHECK(PetscArrayzero(g1, n_comp_i * n_comp_j * dim_embed));
                 for (auto & func : g1_jac_fns)
                     func->evaluate(g1);
                 for (PetscInt c = 0; c < n_comp_i * n_comp_j * this->dim; ++c)
                     g1[c] *= w;
             }
-            if (g2_jac_fns.size() > 0) {
+            if (!g2_jac_fns.empty()) {
                 PETSC_CHECK(PetscArrayzero(g2, n_comp_i * n_comp_j * dim_embed));
                 for (auto & func : g2_jac_fns)
                     func->evaluate(g2);
                 for (PetscInt c = 0; c < n_comp_i * n_comp_j * this->dim; ++c)
                     g2[c] *= w;
             }
-            if (g3_jac_fns.size() > 0) {
+            if (!g3_jac_fns.empty()) {
                 PETSC_CHECK(PetscArrayzero(g3, n_comp_i * n_comp_j * dim_embed * dim_embed));
                 for (auto & func : g3_jac_fns)
                     func->evaluate(g3);

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -4,7 +4,7 @@
 #include "UnstructuredMesh.h"
 #include "Problem.h"
 #include "Logger.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -140,7 +140,7 @@ FVProblemInterface::get_field_component_name(PetscInt fid, PetscInt component) c
     if (fid == 0) {
         const char * name;
         PETSC_CHECK(PetscFVGetComponentName(this->fvm, component, &name));
-        return std::string(name);
+        return { name };
     }
     else
         error("Multiple-field problems are not implemented");

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -8,7 +8,7 @@
 
 namespace godzilla {
 
-const std::string FVProblemInterface::empty_name("");
+const std::string FVProblemInterface::empty_name;
 
 void
 __compute_flux(PetscInt dim,

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -23,7 +23,7 @@ __compute_flux(PetscInt dim,
                void * ctx)
 {
     _F_;
-    FVProblemInterface * fvpi = static_cast<FVProblemInterface *>(ctx);
+    auto * fvpi = static_cast<FVProblemInterface *>(ctx);
     fvpi->compute_flux(dim, nf, x, n, uL, uR, n_consts, constants, flux);
 }
 

--- a/src/FileOutput.cpp
+++ b/src/FileOutput.cpp
@@ -29,7 +29,7 @@ FileOutput::create()
     Output::create();
     if (this->file_base.length() == 0) {
         std::filesystem::path input_file_name(get_app()->get_input_file_name());
-        this->file_base = input_file_name.stem().u8string().c_str();
+        this->file_base = input_file_name.stem().u8string();
     }
 }
 

--- a/src/FunctionAuxiliaryField.cpp
+++ b/src/FunctionAuxiliaryField.cpp
@@ -7,13 +7,13 @@ namespace godzilla {
 
 REGISTER_OBJECT(FunctionAuxiliaryField);
 
-PetscErrorCode
-__function_auxiliary_field(PetscInt dim,
-                           PetscReal time,
-                           const PetscReal x[],
-                           PetscInt nc,
-                           PetscScalar u[],
-                           void * ctx)
+static PetscErrorCode
+function_auxiliary_field(PetscInt dim,
+                         PetscReal time,
+                         const PetscReal x[],
+                         PetscInt nc,
+                         PetscScalar u[],
+                         void * ctx)
 {
     FunctionAuxiliaryField * func = static_cast<FunctionAuxiliaryField *>(ctx);
     func->evaluate(dim, time, x, nc, u);
@@ -52,7 +52,7 @@ FunctionAuxiliaryField::get_num_components() const
 PetscFunc *
 FunctionAuxiliaryField::get_func() const
 {
-    return __function_auxiliary_field;
+    return function_auxiliary_field;
 }
 
 void

--- a/src/FunctionAuxiliaryField.cpp
+++ b/src/FunctionAuxiliaryField.cpp
@@ -15,7 +15,7 @@ function_auxiliary_field(PetscInt dim,
                          PetscScalar u[],
                          void * ctx)
 {
-    FunctionAuxiliaryField * func = static_cast<FunctionAuxiliaryField *>(ctx);
+    auto * func = static_cast<FunctionAuxiliaryField *>(ctx);
     func->evaluate(dim, time, x, nc, u);
     return 0;
 }

--- a/src/FunctionEvaluator.cpp
+++ b/src/FunctionEvaluator.cpp
@@ -2,7 +2,7 @@
 #include "CallStack.h"
 #include "Function.h"
 #include "fmt/format.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/FunctionEvaluator.cpp
+++ b/src/FunctionEvaluator.cpp
@@ -45,7 +45,7 @@ PetscReal
 FunctionEvaluator::evaluate(PetscInt dim, PetscReal time, const PetscReal x[])
 {
     _F_;
-    PetscReal * xx = const_cast<PetscReal *>(x);
+    auto * xx = const_cast<PetscReal *>(x);
     PetscReal zero = 0.;
     try {
         this->parser.DefineVar("t", &time);
@@ -73,7 +73,7 @@ FunctionEvaluator::evaluate(PetscInt dim,
                             PetscReal u[])
 {
     _F_;
-    PetscReal * xx = const_cast<PetscReal *>(x);
+    auto * xx = const_cast<PetscReal *>(x);
     PetscReal zero = 0.;
     try {
         this->parser.DefineVar("t", &time);

--- a/src/FunctionInterface.cpp
+++ b/src/FunctionInterface.cpp
@@ -2,7 +2,7 @@
 #include "CallStack.h"
 #include "App.h"
 #include "Problem.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/GYMLFile.cpp
+++ b/src/GYMLFile.cpp
@@ -16,7 +16,7 @@
 #include "CallStack.h"
 #include "Validation.h"
 #include "Utils.h"
-#include "assert.h"
+#include "cassert"
 #include "fmt/format.h"
 #include "yaml-cpp/node/iterator.h"
 

--- a/src/GYMLFile.cpp
+++ b/src/GYMLFile.cpp
@@ -55,10 +55,10 @@ GYMLFile::build_functions()
 
     for (const auto & it : funcs_node) {
         YAML::Node fn_node = it.first;
-        std::string name = fn_node.as<std::string>();
+        auto name = fn_node.as<std::string>();
 
         Parameters * params = build_params(funcs_node, name);
-        const std::string & class_name = params->get<std::string>("_type");
+        const auto & class_name = params->get<std::string>("_type");
         auto fn = Factory::create<Function>(class_name, name, params);
         assert(this->problem != nullptr);
         this->problem->add_function(fn);
@@ -80,15 +80,14 @@ void
 GYMLFile::build_ts_adapt(const YAML::Node & problem_node)
 {
     _F_;
-    TransientProblemInterface * tpi = dynamic_cast<TransientProblemInterface *>(this->problem);
+    auto * tpi = dynamic_cast<TransientProblemInterface *>(this->problem);
     if (tpi != nullptr) {
         Parameters * params = build_params(problem_node, "ts_adapt");
         params->set<const Problem *>("_problem") = this->problem;
         params->set<const TransientProblemInterface *>("_tpi") = tpi;
 
-        const std::string & class_name = params->get<std::string>("_type");
-        TimeSteppingAdaptor * ts_adaptor =
-            Factory::create<TimeSteppingAdaptor>(class_name, "ts_adapt", params);
+        const auto & class_name = params->get<std::string>("_type");
+        auto * ts_adaptor = Factory::create<TimeSteppingAdaptor>(class_name, "ts_adapt", params);
         tpi->set_time_stepping_adaptor(ts_adaptor);
     }
     else
@@ -102,7 +101,7 @@ GYMLFile::build_partitioner()
     if (!this->mesh)
         return;
 
-    UnstructuredMesh * mesh = dynamic_cast<UnstructuredMesh *>(this->mesh);
+    auto * mesh = dynamic_cast<UnstructuredMesh *>(this->mesh);
     if (!mesh)
         return;
 
@@ -131,18 +130,18 @@ GYMLFile::build_auxiliary_fields()
 
     lprintf(9, "- auxiliary fields");
 
-    FEProblemInterface * fepface = dynamic_cast<FEProblemInterface *>(this->problem);
+    auto * fepface = dynamic_cast<FEProblemInterface *>(this->problem);
     if (fepface == nullptr)
         log_error("Supplied problem type '%s' does not support auxiliary fields.",
                   this->problem->get_type());
     else {
         for (const auto & it : auxs_root_node) {
             YAML::Node aux_node = it.first;
-            std::string name = aux_node.as<std::string>();
+            auto name = aux_node.as<std::string>();
 
             Parameters * params = build_params(auxs_root_node, name);
             params->set<FEProblemInterface *>("_fepi") = fepface;
-            const std::string & class_name = params->get<std::string>("_type");
+            const auto & class_name = params->get<std::string>("_type");
             auto aux = Factory::create<AuxiliaryField>(class_name, name, params);
             fepface->add_auxiliary_field(aux);
         }
@@ -159,18 +158,18 @@ GYMLFile::build_initial_conditions()
 
     lprintf(9, "- initial conditions");
 
-    DiscreteProblemInterface * dpi = dynamic_cast<DiscreteProblemInterface *>(this->problem);
+    auto * dpi = dynamic_cast<DiscreteProblemInterface *>(this->problem);
     if (dpi == nullptr)
         log_error("Supplied problem type '%s' does not support initial conditions.",
                   this->problem->get_type());
     else {
         for (const auto & it : ics_root_node) {
             YAML::Node ic_node = it.first;
-            std::string name = ic_node.as<std::string>();
+            auto name = ic_node.as<std::string>();
 
             Parameters * params = build_params(ics_root_node, name);
             params->set<const DiscreteProblemInterface *>("_dpi") = dpi;
-            const std::string & class_name = params->get<std::string>("_type");
+            const auto & class_name = params->get<std::string>("_type");
             auto ic = Factory::create<InitialCondition>(class_name, name, params);
             dpi->add_initial_condition(ic);
         }
@@ -187,18 +186,18 @@ GYMLFile::build_boundary_conditions()
 
     lprintf(9, "- boundary conditions");
 
-    DiscreteProblemInterface * dpi = dynamic_cast<DiscreteProblemInterface *>(this->problem);
+    auto * dpi = dynamic_cast<DiscreteProblemInterface *>(this->problem);
     if (dpi == nullptr)
         log_error("Supplied problem type '%s' does not support boundary conditions.",
                   this->problem->get_type());
     else {
         for (const auto & it : bcs_root_node) {
             YAML::Node bc_node = it.first;
-            std::string name = bc_node.as<std::string>();
+            auto name = bc_node.as<std::string>();
 
             Parameters * params = build_params(bcs_root_node, name);
             params->set<const DiscreteProblemInterface *>("_dpi") = dpi;
-            const std::string & class_name = params->get<std::string>("_type");
+            const auto & class_name = params->get<std::string>("_type");
             auto bc = Factory::create<BoundaryCondition>(class_name, name, params);
             dpi->add_boundary_condition(bc);
         }
@@ -217,10 +216,10 @@ GYMLFile::build_postprocessors()
 
     for (const auto & it : pps_root_node) {
         YAML::Node pps_node = it.first;
-        std::string name = pps_node.as<std::string>();
+        auto name = pps_node.as<std::string>();
 
         Parameters * params = build_params(pps_root_node, name);
-        const std::string & class_name = params->get<std::string>("_type");
+        const auto & class_name = params->get<std::string>("_type");
         params->set<const Problem *>("_problem") = this->problem;
         auto pp = Factory::create<Postprocessor>(class_name, name, params);
         problem->add_postprocessor(pp);

--- a/src/HDF5Output.cpp
+++ b/src/HDF5Output.cpp
@@ -32,7 +32,7 @@ HDF5Output::~HDF5Output()
 std::string
 HDF5Output::get_file_ext() const
 {
-    return std::string("h5");
+    return { "h5" };
 }
 
 void

--- a/src/HDF5Output.cpp
+++ b/src/HDF5Output.cpp
@@ -50,8 +50,7 @@ void
 HDF5Output::check()
 {
     _F_;
-    const UnstructuredMesh * mesh =
-        dynamic_cast<const UnstructuredMesh *>(this->problem->get_mesh());
+    const auto * mesh = dynamic_cast<const UnstructuredMesh *>(this->problem->get_mesh());
     if (mesh == nullptr)
         log_error("HDF5 output works only with unstructured meshes.");
 }

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -91,9 +91,9 @@ ImplicitFENonlinearProblem::set_up_time_scheme()
 {
     _F_;
     std::string sch = utils::to_lower(this->scheme);
-    if (sch.compare("beuler") == 0)
+    if (sch == "beuler")
         PETSC_CHECK(TSSetType(this->ts, TSBEULER));
-    else if (sch.compare("cn") == 0)
+    else if (sch == "cn")
         PETSC_CHECK(TSSetType(this->ts, TSCN));
 }
 

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -8,7 +8,7 @@ namespace godzilla {
 
 Init::Init(int argc, char * argv[], MPI_Comm COMM_WORLD_IN)
 {
-    PetscInitialize(&argc, &argv, NULL, NULL);
+    PetscInitialize(&argc, &argv, nullptr, nullptr);
 #ifdef GODZILLA_WITH_PERF_LOG
     PerfLog::init();
 #endif

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -6,7 +6,7 @@
 
 namespace godzilla {
 
-Init::Init(int argc, char * argv[], MPI_Comm COMM_WORLD_IN)
+Init::Init(int argc, char * argv[], MPI_Comm)
 {
     PetscInitialize(&argc, &argv, nullptr, nullptr);
 #ifdef GODZILLA_WITH_PERF_LOG

--- a/src/InitialCondition.cpp
+++ b/src/InitialCondition.cpp
@@ -7,12 +7,12 @@
 namespace godzilla {
 
 static PetscErrorCode
-__initial_condition_function(PetscInt dim,
-                             PetscReal time,
-                             const PetscReal x[],
-                             PetscInt Nc,
-                             PetscScalar u[],
-                             void * ctx)
+initial_condition_function(PetscInt dim,
+                           PetscReal time,
+                           const PetscReal x[],
+                           PetscInt Nc,
+                           PetscScalar u[],
+                           void * ctx)
 {
     _F_;
     InitialCondition * ic = static_cast<InitialCondition *>(ctx);
@@ -73,7 +73,7 @@ PetscFunc *
 InitialCondition::get_function()
 {
     _F_;
-    return __initial_condition_function;
+    return initial_condition_function;
 }
 
 void *

--- a/src/InitialCondition.cpp
+++ b/src/InitialCondition.cpp
@@ -15,7 +15,7 @@ initial_condition_function(PetscInt dim,
                            void * ctx)
 {
     _F_;
-    InitialCondition * ic = static_cast<InitialCondition *>(ctx);
+    auto * ic = static_cast<InitialCondition *>(ctx);
     assert(ic != nullptr);
     ic->evaluate(dim, time, x, Nc, u);
     return 0;
@@ -49,7 +49,7 @@ InitialCondition::create()
         this->fid = this->dpi->get_field_id(field_names[0]);
     }
     else if (field_names.size() > 1) {
-        const std::string & field_name = get_param<std::string>("field");
+        const auto & field_name = get_param<std::string>("field");
         if (field_name.length() > 0) {
             if (this->dpi->has_field_by_name(field_name))
                 this->fid = this->dpi->get_field_id(field_name);

--- a/src/InitialCondition.cpp
+++ b/src/InitialCondition.cpp
@@ -2,7 +2,7 @@
 #include "CallStack.h"
 #include "InitialCondition.h"
 #include "DiscreteProblemInterface.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -88,7 +88,7 @@ InputFile::build_mesh()
     _F_;
     lprintf(9, "- mesh");
     Parameters * params = build_params(this->root, "mesh");
-    const std::string & class_name = params->get<std::string>("_type");
+    const auto & class_name = params->get<std::string>("_type");
     this->mesh = Factory::create<Mesh>(class_name, "mesh", params);
     add_object(this->mesh);
 }
@@ -99,7 +99,7 @@ InputFile::build_problem()
     _F_;
     lprintf(9, "- problem");
     Parameters * params = build_params(this->root, "problem");
-    const std::string & class_name = params->get<std::string>("_type");
+    const auto & class_name = params->get<std::string>("_type");
     params->set<const Mesh *>("_mesh") = this->mesh;
     this->problem = Factory::create<Problem>(class_name, "problem", params);
     add_object(this->problem);
@@ -117,10 +117,10 @@ InputFile::build_outputs()
 
     for (const auto & it : output_root_node) {
         YAML::Node output_node = it.first;
-        std::string name = output_node.as<std::string>();
+        auto name = output_node.as<std::string>();
 
         Parameters * params = build_params(output_root_node, name);
-        const std::string & class_name = params->get<std::string>("_type");
+        const auto & class_name = params->get<std::string>("_type");
         params->set<const Problem *>("_problem") = this->problem;
         auto output = Factory::create<Output>(class_name, name, params);
         assert(this->problem != nullptr);

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -7,7 +7,7 @@
 #include "CallStack.h"
 #include "Validation.h"
 #include "Utils.h"
-#include "assert.h"
+#include "cassert"
 #include "fmt/format.h"
 #include "yaml-cpp/node/iterator.h"
 

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -23,8 +23,6 @@ InputFile::InputFile(const App * app) :
     _F_;
 }
 
-InputFile::~InputFile() {}
-
 bool
 InputFile::parse(const std::string & file_name)
 {

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -227,7 +227,7 @@ bool
 InputFile::read_bool_value(const std::string & param_name, const YAML::Node & val_node)
 {
     _F_;
-    bool val;
+    bool val = false;
     if (val_node.IsScalar()) {
         std::string str = utils::to_lower(val_node.as<std::string>());
         if (validation::in(str, { "on", "true", "yes" }))

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -301,7 +301,7 @@ InputFile::check_params(const Parameters * params,
     else
         this->valid_param_object_names.insert(name);
 
-    if (unused_param_names.size() > 0)
+    if (!unused_param_names.empty())
         log_warning("%s: Following parameters were not used: %s",
                     name,
                     fmt::to_string(fmt::join(unused_param_names, ", ")));

--- a/src/L2Diff.cpp
+++ b/src/L2Diff.cpp
@@ -8,13 +8,13 @@ namespace godzilla {
 
 REGISTER_OBJECT(L2Diff);
 
-PetscErrorCode
-__l2_diff(PetscInt dim,
-          PetscReal time,
-          const PetscReal x[],
-          PetscInt nc,
-          PetscScalar u[],
-          void * ctx)
+static PetscErrorCode
+l2_diff_eval(PetscInt dim,
+             PetscReal time,
+             const PetscReal x[],
+             PetscInt nc,
+             PetscScalar u[],
+             void * ctx)
 {
     L2Diff * l2_diff = static_cast<L2Diff *>(ctx);
     l2_diff->evaluate(dim, time, x, nc, u);
@@ -47,7 +47,7 @@ void
 L2Diff::compute()
 {
     _F_;
-    PetscFunc * funcs[1] = { __l2_diff };
+    PetscFunc * funcs[1] = { l2_diff_eval };
     void * ctxs[1] = { this };
     PETSC_CHECK(DMComputeL2Diff(this->problem->get_dm(),
                                 this->problem->get_time(),

--- a/src/L2Diff.cpp
+++ b/src/L2Diff.cpp
@@ -16,7 +16,7 @@ l2_diff_eval(PetscInt dim,
              PetscScalar u[],
              void * ctx)
 {
-    L2Diff * l2_diff = static_cast<L2Diff *>(ctx);
+    auto * l2_diff = static_cast<L2Diff *>(ctx);
     l2_diff->evaluate(dim, time, x, nc, u);
     return 0;
 }

--- a/src/L2FieldDiff.cpp
+++ b/src/L2FieldDiff.cpp
@@ -5,7 +5,7 @@
 #include "FEProblemInterface.h"
 #include "ParsedFunction.h"
 #include "Types.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/L2FieldDiff.cpp
+++ b/src/L2FieldDiff.cpp
@@ -36,7 +36,7 @@ L2FieldDiff::L2FieldDiff(const Parameters & params) :
             params->set<const App *>("_app") = this->app;
             params->set<const Problem *>("_problem") = this->problem;
             params->set<std::vector<std::string>>("function") = it.second;
-            ParsedFunction * pfn = Factory::create<ParsedFunction>(class_name, nm, params);
+            auto * pfn = Factory::create<ParsedFunction>(class_name, nm, params);
 
             const_cast<Problem *>(this->problem)->add_function(pfn);
             this->funcs[field_name] = pfn;

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -31,21 +31,21 @@ LineMesh::LineMesh(const Parameters & parameters) :
 }
 
 PetscReal
-LineMesh::get_x_min()
+LineMesh::get_x_min() const
 {
     _F_;
     return this->xmin;
 }
 
 PetscReal
-LineMesh::get_x_max()
+LineMesh::get_x_max() const
 {
     _F_;
     return this->xmax;
 }
 
 PetscInt
-LineMesh::get_nx()
+LineMesh::get_nx() const
 {
     _F_;
     return this->nx;

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -142,7 +142,7 @@ void
 LinearProblem::set_up_monitors()
 {
     _F_;
-    PETSC_CHECK(KSPMonitorSet(this->ksp, __ksp_monitor_linear, this, 0));
+    PETSC_CHECK(KSPMonitorSet(this->ksp, __ksp_monitor_linear, this, nullptr));
 }
 
 void

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -48,10 +48,10 @@ LinearProblem::parameters()
 
 LinearProblem::LinearProblem(const Parameters & parameters) :
     Problem(parameters),
-    ksp(NULL),
-    x(NULL),
-    b(NULL),
-    A(NULL),
+    ksp(nullptr),
+    x(nullptr),
+    b(nullptr),
+    A(nullptr),
     lin_rel_tol(get_param<PetscReal>("lin_rel_tol")),
     lin_abs_tol(get_param<PetscReal>("lin_abs_tol")),
     lin_max_iter(get_param<PetscInt>("lin_max_iter"))

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -10,7 +10,7 @@ PetscErrorCode
 __compute_rhs(KSP ksp, Vec b, void * ctx)
 {
     _F_;
-    LinearProblem * problem = static_cast<LinearProblem *>(ctx);
+    auto * problem = static_cast<LinearProblem *>(ctx);
     return problem->compute_rhs_callback(b);
 }
 
@@ -18,7 +18,7 @@ PetscErrorCode
 __compute_operators(KSP ksp, Mat A, Mat B, void * ctx)
 {
     _F_;
-    LinearProblem * problem = static_cast<LinearProblem *>(ctx);
+    auto * problem = static_cast<LinearProblem *>(ctx);
     return problem->compute_operators_callback(A, B);
 }
 
@@ -26,7 +26,7 @@ PetscErrorCode
 __ksp_monitor_linear(KSP ksp, PetscInt it, PetscReal rnorm, void * ctx)
 {
     _F_;
-    LinearProblem * problem = static_cast<LinearProblem *>(ctx);
+    auto * problem = static_cast<LinearProblem *>(ctx);
     return problem->ksp_monitor_callback(it, rnorm);
 }
 

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -7,7 +7,7 @@
 namespace godzilla {
 
 PetscErrorCode
-__compute_rhs(KSP ksp, Vec b, void * ctx)
+__compute_rhs(KSP, Vec b, void * ctx)
 {
     _F_;
     auto * problem = static_cast<LinearProblem *>(ctx);
@@ -15,7 +15,7 @@ __compute_rhs(KSP ksp, Vec b, void * ctx)
 }
 
 PetscErrorCode
-__compute_operators(KSP ksp, Mat A, Mat B, void * ctx)
+__compute_operators(KSP, Mat A, Mat B, void * ctx)
 {
     _F_;
     auto * problem = static_cast<LinearProblem *>(ctx);
@@ -23,7 +23,7 @@ __compute_operators(KSP ksp, Mat A, Mat B, void * ctx)
 }
 
 PetscErrorCode
-__ksp_monitor_linear(KSP ksp, PetscInt it, PetscReal rnorm, void * ctx)
+__ksp_monitor_linear(KSP, PetscInt it, PetscReal rnorm, void * ctx)
 {
     _F_;
     auto * problem = static_cast<LinearProblem *>(ctx);

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -39,7 +39,7 @@ Logger::print() const
     for (auto & s : this->entries)
         fmt::fprintf(stderr, "%s\n", s);
 
-    fmt::fprintf(stderr, "%s", Terminal::Color::magenta);
+    fmt::fprintf(stderr, "%s", (const char *) Terminal::Color::magenta);
     if (this->num_errors > 0)
         fmt::fprintf(stderr, "%d error(s)", this->num_errors);
 
@@ -49,7 +49,7 @@ Logger::print() const
 
         fmt::fprintf(stderr, "%d warning(s)", this->num_warnings);
     }
-    fmt::fprintf(stderr, " found.%s\n", Terminal::Color::normal);
+    fmt::fprintf(stderr, " found.%s\n", (const char *) Terminal::Color::normal);
 }
 
 } // namespace godzilla

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -13,8 +13,6 @@ Mesh::parameters()
 
 Mesh::Mesh(const Parameters & parameters) : Object(parameters), PrintInterface(this), dim(-1) {}
 
-Mesh::~Mesh() {}
-
 PetscInt
 Mesh::get_dimension() const
 {

--- a/src/MeshPartitioningOutput.cpp
+++ b/src/MeshPartitioningOutput.cpp
@@ -34,7 +34,7 @@ MeshPartitioningOutput::check()
 std::string
 MeshPartitioningOutput::get_file_ext() const
 {
-    return std::string("h5");
+    return { "h5" };
 }
 
 void

--- a/src/MeshPartitioningOutput.cpp
+++ b/src/MeshPartitioningOutput.cpp
@@ -61,7 +61,8 @@ MeshPartitioningOutput::output_step()
             n_dofs[i] = 1;
         else
             n_dofs[i] = 0;
-    PETSC_CHECK(DMPlexCreateSection(dmp, NULL, nc, n_dofs, 0, NULL, NULL, NULL, NULL, &s));
+    PETSC_CHECK(
+        DMPlexCreateSection(dmp, nullptr, nc, n_dofs, 0, nullptr, nullptr, nullptr, nullptr, &s));
     PETSC_CHECK(PetscSectionSetFieldName(s, 0, ""));
     PETSC_CHECK(DMSetLocalSection(dmp, s));
 

--- a/src/NaturalRiemannBC.cpp
+++ b/src/NaturalRiemannBC.cpp
@@ -13,7 +13,7 @@ natural_riemann_boundary_condition_function(PetscReal time,
                                             void * ctx)
 {
     _F_;
-    NaturalRiemannBC * bc = static_cast<NaturalRiemannBC *>(ctx);
+    auto * bc = static_cast<NaturalRiemannBC *>(ctx);
     assert(bc != nullptr);
     bc->evaluate(time, c, n, xI, xG);
     return 0;

--- a/src/NaturalRiemannBC.cpp
+++ b/src/NaturalRiemannBC.cpp
@@ -5,12 +5,12 @@
 namespace godzilla {
 
 static PetscErrorCode
-__natural_riemann_boundary_condition_function(PetscReal time,
-                                              const PetscReal * c,
-                                              const PetscReal * n,
-                                              const PetscScalar * xI,
-                                              PetscScalar * xG,
-                                              void * ctx)
+natural_riemann_boundary_condition_function(PetscReal time,
+                                            const PetscReal * c,
+                                            const PetscReal * n,
+                                            const PetscScalar * xI,
+                                            PetscScalar * xG,
+                                            void * ctx)
 {
     _F_;
     NaturalRiemannBC * bc = static_cast<NaturalRiemannBC *>(ctx);
@@ -44,7 +44,7 @@ NaturalRiemannBC::add_boundary()
                                    this->fid,
                                    get_num_components(),
                                    get_num_components() == 0 ? nullptr : get_components().data(),
-                                   (void (*)(void)) __natural_riemann_boundary_condition_function,
+                                   (void (*)(void)) natural_riemann_boundary_condition_function,
                                    nullptr,
                                    (void *) this,
                                    &this->bd));

--- a/src/NaturalRiemannBC.cpp
+++ b/src/NaturalRiemannBC.cpp
@@ -1,6 +1,6 @@
 #include "NaturalRiemannBC.h"
 #include "CallStack.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -77,6 +77,7 @@ NonlinearProblem::NonlinearProblem(const Parameters & parameters) :
     x(nullptr),
     r(nullptr),
     J(nullptr),
+    converged_reason(SNES_CONVERGED_ITERATING),
     line_search_type(get_param<std::string>("line_search")),
     nl_rel_tol(get_param<PetscReal>("nl_rel_tol")),
     nl_abs_tol(get_param<PetscReal>("nl_abs_tol")),

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -72,11 +72,11 @@ NonlinearProblem::parameters()
 
 NonlinearProblem::NonlinearProblem(const Parameters & parameters) :
     Problem(parameters),
-    snes(NULL),
-    ksp(NULL),
-    x(NULL),
-    r(NULL),
-    J(NULL),
+    snes(nullptr),
+    ksp(nullptr),
+    x(nullptr),
+    r(nullptr),
+    J(nullptr),
     line_search_type(get_param<std::string>("line_search")),
     nl_rel_tol(get_param<PetscReal>("nl_rel_tol")),
     nl_abs_tol(get_param<PetscReal>("nl_abs_tol")),
@@ -257,7 +257,7 @@ NonlinearProblem::solve()
 {
     _F_;
     lprintf(9, "Solving");
-    PETSC_CHECK(SNESSolve(this->snes, NULL, this->x));
+    PETSC_CHECK(SNESSolve(this->snes, nullptr, this->x));
     PETSC_CHECK(SNESGetConvergedReason(this->snes, &this->converged_reason));
 }
 

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -9,7 +9,7 @@
 namespace godzilla {
 
 PetscErrorCode
-__compute_residual(SNES snes, Vec x, Vec f, void * ctx)
+__compute_residual(SNES, Vec x, Vec f, void * ctx)
 {
     _F_;
     auto * problem = static_cast<NonlinearProblem *>(ctx);
@@ -17,7 +17,7 @@ __compute_residual(SNES snes, Vec x, Vec f, void * ctx)
 }
 
 PetscErrorCode
-__compute_jacobian(SNES snes, Vec x, Mat J, Mat Jp, void * ctx)
+__compute_jacobian(SNES, Vec x, Mat J, Mat Jp, void * ctx)
 {
     _F_;
     auto * problem = static_cast<NonlinearProblem *>(ctx);
@@ -25,7 +25,7 @@ __compute_jacobian(SNES snes, Vec x, Mat J, Mat Jp, void * ctx)
 }
 
 PetscErrorCode
-__ksp_monitor(KSP ksp, PetscInt it, PetscReal rnorm, void * ctx)
+__ksp_monitor(KSP, PetscInt it, PetscReal rnorm, void * ctx)
 {
     _F_;
     auto * problem = static_cast<NonlinearProblem *>(ctx);
@@ -33,7 +33,7 @@ __ksp_monitor(KSP ksp, PetscInt it, PetscReal rnorm, void * ctx)
 }
 
 PetscErrorCode
-__snes_monitor(SNES snes, PetscInt it, PetscReal norm, void * ctx)
+__snes_monitor(SNES, PetscInt it, PetscReal norm, void * ctx)
 {
     _F_;
     auto * problem = static_cast<NonlinearProblem *>(ctx);

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -215,8 +215,8 @@ void
 NonlinearProblem::set_up_monitors()
 {
     _F_;
-    PETSC_CHECK(SNESMonitorSet(this->snes, __snes_monitor, this, 0));
-    PETSC_CHECK(KSPMonitorSet(this->ksp, __ksp_monitor, this, 0));
+    PETSC_CHECK(SNESMonitorSet(this->snes, __snes_monitor, this, nullptr));
+    PETSC_CHECK(KSPMonitorSet(this->ksp, __ksp_monitor, this, nullptr));
 }
 
 void

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -187,15 +187,15 @@ NonlinearProblem::set_up_line_search()
     _F_;
     SNESLineSearch line_search;
     PETSC_CHECK(SNESGetLineSearch(this->snes, &line_search));
-    if (this->line_search_type.compare("basic") == 0)
+    if (this->line_search_type == "basic")
         PETSC_CHECK(SNESLineSearchSetType(line_search, SNESLINESEARCHBASIC));
-    else if (this->line_search_type.compare("l2") == 0)
+    else if (this->line_search_type == "l2")
         PETSC_CHECK(SNESLineSearchSetType(line_search, SNESLINESEARCHL2));
-    else if (this->line_search_type.compare("cp") == 0)
+    else if (this->line_search_type == "cp")
         PETSC_CHECK(SNESLineSearchSetType(line_search, SNESLINESEARCHCP));
-    else if (this->line_search_type.compare("nleqerr") == 0)
+    else if (this->line_search_type == "nleqerr")
         PETSC_CHECK(SNESLineSearchSetType(line_search, SNESLINESEARCHNLEQERR));
-    else if (this->line_search_type.compare("shell") == 0)
+    else if (this->line_search_type == "shell")
         PETSC_CHECK(SNESLineSearchSetType(line_search, SNESLINESEARCHSHELL));
     else
         PETSC_CHECK(SNESLineSearchSetType(line_search, SNESLINESEARCHBT));

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -12,7 +12,7 @@ PetscErrorCode
 __compute_residual(SNES snes, Vec x, Vec f, void * ctx)
 {
     _F_;
-    NonlinearProblem * problem = static_cast<NonlinearProblem *>(ctx);
+    auto * problem = static_cast<NonlinearProblem *>(ctx);
     return problem->compute_residual_callback(x, f);
 }
 
@@ -20,7 +20,7 @@ PetscErrorCode
 __compute_jacobian(SNES snes, Vec x, Mat J, Mat Jp, void * ctx)
 {
     _F_;
-    NonlinearProblem * problem = static_cast<NonlinearProblem *>(ctx);
+    auto * problem = static_cast<NonlinearProblem *>(ctx);
     return problem->compute_jacobian_callback(x, J, Jp);
 }
 
@@ -28,7 +28,7 @@ PetscErrorCode
 __ksp_monitor(KSP ksp, PetscInt it, PetscReal rnorm, void * ctx)
 {
     _F_;
-    NonlinearProblem * problem = static_cast<NonlinearProblem *>(ctx);
+    auto * problem = static_cast<NonlinearProblem *>(ctx);
     return problem->ksp_monitor_callback(it, rnorm);
 }
 
@@ -36,7 +36,7 @@ PetscErrorCode
 __snes_monitor(SNES snes, PetscInt it, PetscReal norm, void * ctx)
 {
     _F_;
-    NonlinearProblem * problem = static_cast<NonlinearProblem *>(ctx);
+    auto * problem = static_cast<NonlinearProblem *>(ctx);
     return problem->snes_monitor_callback(it, norm);
 }
 

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -49,7 +49,7 @@ Output::set_up_exec()
     _F_;
     if (is_param_valid("on")) {
         const auto & on = get_param<std::vector<std::string>>("on");
-        if (on.size() > 0) {
+        if (!on.empty()) {
             bool none = false;
             unsigned int mask = 0;
             for (auto & s : on) {

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -54,13 +54,13 @@ Output::set_up_exec()
             unsigned int mask = 0;
             for (auto & s : on) {
                 std::string ls = utils::to_lower(s);
-                if (ls.compare("initial") == 0)
+                if (ls == "initial")
                     mask |= ON_INITIAL;
-                else if (ls.compare("timestep") == 0)
+                else if (ls == "timestep")
                     mask |= ON_TIMESTEP;
-                else if (ls.compare("final") == 0)
+                else if (ls == "final")
                     mask |= ON_FINAL;
-                else if (ls.compare("none") == 0)
+                else if (ls == "none")
                     none = true;
             }
 

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -2,7 +2,7 @@
 #include "CallStack.h"
 #include "Problem.h"
 #include "Utils.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/ParsedFunction.cpp
+++ b/src/ParsedFunction.cpp
@@ -8,7 +8,7 @@ namespace godzilla {
 REGISTER_OBJECT(ParsedFunction);
 
 static double
-__parsed_function_eval(void * ctx, double t, double x, double y, double z)
+parsed_function_eval(void * ctx, double t, double x, double y, double z)
 {
     ParsedFunction * fn = static_cast<ParsedFunction *>(ctx);
     PetscReal u[1] = { 0. };
@@ -18,12 +18,12 @@ __parsed_function_eval(void * ctx, double t, double x, double y, double z)
 }
 
 static PetscErrorCode
-__parsed_function(PetscInt dim,
-                  PetscReal time,
-                  const PetscReal x[],
-                  PetscInt nc,
-                  PetscScalar u[],
-                  void * ctx)
+parsed_function(PetscInt dim,
+                PetscReal time,
+                const PetscReal x[],
+                PetscInt nc,
+                PetscScalar u[],
+                void * ctx)
 {
     ParsedFunction * fn = static_cast<ParsedFunction *>(ctx);
     fn->evaluate(dim, time, x, nc, u);
@@ -56,7 +56,7 @@ PetscFunc *
 ParsedFunction::get_function()
 {
     _F_;
-    return __parsed_function;
+    return parsed_function;
 }
 
 void *
@@ -71,7 +71,7 @@ ParsedFunction::register_callback(mu::Parser & parser)
 {
     _F_;
     if (this->function.size() == 1)
-        parser.DefineFunUserData(get_name(), __parsed_function_eval, this);
+        parser.DefineFunUserData(get_name(), parsed_function_eval, this);
 }
 
 void

--- a/src/ParsedFunction.cpp
+++ b/src/ParsedFunction.cpp
@@ -10,7 +10,7 @@ REGISTER_OBJECT(ParsedFunction);
 static double
 parsed_function_eval(void * ctx, double t, double x, double y, double z)
 {
-    ParsedFunction * fn = static_cast<ParsedFunction *>(ctx);
+    auto * fn = static_cast<ParsedFunction *>(ctx);
     PetscReal u[1] = { 0. };
     PetscReal coord[3] = { x, y, z };
     fn->evaluate(3, t, coord, 1, u);
@@ -25,7 +25,7 @@ parsed_function(PetscInt dim,
                 PetscScalar u[],
                 void * ctx)
 {
-    ParsedFunction * fn = static_cast<ParsedFunction *>(ctx);
+    auto * fn = static_cast<ParsedFunction *>(ctx);
     fn->evaluate(dim, time, x, nc, u);
     return 0;
 }

--- a/src/PiecewiseLinear.cpp
+++ b/src/PiecewiseLinear.cpp
@@ -9,7 +9,7 @@ REGISTER_OBJECT(PiecewiseLinear);
 static double
 piecewise_linear_function_eval(void * ctx, double x)
 {
-    PiecewiseLinear * fn = static_cast<PiecewiseLinear *>(ctx);
+    auto * fn = static_cast<PiecewiseLinear *>(ctx);
     return fn->evaluate(x);
 }
 

--- a/src/PiecewiseLinear.cpp
+++ b/src/PiecewiseLinear.cpp
@@ -6,8 +6,8 @@ namespace godzilla {
 
 REGISTER_OBJECT(PiecewiseLinear);
 
-double
-__piecewise_linear_function_eval(void * ctx, double x)
+static double
+piecewise_linear_function_eval(void * ctx, double x)
 {
     PiecewiseLinear * fn = static_cast<PiecewiseLinear *>(ctx);
     return fn->evaluate(x);
@@ -33,7 +33,7 @@ void
 PiecewiseLinear::register_callback(mu::Parser & parser)
 {
     _F_;
-    parser.DefineFunUserData(get_name(), __piecewise_linear_function_eval, this);
+    parser.DefineFunUserData(get_name(), piecewise_linear_function_eval, this);
 }
 
 PetscReal

--- a/src/Postprocessor.cpp
+++ b/src/Postprocessor.cpp
@@ -19,6 +19,4 @@ Postprocessor::Postprocessor(const Parameters & params) :
 {
 }
 
-Postprocessor::~Postprocessor() {}
-
 } // namespace godzilla

--- a/src/PrintInterface.cpp
+++ b/src/PrintInterface.cpp
@@ -24,6 +24,7 @@ PrintInterface::PrintInterface(const App * app) :
 PrintInterface::PrintInterface(MPI_Comm comm,
                                const unsigned int & verbosity_level,
                                const std::string & prefix) :
+    proc_id(0),
     verbosity_level(verbosity_level),
     prefix(prefix)
 {

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -25,8 +25,6 @@ Problem::Problem(const Parameters & parameters) :
 {
 }
 
-Problem::~Problem() {}
-
 void
 Problem::check()
 {

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -39,14 +39,14 @@ RectangleMesh::RectangleMesh(const Parameters & parameters) :
         log_error("Parameter 'ymax' must be larger than 'ymin'.");
 }
 
-PetscInt
+PetscReal
 RectangleMesh::get_x_min() const
 {
     _F_;
     return this->xmin;
 }
 
-PetscInt
+PetscReal
 RectangleMesh::get_x_max() const
 {
     _F_;
@@ -60,14 +60,14 @@ RectangleMesh::get_nx() const
     return this->nx;
 }
 
-PetscInt
+PetscReal
 RectangleMesh::get_y_min() const
 {
     _F_;
     return this->ymin;
 }
 
-PetscInt
+PetscReal
 RectangleMesh::get_y_max() const
 {
     _F_;

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -85,8 +85,6 @@ void
 RectangleMesh::create_dm()
 {
     _F_;
-    PetscErrorCode ierr;
-
     PetscReal lower[2] = { this->xmin, this->ymin };
     PetscReal upper[2] = { this->xmax, this->ymax };
     PetscInt faces[2] = { this->nx, this->ny };

--- a/src/TimeSteppingAdaptor.cpp
+++ b/src/TimeSteppingAdaptor.cpp
@@ -1,7 +1,7 @@
 #include "TimeSteppingAdaptor.h"
 #include "CallStack.h"
 #include "TransientProblemInterface.h"
-#include <assert.h>
+#include <cassert>
 
 namespace godzilla {
 

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -34,7 +34,7 @@ __transient_post_step(TS ts)
 }
 
 PetscErrorCode
-__transient_monitor(TS ts, PetscInt stepi, PetscReal time, Vec x, void * ctx)
+__transient_monitor(TS, PetscInt stepi, PetscReal time, Vec x, void * ctx)
 {
     _F_;
     auto * tpi = static_cast<TransientProblemInterface *>(ctx);

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -120,7 +120,7 @@ TransientProblemInterface::set_up_monitors()
     _F_;
     PETSC_CHECK(TSSetPreStep(this->ts, __transient_pre_step));
     PETSC_CHECK(TSSetPostStep(this->ts, __transient_post_step));
-    PETSC_CHECK(TSMonitorSet(this->ts, __transient_monitor, this, NULL));
+    PETSC_CHECK(TSMonitorSet(this->ts, __transient_monitor, this, nullptr));
 }
 
 PetscErrorCode

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -19,7 +19,7 @@ __transient_pre_step(TS ts)
     _F_;
     void * ctx;
     TSGetApplicationContext(ts, &ctx);
-    TransientProblemInterface * tpi = static_cast<TransientProblemInterface *>(ctx);
+    auto * tpi = static_cast<TransientProblemInterface *>(ctx);
     return tpi->pre_step();
 }
 
@@ -29,7 +29,7 @@ __transient_post_step(TS ts)
     _F_;
     void * ctx;
     TSGetApplicationContext(ts, &ctx);
-    TransientProblemInterface * tpi = static_cast<TransientProblemInterface *>(ctx);
+    auto * tpi = static_cast<TransientProblemInterface *>(ctx);
     return tpi->post_step();
 }
 
@@ -37,7 +37,7 @@ PetscErrorCode
 __transient_monitor(TS ts, PetscInt stepi, PetscReal time, Vec x, void * ctx)
 {
     _F_;
-    TransientProblemInterface * tpi = static_cast<TransientProblemInterface *>(ctx);
+    auto * tpi = static_cast<TransientProblemInterface *>(ctx);
     return tpi->ts_monitor_callback(stepi, time, x);
 }
 

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -6,7 +6,7 @@
 #include "NonlinearProblem.h"
 #include "Output.h"
 #include "petscdmplex.h"
-#include <assert.h>
+#include <cassert>
 #include "petsc/private/tsimpl.h"
 
 PETSC_EXTERN PetscErrorCode TSAdaptCreate_godzilla(TSAdapt adapt);

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -42,7 +42,7 @@ UnstructuredMesh::create()
     _F_;
     create_dm();
     PETSC_CHECK(DMSetFromOptions(this->dm));
-    PETSC_CHECK(DMViewFromOptions(dm, NULL, "-dm_view"));
+    PETSC_CHECK(DMViewFromOptions(dm, nullptr, "-dm_view"));
     PETSC_CHECK(DMSetUp(this->dm));
     PETSC_CHECK(DMGetDimension(this->dm, &this->dim));
 
@@ -152,7 +152,7 @@ UnstructuredMesh::distribute()
     PETSC_CHECK(DMPlexSetPartitioner(this->dm, this->partitioner));
 
     DM dm_dist = nullptr;
-    PETSC_CHECK(DMPlexDistribute(this->dm, this->partition_overlap, NULL, &dm_dist));
+    PETSC_CHECK(DMPlexDistribute(this->dm, this->partition_overlap, nullptr, &dm_dist));
     if (dm_dist) {
         PETSC_CHECK(DMDestroy(&this->dm));
         this->dm = dm_dist;
@@ -309,7 +309,7 @@ UnstructuredMesh::construct_ghost_cells()
 {
     _F_;
     DM gdm;
-    PETSC_CHECK(DMPlexConstructGhostCells(this->dm, NULL, NULL, &gdm));
+    PETSC_CHECK(DMPlexConstructGhostCells(this->dm, nullptr, nullptr, &gdm));
     PETSC_CHECK(DMDestroy(&this->dm));
     this->dm = gdm;
 }

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -15,6 +15,7 @@ UnstructuredMesh::parameters()
 UnstructuredMesh::UnstructuredMesh(const Parameters & parameters) :
     Mesh(parameters),
     dm(nullptr),
+    partitioner(nullptr),
     partition_overlap(0)
 {
     _F_;

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -49,8 +49,7 @@ void
 VTKOutput::check()
 {
     _F_;
-    const UnstructuredMesh * mesh =
-        dynamic_cast<const UnstructuredMesh *>(this->problem->get_mesh());
+    const auto * mesh = dynamic_cast<const UnstructuredMesh *>(this->problem->get_mesh());
     if (mesh == nullptr)
         log_error("VTK output works only with unstructured meshes.");
 }

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -31,7 +31,7 @@ VTKOutput::~VTKOutput()
 std::string
 VTKOutput::get_file_ext() const
 {
-    return std::string("vtk");
+    return { "vtk" };
 }
 
 void

--- a/src/Validation.cpp
+++ b/src/Validation.cpp
@@ -16,7 +16,7 @@ in(const std::string & value, const std::vector<std::string> & options)
     _F_;
     std::string v = utils::to_lower(value);
     for (auto & o : options)
-        if (v.compare(utils::to_lower(o)) == 0)
+        if (v == utils::to_lower(o))
             return true;
     return false;
 }

--- a/test/src/Factory_test.cpp
+++ b/test/src/Factory_test.cpp
@@ -10,7 +10,7 @@ using namespace godzilla;
 TEST(FactoryTest, valid_params_unreg_obj)
 {
     EXPECT_DEATH(Parameters * params = Factory::get_parameters("ASDF"),
-                 "Getting valid_params for object 'ASDF' failed.  Object is not registred.");
+                 "Getting valid_params for object 'ASDF' failed.  Object is not registered.");
 }
 
 TEST(FactoryTest, create_unreg_obj)


### PR DESCRIPTION
- tests: updating NaturalBC test
- updating _F_ macro, so it behaves like a statement
- explicity casting terminal color as const char * in fmt::fprintf calls
- Renaming private function callbacks
- clang-tidy: using auto with static_cast
- Using nullptr instead of NULL
- overriden methods are marked with override
- Single-parameter constructors are marked explicit
- LineMesh: getters are marked const
