### PR TITLE
clang tidy

### DIFF
--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -83,7 +83,7 @@ public:
     /// @param component Component index
     /// @param name Component name
     virtual void
-    set_field_component_name(PetscInt fid, PetscInt component, const std::string name) = 0;
+    set_field_component_name(PetscInt fid, PetscInt component, const std::string & name) = 0;
 
     /// Add initial condition
     ///

--- a/include/ExodusIIMesh.h
+++ b/include/ExodusIIMesh.h
@@ -10,7 +10,10 @@ class ExodusIIMesh : public UnstructuredMesh {
 public:
     explicit ExodusIIMesh(const Parameters & parameters);
 
-    const std::string get_file_name() const;
+    /// Return ExodusII file name
+    ///
+    /// @return Name of the ExodusII file
+    const std::string & get_file_name() const;
 
 protected:
     void create_dm() override;

--- a/include/ExodusIIOutput.h
+++ b/include/ExodusIIOutput.h
@@ -56,7 +56,7 @@ protected:
     void write_block_elem_variables(int blk_id, const PetscScalar * sln);
     void write_global_variables();
     void write_block_connectivity(int blk_id,
-                                  int n_elems_in_block = 0,
+                                  PetscInt n_elems_in_block = 0,
                                   const PetscInt * cells = nullptr);
 
     /// Variable names to be stored

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -31,7 +31,7 @@ public:
     PetscInt get_field_order(PetscInt fid) const override;
     std::string get_field_component_name(PetscInt fid, PetscInt component) const override;
     void
-    set_field_component_name(PetscInt fid, PetscInt component, const std::string name) override;
+    set_field_component_name(PetscInt fid, PetscInt component, const std::string & name) override;
     PetscInt get_field_dof(PetscInt point, PetscInt fid) const override;
     Vec get_solution_vector_local() const override;
     WeakForm * get_weak_form() const override;

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -22,7 +22,7 @@ public:
     PetscInt get_field_order(PetscInt fid) const override;
     std::string get_field_component_name(PetscInt fid, PetscInt component) const override;
     void
-    set_field_component_name(PetscInt fid, PetscInt component, const std::string name) override;
+    set_field_component_name(PetscInt fid, PetscInt component, const std::string & name) override;
     PetscInt get_field_dof(PetscInt point, PetscInt fid) const override;
     Vec get_solution_vector_local() const override;
     WeakForm * get_weak_form() const override;

--- a/include/Factory.h
+++ b/include/Factory.h
@@ -56,9 +56,7 @@ public:
     static char
     reg(const std::string & class_name)
     {
-        Entry entry;
-        entry.build_ptr = &build_obj<T>;
-        entry.params_ptr = &call_parameters<T>;
+        Entry entry = { &build_obj<T>, &call_parameters<T> };
         classes[class_name] = entry;
         return '\0';
     }

--- a/include/LoggingInterface.h
+++ b/include/LoggingInterface.h
@@ -10,7 +10,7 @@ class LoggingInterface {
 public:
     explicit LoggingInterface(Logger * alogger, std::string aprefix = "") :
         logger(alogger),
-        prefix(aprefix)
+        prefix(std::move(aprefix))
     {
     }
 

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -227,11 +227,11 @@ public:
     Parameters &
     operator+=(const Parameters & rhs)
     {
-        for (auto it = rhs.begin(); it != rhs.end(); ++it) {
-            auto jt = this->params.find(it->first);
+        for (const auto & rpar : rhs) {
+            auto jt = this->params.find(rpar.first);
             if (jt != this->params.end())
                 delete jt->second;
-            this->params[it->first] = it->second->copy();
+            this->params[rpar.first] = rpar.second->copy();
         }
         return *this;
     }

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -12,7 +12,7 @@ namespace godzilla {
 ///
 class Parameters {
 public:
-    Parameters();
+    Parameters() = default;
     Parameters(const Parameters & p);
     virtual ~Parameters();
 

--- a/include/PrintInterface.h
+++ b/include/PrintInterface.h
@@ -16,7 +16,7 @@ class PrintInterface {
 public:
     explicit PrintInterface(const Object * obj);
     explicit PrintInterface(const App * app);
-    PrintInterface(MPI_Comm comm, const unsigned int & verbosity_level, const std::string & prefix);
+    PrintInterface(MPI_Comm comm, const unsigned int & verbosity_level, std::string prefix);
 
 protected:
     /// Print a message on a terminal

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -132,7 +132,7 @@ protected:
 
     void create_cell_set(PetscInt id, const std::string & name);
 
-    void create_face_set_labels(const std::map<int, std::string> & names);
+    void create_face_set_labels(const std::map<PetscInt, std::string> & names);
 
     void create_face_set(PetscInt id);
 

--- a/include/Validation.h
+++ b/include/Validation.h
@@ -6,11 +6,11 @@
 namespace godzilla {
 namespace validation {
 
-/// Check that `param` attains one of the `options`
+/// Check that `value` is equal to one of the `options`
 ///
-/// @return `true` if name is one f the options, `false` otherwise
+/// @return `true` if `value` is one of the `options`, `false` otherwise
 /// @param value Value to test
-/// @param options Possible options that value can have
+/// @param options Possible options
 bool in(const std::string & value, const std::vector<std::string> & options);
 
 } // namespace validation

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -1,5 +1,4 @@
 #include "App.h"
-#include "GodzillaConfig.h"
 #include "GYMLFile.h"
 #include "Mesh.h"
 #include "Problem.h"

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -132,7 +132,7 @@ BoxMesh::create_dm()
                                     &this->dm));
 
     // create user-friendly names for sides
-    std::map<int, std::string> face_set_names;
+    std::map<PetscInt, std::string> face_set_names;
     face_set_names[1] = "back";
     face_set_names[2] = "front";
     face_set_names[3] = "bottom";

--- a/src/ConstantIC.cpp
+++ b/src/ConstantIC.cpp
@@ -26,7 +26,7 @@ PetscInt
 ConstantIC::get_num_components() const
 {
     _F_;
-    return this->values.size();
+    return (PetscInt) this->values.size();
 }
 
 void

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -1,4 +1,3 @@
-#include "Godzilla.h"
 #include "Parameters.h"
 #include "CallStack.h"
 #include "App.h"

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -82,7 +82,7 @@ DiscreteProblemInterface::set_up_initial_conditions()
 {
     _F_;
 
-    PetscInt n_ics = this->ics.size();
+    auto n_ics = this->ics.size();
     if (n_ics == 0)
         return;
     PetscInt n_fields = get_num_fields();
@@ -161,7 +161,7 @@ void
 DiscreteProblemInterface::set_initial_guess_from_ics()
 {
     _F_;
-    PetscInt n_ics = this->ics.size();
+    auto n_ics = this->ics.size();
     PetscFunc * ic_funcs[n_ics];
     void * ic_ctxs[n_ics];
     for (auto & ic : this->ics) {

--- a/src/EssentialBC.cpp
+++ b/src/EssentialBC.cpp
@@ -80,8 +80,8 @@ EssentialBC::add_boundary()
                                    this->fid,
                                    get_num_components(),
                                    get_num_components() == 0 ? nullptr : get_components().data(),
-                                   (void (*)(void)) get_function(),
-                                   (void (*)(void)) get_function_t(),
+                                   (void (*)()) get_function(),
+                                   (void (*)()) get_function_t(),
                                    (void *) get_context(),
                                    nullptr));
 }

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -30,7 +30,7 @@ ExodusIIMesh::ExodusIIMesh(const Parameters & parameters) :
             this->file_name);
 }
 
-const std::string
+const std::string &
 ExodusIIMesh::get_file_name() const
 {
     _F_;

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -64,7 +64,9 @@ ExodusIIMesh::create_dm()
                 create_cell_set(it.first, it.second);
         }
 
-        auto sideset_names = f.read_side_set_names();
+        std::map<PetscInt, std::string> sideset_names;
+        for (auto it : f.read_side_set_names())
+            sideset_names[it.first] = it.second;
         create_face_set_labels(sideset_names);
 
         f.close();

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -553,9 +553,7 @@ ExodusIIOutput::write_nodal_variables(const PetscScalar * sln)
 
     for (PetscInt n = first; n < last; n++) {
         int exo_var_id = 1;
-        for (std::size_t i = 0; i < this->nodal_var_fids.size(); i++) {
-            PetscInt fid = this->nodal_var_fids[i];
-
+        for (auto fid : this->nodal_var_fids) {
             PetscInt offset = this->dpi->get_field_dof(n, fid);
             PetscInt nc = this->dpi->get_field_num_components(fid);
             for (PetscInt c = 0; c < nc; c++, exo_var_id++) {
@@ -592,9 +590,7 @@ ExodusIIOutput::write_block_elem_variables(int blk_id, const PetscScalar * sln)
 
     for (PetscInt n = first; n < last; n++) {
         int exo_var_id = 1;
-        for (std::size_t i = 0; i < this->elem_var_fids.size(); i++) {
-            PetscInt fid = this->elem_var_fids[i];
-
+        for (auto & fid : this->elem_var_fids) {
             PetscInt offset = this->dpi->get_field_dof(n, fid);
             PetscInt nc = this->dpi->get_field_num_components(fid);
             for (PetscInt c = 0; c < nc; c++, exo_var_id++) {

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -511,11 +511,7 @@ ExodusIIOutput::write_all_variable_names()
     }
     this->exo->write_nodal_var_names(nodal_var_names);
     this->exo->write_elem_var_names(elem_var_names);
-
-    std::vector<std::string> global_var_names;
-    for (auto & name : this->global_var_names)
-        global_var_names.push_back(name);
-    this->exo->write_global_var_names(global_var_names);
+    this->exo->write_global_var_names(this->global_var_names);
 }
 
 void

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -117,6 +117,7 @@ FEProblemInterface::get_field_names() const
 {
     _F_;
     std::vector<std::string> infos;
+    infos.reserve(this->fields.size());
     for (const auto & it : this->fields)
         infos.push_back(it.second.name);
 

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -109,7 +109,7 @@ PetscInt
 FEProblemInterface::get_num_fields() const
 {
     _F_;
-    return this->fields.size();
+    return (PetscInt) this->fields.size();
 }
 
 std::vector<std::string>
@@ -248,7 +248,7 @@ PetscInt
 FEProblemInterface::get_num_aux_fields() const
 {
     _F_;
-    return this->aux_fields.size();
+    return (PetscInt) this->aux_fields.size();
 }
 
 const std::string &
@@ -404,7 +404,7 @@ FEProblemInterface::compute_global_aux_fields(DM dm,
                                               Vec a)
 {
     _F_;
-    PetscInt n_auxs = this->aux_fields.size();
+    auto n_auxs = this->aux_fields.size();
     auto ** func = new PetscFunc *[n_auxs];
     void ** ctxs = new void *[n_auxs];
     for (PetscInt i = 0; i < n_auxs; i++) {
@@ -432,7 +432,7 @@ FEProblemInterface::compute_label_aux_fields(DM dm,
                                              Vec a)
 {
     _F_;
-    PetscInt n_auxs = this->aux_fields.size();
+    auto n_auxs = this->aux_fields.size();
     auto ** func = new PetscFunc *[n_auxs];
     void ** ctxs = new void *[n_auxs];
     for (PetscInt i = 0; i < n_auxs; i++) {

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -219,7 +219,7 @@ FEProblemInterface::get_field_component_name(PetscInt fid, PetscInt component) c
 void
 FEProblemInterface::set_field_component_name(PetscInt fid,
                                              PetscInt component,
-                                             const std::string name)
+                                             const std::string & name)
 {
     _F_;
     const auto & it = this->fields.find(fid);

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -207,7 +207,7 @@ FEProblemInterface::get_field_component_name(PetscInt fid, PetscInt component) c
     if (it != this->fields.end()) {
         const FieldInfo & fi = it->second;
         if (fi.nc == 1)
-            return std::string("");
+            return { "" };
         else {
             assert(component < it->second.nc && component < it->second.component_names.size());
             return it->second.component_names.at(component);

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -149,7 +149,7 @@ FVProblemInterface::get_field_component_name(PetscInt fid, PetscInt component) c
 void
 FVProblemInterface::set_field_component_name(PetscInt fid,
                                              PetscInt component,
-                                             const std::string name)
+                                             const std::string & name)
 {
     _F_;
     const auto & it = this->fields.find(fid);

--- a/src/GYMLFile.cpp
+++ b/src/GYMLFile.cpp
@@ -1,7 +1,6 @@
 #include "GYMLFile.h"
 #include "App.h"
 #include "Factory.h"
-#include "Mesh.h"
 #include "UnstructuredMesh.h"
 #include "Problem.h"
 #include "Function.h"
@@ -14,10 +13,8 @@
 #include "TimeSteppingAdaptor.h"
 #include "Postprocessor.h"
 #include "CallStack.h"
-#include "Validation.h"
 #include "Utils.h"
 #include "cassert"
-#include "fmt/format.h"
 #include "yaml-cpp/node/iterator.h"
 
 namespace godzilla {

--- a/src/L2FieldDiff.cpp
+++ b/src/L2FieldDiff.cpp
@@ -5,7 +5,6 @@
 #include "FEProblemInterface.h"
 #include "ParsedFunction.h"
 #include "Types.h"
-#include <cassert>
 
 namespace godzilla {
 

--- a/src/L2FieldDiff.cpp
+++ b/src/L2FieldDiff.cpp
@@ -32,11 +32,11 @@ L2FieldDiff::L2FieldDiff(const Parameters & params) :
             std::string nm = get_name() + "_" + field_name;
 
             const std::string class_name = "ParsedFunction";
-            Parameters * params = Factory::get_parameters(class_name);
-            params->set<const App *>("_app") = this->app;
-            params->set<const Problem *>("_problem") = this->problem;
-            params->set<std::vector<std::string>>("function") = it.second;
-            auto * pfn = Factory::create<ParsedFunction>(class_name, nm, params);
+            Parameters * fn_pars = Factory::get_parameters(class_name);
+            fn_pars->set<const App *>("_app") = this->app;
+            fn_pars->set<const Problem *>("_problem") = this->problem;
+            fn_pars->set<std::vector<std::string>>("function") = it.second;
+            auto * pfn = Factory::create<ParsedFunction>(class_name, nm, fn_pars);
 
             const_cast<Problem *>(this->problem)->add_function(pfn);
             this->funcs[field_name] = pfn;
@@ -72,7 +72,7 @@ L2FieldDiff::compute()
 {
     _F_;
     auto n_fields = this->funcs.size();
-    PetscFunc * funcs[n_fields];
+    PetscFunc * pfns[n_fields];
     void * ctxs[n_fields];
     PetscReal diff[n_fields];
 
@@ -80,14 +80,14 @@ L2FieldDiff::compute()
         PetscInt fid = this->fepi->get_field_id(it.first);
         ParsedFunction * pfn = it.second;
 
-        funcs[fid] = pfn->get_function();
+        pfns[fid] = pfn->get_function();
         ctxs[fid] = pfn->get_context();
         diff[fid] = 0.;
     }
 
     PETSC_CHECK(DMComputeL2FieldDiff(this->problem->get_dm(),
                                      this->problem->get_time(),
-                                     funcs,
+                                     pfns,
                                      ctxs,
                                      this->problem->get_solution_vector(),
                                      diff));

--- a/src/L2FieldDiff.cpp
+++ b/src/L2FieldDiff.cpp
@@ -49,7 +49,7 @@ L2FieldDiff::create()
 {
     _F_;
     auto field_names = this->fepi->get_field_names();
-    PetscInt n_fields = field_names.size();
+    auto n_fields = field_names.size();
 
     if (this->funcs.size() == n_fields) {
         this->l2_diff.resize(n_fields, 0.);
@@ -71,7 +71,7 @@ void
 L2FieldDiff::compute()
 {
     _F_;
-    PetscInt n_fields = this->funcs.size();
+    auto n_fields = this->funcs.size();
     PetscFunc * funcs[n_fields];
     void * ctxs[n_fields];
     PetscReal diff[n_fields];

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -71,7 +71,7 @@ LineMesh::create_dm()
                                     &this->dm));
 
     // create user-friendly names for sides
-    std::map<int, std::string> face_set_names;
+    std::map<PetscInt, std::string> face_set_names;
     face_set_names[1] = "left";
     face_set_names[2] = "right";
     create_face_set_labels(face_set_names);

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -1,7 +1,6 @@
 #include "LinearProblem.h"
 #include "CallStack.h"
 #include "Mesh.h"
-#include "Utils.h"
 #include "Output.h"
 
 namespace godzilla {

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -52,6 +52,7 @@ LinearProblem::LinearProblem(const Parameters & parameters) :
     x(nullptr),
     b(nullptr),
     A(nullptr),
+    converged_reason(KSP_CONVERGED_ITERATING),
     lin_rel_tol(get_param<PetscReal>("lin_rel_tol")),
     lin_abs_tol(get_param<PetscReal>("lin_abs_tol")),
     lin_max_iter(get_param<PetscInt>("lin_max_iter"))

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,8 +1,6 @@
 #include "Logger.h"
 #include "CallStack.h"
-#include "petscsys.h"
 #include "fmt/printf.h"
-#include "fmt/color.h"
 
 namespace godzilla {
 

--- a/src/NaturalRiemannBC.cpp
+++ b/src/NaturalRiemannBC.cpp
@@ -44,7 +44,7 @@ NaturalRiemannBC::add_boundary()
                                    this->fid,
                                    get_num_components(),
                                    get_num_components() == 0 ? nullptr : get_components().data(),
-                                   (void (*)(void)) natural_riemann_boundary_condition_function,
+                                   (void (*)()) natural_riemann_boundary_condition_function,
                                    nullptr,
                                    (void *) this,
                                    &this->bd));

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -2,7 +2,6 @@
 #include "CallStack.h"
 #include "Problem.h"
 #include "Utils.h"
-#include <cassert>
 
 namespace godzilla {
 

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -3,8 +3,6 @@
 
 namespace godzilla {
 
-Parameters::Parameters() {}
-
 Parameters::Parameters(const Parameters & p)
 {
     *this = p;

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -17,8 +17,8 @@ Parameters &
 Parameters::operator=(const Parameters & rhs)
 {
     this->clear();
-    for (auto it = rhs.begin(); it != rhs.end(); ++it)
-        this->params[it->first] = it->second->copy();
+    for (const auto & par : rhs)
+        this->params[par.first] = par.second->copy();
     return *this;
 }
 

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -1,5 +1,4 @@
 #include "Parameters.h"
-#include <cmath>
 
 namespace godzilla {
 

--- a/src/PerfLog.cpp
+++ b/src/PerfLog.cpp
@@ -128,7 +128,7 @@ PerfLog::Stage::get_id() const
 
 // Event info
 
-PerfLog::EventInfo::EventInfo(PetscLogEvent event_id, PetscLogStage stage_id)
+PerfLog::EventInfo::EventInfo(PetscLogEvent event_id, PetscLogStage stage_id) : info()
 {
     PetscLogEventGetPerfInfo(stage_id, event_id, &this->info);
 }

--- a/src/Postprocessor.cpp
+++ b/src/Postprocessor.cpp
@@ -1,5 +1,4 @@
 #include "Postprocessor.h"
-#include "CallStack.h"
 #include "Problem.h"
 
 namespace godzilla {

--- a/src/PrintInterface.cpp
+++ b/src/PrintInterface.cpp
@@ -23,10 +23,10 @@ PrintInterface::PrintInterface(const App * app) :
 
 PrintInterface::PrintInterface(MPI_Comm comm,
                                const unsigned int & verbosity_level,
-                               const std::string & prefix) :
+                               std::string prefix) :
     proc_id(0),
     verbosity_level(verbosity_level),
-    prefix(prefix)
+    prefix(std::move(prefix))
 {
     MPI_Comm_rank(comm, &this->proc_id);
 }

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -101,7 +101,7 @@ RectangleMesh::create_dm()
                                     &this->dm));
 
     // create user-friendly names for sides
-    std::map<int, std::string> face_set_names;
+    std::map<PetscInt, std::string> face_set_names;
     face_set_names[1] = "bottom";
     face_set_names[2] = "right";
     face_set_names[3] = "top";

--- a/src/TimeSteppingAdaptor.cpp
+++ b/src/TimeSteppingAdaptor.cpp
@@ -1,7 +1,6 @@
 #include "TimeSteppingAdaptor.h"
 #include "CallStack.h"
 #include "TransientProblemInterface.h"
-#include <cassert>
 
 namespace godzilla {
 

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -58,7 +58,8 @@ TransientProblemInterface::TransientProblemInterface(Problem * problem, const Pa
     ts_adaptor(nullptr),
     start_time(params.get<PetscReal>("start_time")),
     end_time(params.get<PetscReal>("end_time")),
-    dt(params.get<PetscReal>("dt"))
+    dt(params.get<PetscReal>("dt")),
+    converged_reason(TS_CONVERGED_ITERATING)
 {
     _F_;
 }

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -3,9 +3,7 @@
 #include "Problem.h"
 #include "TimeSteppingAdaptor.h"
 #include "TransientProblemInterface.h"
-#include "NonlinearProblem.h"
 #include "Output.h"
-#include "petscdmplex.h"
 #include <cassert>
 #include "petsc/private/tsimpl.h"
 

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -170,7 +170,7 @@ UnstructuredMesh::is_simplex() const
 }
 
 void
-UnstructuredMesh::create_face_set_labels(const std::map<int, std::string> & names)
+UnstructuredMesh::create_face_set_labels(const std::map<PetscInt, std::string> & names)
 {
     _F_;
     DMLabel fs_label;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,7 +1,6 @@
 #include "Utils.h"
 #include "CallStack.h"
 #include <algorithm>
-#include <unistd.h>
 #include <sys/stat.h>
 
 namespace godzilla {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -11,7 +11,7 @@ bool
 path_exists(const std::string & path)
 {
     _F_;
-    struct stat buffer;
+    struct stat buffer = {};
     return (stat(path.c_str(), &buffer) == 0);
 }
 

--- a/src/Validation.cpp
+++ b/src/Validation.cpp
@@ -1,24 +1,19 @@
 #include "Validation.h"
 #include "Utils.h"
 #include "CallStack.h"
+#include <algorithm>
 
 namespace godzilla {
 namespace validation {
 
-/// Check that `param` attains one of the `options`
-///
-/// @return `true` if name is one f the options, `false` otherwise
-/// @param value Value to test
-/// @param options Possible options that value can have
 bool
 in(const std::string & value, const std::vector<std::string> & options)
 {
     _F_;
     std::string v = utils::to_lower(value);
-    for (auto & o : options)
-        if (v == utils::to_lower(o))
-            return true;
-    return false;
+    return std::any_of(options.cbegin(), options.cend(), [v](const std::string & o) {
+        return v == utils::to_lower(o);
+    });
 }
 
 } // namespace validation


### PR DESCRIPTION
- fixing const std:string in set_field_name API
- fixing narrowing conversions
- fixing shadowed vars
- using std::any_of
- Fixing uninitialized member variable
- passing prefix by value and using std::move
- use trivial default c-tor
- fixing uninitialized member variable
- using range-based loop
- fixing redundant use of `void`
- fixing ExodusIIMesh::get_file_name API
- writing global var names via exodusIIcpp API
- using range-based loop
- initialize `entry` during construction time
- pre-allocate std::vector
- using brace operator
- fixing uninitialized member variable
- passing by value and using std::move
- using range-based loop
- initialize `buffer` struct
- removing unused #includes
