### PR TITLE
Removing PetscDS from BoundaryCondition

### DIFF
--- a/include/BoundaryCondition.h
+++ b/include/BoundaryCondition.h
@@ -49,12 +49,6 @@ protected:
     /// Discrete problem this object is part of
     const DiscreteProblemInterface * dpi;
 
-    /// DM object
-    DM dm;
-
-    /// DS object
-    PetscDS ds;
-
     /// DMLabel associated with the boundary name this boundary condition acts on
     DMLabel label;
 

--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -118,6 +118,30 @@ public:
     /// @return The weak form associated with this problem
     virtual WeakForm * get_weak_form() const = 0;
 
+    // NOTE: these may be pushed down into child classes if needed
+    virtual void add_boundary_essential(const std::string & name,
+                                        DMLabel label,
+                                        const std::vector<Int> & ids,
+                                        Int field,
+                                        const std::vector<Int> & components,
+                                        PetscFunc * fn,
+                                        PetscFunc * fn_t,
+                                        void * context) const = 0;
+    virtual void add_boundary_natural(const std::string & name,
+                                      DMLabel label,
+                                      const std::vector<Int> & ids,
+                                      Int field,
+                                      const std::vector<Int> & components,
+                                      void * context) const = 0;
+    virtual void add_boundary_natural_riemann(const std::string & name,
+                                              DMLabel label,
+                                              const std::vector<Int> & ids,
+                                              Int field,
+                                              const std::vector<Int> & components,
+                                              PetscNaturalRiemannBCFunc * fn,
+                                              PetscNaturalRiemannBCFunc * fn_t,
+                                              void * context) const = 0;
+
 protected:
     virtual void init();
     virtual void create();

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -207,6 +207,7 @@ protected:
 
     void create() override;
     void init() override;
+
     virtual void allocate_objects();
 
     /// Create FE object from FieldInfo
@@ -216,6 +217,29 @@ protected:
 
     /// Set up discretization system
     void set_up_ds() override;
+
+    void add_boundary_essential(const std::string & name,
+                                DMLabel label,
+                                const std::vector<Int> & ids,
+                                Int field,
+                                const std::vector<Int> & components,
+                                PetscFunc * fn,
+                                PetscFunc * fn_t,
+                                void * context) const override;
+    void add_boundary_natural(const std::string & name,
+                              DMLabel label,
+                              const std::vector<Int> & ids,
+                              Int field,
+                              const std::vector<Int> & components,
+                              void * context) const override;
+    void add_boundary_natural_riemann(const std::string & name,
+                                      DMLabel label,
+                                      const std::vector<Int> & ids,
+                                      Int field,
+                                      const std::vector<Int> & components,
+                                      PetscNaturalRiemannBCFunc * fn,
+                                      PetscNaturalRiemannBCFunc * fn_t,
+                                      void * context) const override;
 
     /// Set up quadrature
     virtual void set_up_quadrature();

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -40,6 +40,28 @@ protected:
     void create() override;
     virtual void allocate_objects();
     void set_up_ds() override;
+    void add_boundary_essential(const std::string & name,
+                                DMLabel label,
+                                const std::vector<Int> & ids,
+                                Int field,
+                                const std::vector<Int> & components,
+                                PetscFunc * fn,
+                                PetscFunc * fn_t,
+                                void * context) const override;
+    void add_boundary_natural(const std::string & name,
+                              DMLabel label,
+                              const std::vector<Int> & ids,
+                              Int field,
+                              const std::vector<Int> & components,
+                              void * context) const override;
+    void add_boundary_natural_riemann(const std::string & name,
+                                      DMLabel label,
+                                      const std::vector<Int> & ids,
+                                      Int field,
+                                      const std::vector<Int> & components,
+                                      PetscNaturalRiemannBCFunc * fn,
+                                      PetscNaturalRiemannBCFunc * fn_t,
+                                      void * context) const override;
 
     /// Compute flux
     ///

--- a/include/NaturalBC.h
+++ b/include/NaturalBC.h
@@ -42,9 +42,6 @@ protected:
     /// WeakForm object
     WeakForm * wf;
 
-    /// Boundary number
-    Int bd;
-
 public:
     static Parameters parameters();
 };

--- a/include/NaturalRiemannBC.h
+++ b/include/NaturalRiemannBC.h
@@ -23,9 +23,6 @@ public:
 protected:
     void add_boundary() override;
 
-    /// Boundary number
-    Int bd;
-
 public:
     static Parameters parameters();
 };

--- a/include/Types.h
+++ b/include/Types.h
@@ -50,4 +50,11 @@ typedef void PetscFieldFunc(Int dim,
 typedef PetscErrorCode
 PetscFunc(Int dim, Real time, const Real x[], Int Nc, Scalar u[], void * ctx);
 
+typedef PetscErrorCode PetscNaturalRiemannBCFunc(Real time,
+                                                 const Real * c,
+                                                 const Real * n,
+                                                 const Scalar * xI,
+                                                 Scalar * xG,
+                                                 void * ctx);
+
 } // namespace godzilla

--- a/src/BoundaryCondition.cpp
+++ b/src/BoundaryCondition.cpp
@@ -24,8 +24,6 @@ BoundaryCondition::BoundaryCondition(const Parameters & params) :
     Object(params),
     PrintInterface(this),
     dpi(get_param<const DiscreteProblemInterface *>("_dpi")),
-    dm(nullptr),
-    ds(nullptr),
     label(nullptr),
     fid(-1),
     ids({}),
@@ -40,8 +38,6 @@ BoundaryCondition::create()
     _F_;
     Problem * problem = this->app->get_problem();
     assert(problem != nullptr);
-    this->dm = problem->get_dm();
-    assert(this->dm != nullptr);
 
     assert(this->dpi != nullptr);
     const UnstructuredMesh * mesh = this->dpi->get_mesh();
@@ -89,7 +85,6 @@ void
 BoundaryCondition::set_up()
 {
     _F_;
-    PETSC_CHECK(DMGetDS(this->dm, &this->ds));
     IndexSet is = IndexSet::values_from_label(this->label);
     is.get_indices();
     this->ids = is.to_std_vector();

--- a/src/EssentialBC.cpp
+++ b/src/EssentialBC.cpp
@@ -1,5 +1,6 @@
 #include "EssentialBC.h"
 #include "CallStack.h"
+#include "DiscreteProblemInterface.h"
 #include <cassert>
 
 namespace godzilla {
@@ -71,20 +72,14 @@ void
 EssentialBC::add_boundary()
 {
     _F_;
-    const auto & components = get_components();
-    PETSC_CHECK(PetscDSAddBoundary(this->ds,
-                                   DM_BC_ESSENTIAL,
-                                   get_name().c_str(),
-                                   this->label,
-                                   this->ids.size(),
-                                   this->ids.data(),
-                                   this->fid,
-                                   components.size(),
-                                   components.size() == 0 ? nullptr : components.data(),
-                                   (void (*)()) get_function(),
-                                   (void (*)()) get_function_t(),
-                                   (void *) get_context(),
-                                   nullptr));
+    this->dpi->add_boundary_essential(get_name(),
+                                      this->label,
+                                      this->ids,
+                                      this->fid,
+                                      get_components(),
+                                      get_function(),
+                                      get_function_t(),
+                                      this);
 }
 
 } // namespace godzilla

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -1690,4 +1690,68 @@ FEProblemInterface::get_next_id(const std::vector<Int> & ids) const
     return -1;
 }
 
+void
+FEProblemInterface::add_boundary_essential(const std::string & name,
+                                           DMLabel label,
+                                           const std::vector<Int> & ids,
+                                           Int field,
+                                           const std::vector<Int> & components,
+                                           PetscFunc * fn,
+                                           PetscFunc * fn_t,
+                                           void * context) const
+{
+    _F_;
+    PETSC_CHECK(PetscDSAddBoundary(this->ds,
+                                   DM_BC_ESSENTIAL,
+                                   name.c_str(),
+                                   label,
+                                   ids.size(),
+                                   ids.data(),
+                                   field,
+                                   components.size(),
+                                   components.size() == 0 ? nullptr : components.data(),
+                                   (void (*)()) fn,
+                                   (void (*)()) fn_t,
+                                   context,
+                                   nullptr));
+}
+
+void
+FEProblemInterface::add_boundary_natural(const std::string & name,
+                                         DMLabel label,
+                                         const std::vector<Int> & ids,
+                                         Int field,
+                                         const std::vector<Int> & components,
+                                         void * context) const
+{
+    _F_;
+    PETSC_CHECK(PetscDSAddBoundary(this->ds,
+                                   DM_BC_NATURAL,
+                                   name.c_str(),
+                                   label,
+                                   ids.size(),
+                                   ids.data(),
+                                   field,
+                                   components.size(),
+                                   components.size() == 0 ? nullptr : components.data(),
+                                   nullptr,
+                                   nullptr,
+                                   context,
+                                   nullptr));
+}
+
+void
+FEProblemInterface::add_boundary_natural_riemann(const std::string & name,
+                                                 DMLabel label,
+                                                 const std::vector<Int> & ids,
+                                                 Int field,
+                                                 const std::vector<Int> & components,
+                                                 PetscNaturalRiemannBCFunc * fn,
+                                                 PetscNaturalRiemannBCFunc * fn_t,
+                                                 void * context) const
+{
+    _F_;
+    error("Natural Riemann BCs are not supported for FE problems");
+}
+
 } // namespace godzilla

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -260,4 +260,56 @@ FVProblemInterface::set_up_ds()
     PETSC_CHECK(PetscDSSetContext(this->ds, 0, this));
 }
 
+void
+FVProblemInterface::add_boundary_essential(const std::string & name,
+                                           DMLabel label,
+                                           const std::vector<Int> & ids,
+                                           Int field,
+                                           const std::vector<Int> & components,
+                                           PetscFunc * fn,
+                                           PetscFunc * fn_t,
+                                           void * context) const
+{
+    _F_;
+    error("Essential BCs are not supported for FV problems");
+}
+
+void
+FVProblemInterface::add_boundary_natural(const std::string & name,
+                                         DMLabel label,
+                                         const std::vector<Int> & ids,
+                                         Int field,
+                                         const std::vector<Int> & components,
+                                         void * context) const
+{
+    _F_;
+    error("Natural BCs are not supported for FV problems");
+}
+
+void
+FVProblemInterface::add_boundary_natural_riemann(const std::string & name,
+                                                 DMLabel label,
+                                                 const std::vector<Int> & ids,
+                                                 Int field,
+                                                 const std::vector<Int> & components,
+                                                 PetscNaturalRiemannBCFunc * fn,
+                                                 PetscNaturalRiemannBCFunc * fn_t,
+                                                 void * context) const
+{
+    _F_;
+    PETSC_CHECK(PetscDSAddBoundary(this->ds,
+                                   DM_BC_NATURAL_RIEMANN,
+                                   name.c_str(),
+                                   label,
+                                   ids.size(),
+                                   ids.data(),
+                                   field,
+                                   components.size(),
+                                   components.size() == 0 ? nullptr : components.data(),
+                                   (void (*)()) fn,
+                                   (void (*)()) fn_t,
+                                   context,
+                                   nullptr));
+}
+
 } // namespace godzilla

--- a/src/NaturalBC.cpp
+++ b/src/NaturalBC.cpp
@@ -16,8 +16,7 @@ NaturalBC::parameters()
 
 NaturalBC::NaturalBC(const Parameters & params) :
     BoundaryCondition(params),
-    wf(this->dpi->get_weak_form()),
-    bd(-1)
+    wf(this->dpi->get_weak_form())
 {
     _F_;
 }
@@ -26,20 +25,12 @@ void
 NaturalBC::add_boundary()
 {
     _F_;
-    const auto & components = get_components();
-    PETSC_CHECK(PetscDSAddBoundary(this->ds,
-                                   DM_BC_NATURAL,
-                                   get_name().c_str(),
-                                   this->label,
-                                   this->ids.size(),
-                                   this->ids.data(),
-                                   this->fid,
-                                   components.size(),
-                                   components.size() == 0 ? nullptr : components.data(),
-                                   nullptr,
-                                   nullptr,
-                                   (void *) this,
-                                   &this->bd));
+    this->dpi->add_boundary_natural(get_name(),
+                                    this->label,
+                                    this->ids,
+                                    this->fid,
+                                    get_components(),
+                                    this);
 }
 
 void

--- a/src/NaturalRiemannBC.cpp
+++ b/src/NaturalRiemannBC.cpp
@@ -1,5 +1,6 @@
 #include "NaturalRiemannBC.h"
 #include "CallStack.h"
+#include "DiscreteProblemInterface.h"
 #include <cassert>
 
 namespace godzilla {
@@ -26,7 +27,7 @@ NaturalRiemannBC::parameters()
     return params;
 }
 
-NaturalRiemannBC::NaturalRiemannBC(const Parameters & params) : BoundaryCondition(params), bd(-1)
+NaturalRiemannBC::NaturalRiemannBC(const Parameters & params) : BoundaryCondition(params)
 {
     _F_;
 }
@@ -35,20 +36,14 @@ void
 NaturalRiemannBC::add_boundary()
 {
     _F_;
-    const auto & components = get_components();
-    PETSC_CHECK(PetscDSAddBoundary(this->ds,
-                                   DM_BC_NATURAL_RIEMANN,
-                                   get_name().c_str(),
-                                   this->label,
-                                   this->ids.size(),
-                                   this->ids.data(),
-                                   this->fid,
-                                   components.size(),
-                                   components.size() == 0 ? nullptr : components.data(),
-                                   (void (*)()) natural_riemann_boundary_condition_function,
-                                   nullptr,
-                                   (void *) this,
-                                   &this->bd));
+    this->dpi->add_boundary_natural_riemann(get_name(),
+                                            this->label,
+                                            this->ids,
+                                            this->fid,
+                                            get_components(),
+                                            natural_riemann_boundary_condition_function,
+                                            nullptr,
+                                            this);
 }
 
 } // namespace godzilla

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -105,12 +105,6 @@ TEST(NaturalBCTest, fe)
             set_jacobian_block(this->fid, new TestNatG0(this), nullptr, nullptr, nullptr);
         }
 
-        Int
-        get_bd() const
-        {
-            return this->bd;
-        }
-
         WeakForm *
         get_wf() const
         {
@@ -164,35 +158,7 @@ TEST(NaturalBCTest, fe)
     PetscDSGetNumBoundary(ds, &num_bd);
     EXPECT_EQ(num_bd, 1);
     //
-    DMBoundaryConditionType type;
-    const char * name;
-    DMLabel label;
-    Int nv;
-    const Int * values;
-    Int field;
-    Int nc;
-    const Int * comps;
-    PetscDSGetBoundary(ds,
-                       bc.get_bd(),
-                       nullptr,
-                       &type,
-                       &name,
-                       &label,
-                       &nv,
-                       &values,
-                       &field,
-                       &nc,
-                       &comps,
-                       nullptr,
-                       nullptr,
-                       nullptr);
-    EXPECT_STREQ(name, "bc1");
-    EXPECT_EQ(nv, 1);
-    EXPECT_EQ(values[0], 1);
-    EXPECT_EQ(field, 0);
-    EXPECT_EQ(nc, 1);
-    EXPECT_EQ(comps[0], 0);
-    //
+    Int field = bc.get_field_id();
     WeakForm * wf = bc.get_wf();
     Int id = bc.get_ids()[0];
     Int part = 0;


### PR DESCRIPTION
Adding boundary conditions is handled via DiscreteProblemInterface.
