### PR TITLE
FEProblemInterface::add/set_(aux)_fe

### DIFF
--- a/examples/burgers-eqn/src/BurgersEquation.cpp
+++ b/examples/burgers-eqn/src/BurgersEquation.cpp
@@ -62,7 +62,7 @@ void
 BurgersEquation::set_up_fields()
 {
     _F_;
-    add_fe(u_id, "u", 1, 1);
+    set_fe(u_id, "u", 1, 1);
 }
 
 void

--- a/examples/heat-eqn/src/HeatEquationExplicit.cpp
+++ b/examples/heat-eqn/src/HeatEquationExplicit.cpp
@@ -70,8 +70,8 @@ void
 HeatEquationExplicit::set_up_fields()
 {
     _F_;
-    add_fe(temp_id, "temp", 1, this->order);
-    add_aux_fe(ffn_aux_id, "forcing_fn", 1, this->order);
+    set_fe(temp_id, "temp", 1, this->order);
+    set_aux_fe(ffn_aux_id, "forcing_fn", 1, this->order);
 }
 
 void

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -110,11 +110,11 @@ void
 HeatEquationProblem::set_up_fields()
 {
     _F_;
-    add_fe(temp_id, "temp", 1, this->p_order);
+    set_fe(temp_id, "temp", 1, this->p_order);
 
-    add_aux_fe(q_ppp_id, "q_ppp", 1, 0);
-    add_aux_fe(htc_aux_id, "htc", 1, this->p_order);
-    add_aux_fe(T_ambient_aux_id, "T_ambient", 1, this->p_order);
+    set_aux_fe(q_ppp_id, "q_ppp", 1, 0);
+    set_aux_fe(htc_aux_id, "htc", 1, this->p_order);
+    set_aux_fe(T_ambient_aux_id, "T_ambient", 1, this->p_order);
 }
 
 void

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -280,12 +280,12 @@ NSIncompressibleProblem::set_up_fields()
     const char * comp_name[] = { "x", "y", "z" };
 
     PetscInt dim = this->get_dimension();
-    add_fe(velocity_id, "velocity", dim, 2);
+    set_fe(velocity_id, "velocity", dim, 2);
     for (unsigned int i = 0; i < dim; i++)
         set_field_component_name(velocity_id, i, comp_name[i]);
-    add_fe(pressure_id, "pressure", 1, 1);
+    set_fe(pressure_id, "pressure", 1, 1);
 
-    add_aux_fe(ffn_aid, "ffn", dim, 2);
+    set_aux_fe(ffn_aid, "ffn", dim, 2);
 }
 
 void

--- a/examples/poisson/src/PoissonEquation.cpp
+++ b/examples/poisson/src/PoissonEquation.cpp
@@ -33,8 +33,8 @@ void
 PoissonEquation::set_up_fields()
 {
     _F_;
-    add_fe(this->iu, "u", 1, this->p_order);
-    add_aux_fe(this->affn, "forcing_fn", 1, this->p_order);
+    set_fe(this->iu, "u", 1, this->p_order);
+    set_aux_fe(this->affn, "forcing_fn", 1, this->p_order);
 }
 
 void

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -68,19 +68,35 @@ public:
 
     /// Adds a volumetric field
     ///
-    /// @param id The field ID
     /// @param name The name of the field
     /// @param nc The number of components
     /// @param k The degree k of the space
-    virtual void add_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k);
+    /// @return ID of the new field
+    virtual PetscInt add_fe(const std::string & name, PetscInt nc, PetscInt k);
 
-    /// Adds a volumetric auxiliary field
+    /// Set a volumetric field
     ///
     /// @param id The field ID
     /// @param name The name of the field
     /// @param nc The number of components
     /// @param k The degree k of the space
-    virtual void add_aux_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k);
+    virtual void set_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k);
+
+    /// Adds a volumetric auxiliary field
+    ///
+    /// @param name The name of the field
+    /// @param nc The number of components
+    /// @param k The degree k of the space
+    /// @return ID of the new field
+    virtual PetscInt add_aux_fe(const std::string & name, PetscInt nc, PetscInt k);
+
+    /// Set a volumetric auxiliary field
+    ///
+    /// @param id The field ID
+    /// @param name The name of the field
+    /// @param nc The number of components
+    /// @param k The degree k of the space
+    virtual void set_aux_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k);
 
     /// Add auxiliary field
     ///
@@ -256,6 +272,8 @@ protected:
                                        PetscScalar u[],
                                        PetscScalar u_x[],
                                        PetscScalar u_t[]);
+
+    PetscInt get_next_id(const std::vector<PetscInt> & ids) const;
 
     /// PETSc section
     PetscSection section;

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+#include <map>
 #include <string>
 #include <typeinfo>
 
@@ -41,6 +43,31 @@ std::string
 type_name()
 {
     return typeid(T).name();
+}
+
+/**
+ *
+ */
+template <typename T, typename U>
+std::vector<T>
+map_keys(const std::map<T, U> & m)
+{
+    std::vector<T> k;
+    k.reserve(m.size());
+    for (auto && it : m)
+        k.push_back(it.first);
+    return k;
+}
+
+template <typename T, typename U>
+std::vector<T>
+map_values(const std::map<T, U> & m)
+{
+    std::vector<T> v;
+    v.reserve(m.size());
+    for (auto && it : m)
+        v.push_back(it.second);
+    return v;
 }
 
 } // namespace utils

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -12,6 +12,7 @@
 #include "WeakForm.h"
 #include "Functional.h"
 #include "IndexSet.h"
+#include "Utils.h"
 #include <cassert>
 #include <petsc/private/petscfeimpl.h>
 
@@ -292,8 +293,18 @@ FEProblemInterface::has_aux_field_by_name(const std::string & name) const
     return it != this->aux_fields_by_name.end();
 }
 
+PetscInt
+FEProblemInterface::add_fe(const std::string & name, PetscInt nc, PetscInt k)
+{
+    _F_;
+    std::vector<PetscInt> keys = utils::map_keys(this->fields);
+    PetscInt id = get_next_id(keys);
+    set_fe(id, name, nc, k);
+    return id;
+}
+
 void
-FEProblemInterface::add_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k)
+FEProblemInterface::set_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k)
 {
     _F_;
     auto it = this->fields.find(id);
@@ -311,8 +322,18 @@ FEProblemInterface::add_fe(PetscInt id, const std::string & name, PetscInt nc, P
         error("Cannot add field '%s' with ID = %d. ID already exists.", name, id);
 }
 
+PetscInt
+FEProblemInterface::add_aux_fe(const std::string & name, PetscInt nc, PetscInt k)
+{
+    _F_;
+    std::vector<PetscInt> keys = utils::map_keys(this->aux_fields);
+    PetscInt id = get_next_id(keys);
+    set_aux_fe(id, name, nc, k);
+    return id;
+}
+
 void
-FEProblemInterface::add_aux_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k)
+FEProblemInterface::set_aux_fe(PetscInt id, const std::string & name, PetscInt nc, PetscInt k)
 {
     _F_;
     auto it = this->aux_fields.find(id);
@@ -1627,6 +1648,18 @@ FEProblemInterface::evaluate_field_jets(PetscDS ds,
         d_offset += n_bf;
     }
     return 0;
+}
+
+PetscInt
+FEProblemInterface::get_next_id(const std::vector<PetscInt> & ids) const
+{
+    std::set<PetscInt> s;
+    for (auto & id : ids)
+        s.insert(id);
+    for (PetscInt id = 0; id < std::numeric_limits<PetscInt>::max(); id++)
+        if (s.find(id) == s.end())
+            return id;
+    return -1;
 }
 
 } // namespace godzilla

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -36,7 +36,7 @@ TEST_F(AuxiliaryFieldTest, api)
         }
     };
 
-    prob->add_aux_fe(0, "fld", 1, 1);
+    prob->set_aux_fe(0, "fld", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
     params.set<const App *>("_app") = app;
@@ -80,7 +80,7 @@ TEST_F(AuxiliaryFieldTest, non_existent_id)
 
     testing::internal::CaptureStderr();
 
-    prob->add_aux_fe(0, "aux1", 1, 1);
+    prob->set_aux_fe(0, "aux1", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
     params.set<const App *>("_app") = app;
@@ -123,7 +123,7 @@ TEST_F(AuxiliaryFieldTest, inconsistent_comp_number)
 
     testing::internal::CaptureStderr();
 
-    prob->add_aux_fe(0, "aux1", 1, 1);
+    prob->set_aux_fe(0, "aux1", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
     params.set<const App *>("_app") = app;
@@ -166,7 +166,7 @@ TEST_F(AuxiliaryFieldTest, non_existent_region)
 
     testing::internal::CaptureStderr();
 
-    prob->add_aux_fe(0, "aux1", 1, 1);
+    prob->set_aux_fe(0, "aux1", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
     params.set<const App *>("_app") = app;

--- a/test/src/BndJacobianFunc_test.cpp
+++ b/test/src/BndJacobianFunc_test.cpp
@@ -49,7 +49,7 @@ protected:
     void
     set_up_fields() override
     {
-        add_fe(0, "u", 1, 1);
+        set_fe(0, "u", 1, 1);
     }
 
     void

--- a/test/src/BndResidualFunc_test.cpp
+++ b/test/src/BndResidualFunc_test.cpp
@@ -49,7 +49,7 @@ protected:
     void
     set_up_fields() override
     {
-        add_fe(0, "u", 1, 1);
+        set_fe(0, "u", 1, 1);
     }
 
     void

--- a/test/src/ConstantAuxiliaryField_test.cpp
+++ b/test/src/ConstantAuxiliaryField_test.cpp
@@ -19,7 +19,7 @@ TEST(ConstantAuxiliaryFieldTest, create)
     prob_params.set<const App *>("_app") = &app;
     prob_params.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    prob.add_aux_fe(0, "aux1", 1, 1);
+    prob.set_aux_fe(0, "aux1", 1, 1);
 
     Parameters aux_params = ConstantAuxiliaryField::parameters();
     aux_params.set<const App *>("_app") = &app;
@@ -58,7 +58,7 @@ TEST(ConstantAuxiliaryFieldTest, evaluate)
     prob_params.set<const App *>("_app") = &app;
     prob_params.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    prob.add_aux_fe(0, "aux1", 1, 1);
+    prob.set_aux_fe(0, "aux1", 1, 1);
 
     Parameters aux_params = ConstantAuxiliaryField::parameters();
     aux_params.set<const App *>("_app") = &app;

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -31,7 +31,7 @@ protected:
     virtual void
     set_up_fields() override
     {
-        add_fe(0, "u", 1, 1);
+        set_fe(0, "u", 1, 1);
     }
     virtual void set_up_weak_form() override;
 };

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -51,7 +51,7 @@ TEST_F(FENonlinearProblemTest, get_fepi_mesh)
 
 TEST_F(FENonlinearProblemTest, fields)
 {
-    prob->add_fe(1, "vec", 3, 1);
+    prob->set_fe(1, "vec", 3, 1);
 
     mesh->create();
     prob->create();
@@ -87,19 +87,22 @@ TEST_F(FENonlinearProblemTest, fields)
                  "\\[ERROR\\] Unable to set component name for single-component field");
     EXPECT_DEATH(prob->set_field_component_name(65536, 0, "x"),
                  "\\[ERROR\\] Field with ID = '65536' does not exist\\.");
+
+    PetscInt fld2_idx = prob->add_fe("fld2", 3, 1);
+    EXPECT_EQ(fld2_idx, 2);
 }
 
 TEST_F(FENonlinearProblemTest, add_duplicate_field_id)
 {
-    prob->add_fe(0, "first", 1, 1);
-    EXPECT_DEATH(prob->add_fe(0, "second", 1, 1),
+    prob->set_fe(0, "first", 1, 1);
+    EXPECT_DEATH(prob->set_fe(0, "second", 1, 1),
                  "\\[ERROR\\] Cannot add field 'second' with ID = 0. ID already exists.");
 }
 
 TEST_F(FENonlinearProblemTest, get_aux_fields)
 {
     mesh->create();
-    prob->add_aux_fe(0, "aux_one", 1, 1);
+    prob->set_aux_fe(0, "aux_one", 1, 1);
     prob->create();
 
     EXPECT_EQ(prob->get_aux_field_name(0), "aux_one");
@@ -117,9 +120,9 @@ TEST_F(FENonlinearProblemTest, get_aux_fields)
 
 TEST_F(FENonlinearProblemTest, add_duplicate_aux_field_id)
 {
-    prob->add_aux_fe(0, "first", 1, 1);
+    prob->set_aux_fe(0, "first", 1, 1);
     EXPECT_DEATH(
-        prob->add_aux_fe(0, "second", 1, 1),
+        prob->set_aux_fe(0, "second", 1, 1),
         "\\[ERROR\\] Cannot add auxiliary field 'second' with ID = 0. ID is already taken.");
 }
 

--- a/test/src/FunctionAuxiliaryField_test.cpp
+++ b/test/src/FunctionAuxiliaryField_test.cpp
@@ -19,7 +19,7 @@ TEST(FunctionAuxiliaryFieldTest, create)
     prob_params.set<const App *>("_app") = &app;
     prob_params.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    prob.add_aux_fe(0, "aux1", 1, 1);
+    prob.set_aux_fe(0, "aux1", 1, 1);
 
     Parameters aux_params = FunctionAuxiliaryField::parameters();
     aux_params.set<const App *>("_app") = &app;
@@ -58,7 +58,7 @@ TEST(FunctionAuxiliaryFieldTest, evaluate)
     prob_params.set<const App *>("_app") = &app;
     prob_params.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    prob.add_aux_fe(0, "aux1", 1, 1);
+    prob.set_aux_fe(0, "aux1", 1, 1);
 
     Parameters aux_params = FunctionAuxiliaryField::parameters();
     aux_params.set<const App *>("_app") = &app;

--- a/test/src/GTest2FieldsFENonlinearProblem.cpp
+++ b/test/src/GTest2FieldsFENonlinearProblem.cpp
@@ -13,5 +13,5 @@ void
 GTest2FieldsFENonlinearProblem::set_up_fields()
 {
     GTestFENonlinearProblem::set_up_fields();
-    add_fe(this->iv, "v", 1, 1);
+    set_fe(this->iv, "v", 1, 1);
 }

--- a/test/src/GTestFENonlinearProblem.cpp
+++ b/test/src/GTestFENonlinearProblem.cpp
@@ -88,7 +88,7 @@ void
 GTestFENonlinearProblem::set_up_fields()
 {
     PetscInt order = 1;
-    add_fe(this->iu, "u", 1, order);
+    set_fe(this->iu, "u", 1, order);
 }
 
 void

--- a/test/src/GTestImplicitFENonlinearProblem.cpp
+++ b/test/src/GTestImplicitFENonlinearProblem.cpp
@@ -106,7 +106,7 @@ GTestImplicitFENonlinearProblem::set_up_fields()
 {
     _F_;
     PetscInt order = 1;
-    add_fe(this->iu, "u", 1, order);
+    set_fe(this->iu, "u", 1, order);
 }
 
 void

--- a/test/src/JacobianFunc_test.cpp
+++ b/test/src/JacobianFunc_test.cpp
@@ -29,7 +29,7 @@ protected:
     void
     set_up_fields() override
     {
-        add_fe(0, "u", 1, 1);
+        set_fe(0, "u", 1, 1);
     }
 
     void

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -145,7 +145,7 @@ TEST(NaturalBCTest, fe)
     prob_params.set<const Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
     app.problem = &prob;
-    prob.add_aux_fe(0, "aux1", 1, 1);
+    prob.set_aux_fe(0, "aux1", 1, 1);
 
     Parameters bc_params = TestNaturalBC::parameters();
     bc_params.set<const App *>("_app") = &app;

--- a/test/src/ResidualFunc_test.cpp
+++ b/test/src/ResidualFunc_test.cpp
@@ -29,7 +29,7 @@ protected:
     void
     set_up_fields() override
     {
-        add_fe(0, "u", 1, 1);
+        set_fe(0, "u", 1, 1);
     }
 
     void

--- a/test/src/Utils_test.cpp
+++ b/test/src/Utils_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "Utils.h"
 
 using namespace godzilla;
@@ -25,4 +25,20 @@ TEST(UtilsTest, has_prefix)
     EXPECT_TRUE(utils::has_prefix("asdf", "as"));
     EXPECT_FALSE(utils::has_prefix("asdf", "long_string"));
     EXPECT_FALSE(utils::has_prefix("asdf", "df"));
+}
+
+TEST(UtilsTest, map_keys)
+{
+    std::map<int, int> m = { { 1, 200 }, { 2, 201 }, { 5, 203 }, { 9, 204 } };
+
+    std::vector<int> keys = utils::map_keys(m);
+    EXPECT_THAT(keys, testing::UnorderedElementsAre(1, 2, 5, 9));
+}
+
+TEST(UtilsTest, map_values)
+{
+    std::map<int, int> m = { { 1, 200 }, { 2, 201 }, { 5, 203 }, { 9, 204 } };
+
+    std::vector<int> keys = utils::map_values(m);
+    EXPECT_THAT(keys, testing::UnorderedElementsAre(200, 201, 203, 204));
 }


### PR DESCRIPTION
FE fields and FE auxiliary fields can be added via `add_(aux)_fe` or
set via `set_(aux)_fe`.
