### PR TITLE
Adding unit test for surface integration

### DIFF
--- a/include/BndJacobianFunc.h
+++ b/include/BndJacobianFunc.h
@@ -19,11 +19,6 @@ protected:
     ///
     /// @return Outward normal
     NO_DISCARD const Normal & get_normal() const;
-
-    /// Get physical coordinates
-    ///
-    /// @return Physical coordinates
-    NO_DISCARD const Point & get_xyz() const;
 };
 
 } // namespace godzilla

--- a/include/BndResidualFunc.h
+++ b/include/BndResidualFunc.h
@@ -20,11 +20,6 @@ protected:
     ///
     /// @return Outward normal
     NO_DISCARD const Normal & get_normal() const;
-
-    /// Get physical coordinates
-    ///
-    /// @return Physical coordinates
-    NO_DISCARD const Point & get_xyz() const;
 };
 
 } // namespace godzilla

--- a/include/FieldValue.h
+++ b/include/FieldValue.h
@@ -57,7 +57,7 @@ public:
     explicit Normal(const Int & dim) : LateBindArray<Real>(), dim(dim) {}
 
     Real
-    operator[](unsigned int idx) const
+    operator()(unsigned int idx) const
     {
         assert(this->data != nullptr);
         assert(idx < this->dim);
@@ -74,7 +74,7 @@ public:
     explicit Point(const Int & dim) : LateBindArray<Real>(), dim(dim) {}
 
     Real
-    operator[](unsigned int idx) const
+    operator()(unsigned int idx) const
     {
         assert(this->data != nullptr);
         assert(idx < this->dim);

--- a/include/JacobianFunc.h
+++ b/include/JacobianFunc.h
@@ -20,6 +20,11 @@ public:
     virtual void evaluate(Scalar val[]) const = 0;
 
 protected:
+    /// Get physical coordinates
+    ///
+    /// @return Physical coordinates
+    NO_DISCARD const Point & get_xyz() const;
+
     /// Get the multiplier a for dF/dU_t
     ///
     /// @return The multiplier a for dF/dU_t

--- a/include/ResidualFunc.h
+++ b/include/ResidualFunc.h
@@ -14,6 +14,12 @@ public:
     ///
     /// @param val Array to store the values into
     virtual void evaluate(Scalar val[]) const = 0;
+
+protected:
+    /// Get physical coordinates
+    ///
+    /// @return Physical coordinates
+    NO_DISCARD const Point & get_xyz() const;
 };
 
 } // namespace godzilla

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -59,7 +59,7 @@ public:
 
     void zero();
 
-    Scalar operator[](Int idx) const;
+    Scalar operator()(Int idx) const;
 
     explicit operator Vec() const;
 

--- a/src/BndJacobianFunc.cpp
+++ b/src/BndJacobianFunc.cpp
@@ -17,11 +17,4 @@ BndJacobianFunc::get_normal() const
     return get_fe_problem()->get_normal();
 }
 
-const Point &
-BndJacobianFunc::get_xyz() const
-{
-    _F_;
-    return get_fe_problem()->get_xyz();
-}
-
 } // namespace godzilla

--- a/src/BndResidualFunc.cpp
+++ b/src/BndResidualFunc.cpp
@@ -17,11 +17,4 @@ BndResidualFunc::get_normal() const
     return get_fe_problem()->get_normal();
 }
 
-const Point &
-BndResidualFunc::get_xyz() const
-{
-    _F_;
-    return get_fe_problem()->get_xyz();
-}
-
 } // namespace godzilla

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -938,6 +938,7 @@ FEProblemInterface::integrate_residual(PetscDS ds,
         for (Int q = 0; q < q_n_pts; ++q) {
             PETSC_CHECK(
                 PetscFEGeomGetPoint(cell_geom, e, q, &q_points[q * cell_geom->dim], &fe_geom));
+            this->asmbl.xyz.set(fe_geom.v);
             Real w = fe_geom.detJ[0] * q_weights[q];
 
             PETSC_CHECK(evaluate_field_jets(ds,
@@ -1091,6 +1092,7 @@ FEProblemInterface::integrate_bnd_residual(PetscDS ds,
         for (Int q = 0; q < q_n_pts; ++q) {
             PETSC_CHECK(
                 PetscFEGeomGetPoint(face_geom, e, q, &q_points[q * face_geom->dim], &fe_geom));
+            this->asmbl.xyz.set(fe_geom.v);
             PETSC_CHECK(PetscFEGeomGetCellPoint(face_geom, e, q, &cell_geom));
             Real w = fe_geom.detJ[0] * q_weights[q];
             this->asmbl.normals.set(fe_geom.n);
@@ -1288,7 +1290,8 @@ FEProblemInterface::integrate_jacobian(PetscDS ds,
                                      this->asmbl.xyz.get());
             }
             else {
-                fe_geom.v = &cell_geom->v[(e * n_pts + q) * dim_embed];
+                this->asmbl.xyz.set(&cell_geom->v[(e * n_pts + q) * dim_embed]);
+                fe_geom.v = this->asmbl.xyz.get();
                 fe_geom.J = &cell_geom->J[(e * n_pts + q) * dim_embed * dim_embed];
                 fe_geom.invJ = &cell_geom->invJ[(e * n_pts + q) * dim_embed * dim_embed];
                 fe_geom.detJ = &cell_geom->detJ[e * n_pts + q];
@@ -1504,7 +1507,8 @@ FEProblemInterface::integrate_bnd_jacobian(PetscDS ds,
                                      this->asmbl.xyz.get());
             }
             else {
-                fe_geom.v = &face_geom->v[(e * n_pts + q) * dim_embed];
+                this->asmbl.xyz.set(&face_geom->v[(e * n_pts + q) * dim_embed]);
+                fe_geom.v = this->asmbl.xyz.get();
                 fe_geom.J = &face_geom->J[(e * n_pts + q) * dim_embed * dim_embed];
                 fe_geom.invJ = &face_geom->invJ[(e * n_pts + q) * dim_embed * dim_embed];
                 fe_geom.detJ = &face_geom->detJ[e * n_pts + q];

--- a/src/JacobianFunc.cpp
+++ b/src/JacobianFunc.cpp
@@ -9,6 +9,13 @@ JacobianFunc::JacobianFunc(const FEProblemInterface * fepi, const std::string & 
 {
 }
 
+const Point &
+JacobianFunc::get_xyz() const
+{
+    _F_;
+    return get_fe_problem()->get_xyz();
+}
+
 const Real &
 JacobianFunc::get_time_shift() const
 {

--- a/src/ResidualFunc.cpp
+++ b/src/ResidualFunc.cpp
@@ -7,4 +7,11 @@ ResidualFunc::ResidualFunc(const FEProblemInterface * fepi, const std::string & 
 {
 }
 
+const Point &
+ResidualFunc::get_xyz() const
+{
+    _F_;
+    return get_fe_problem()->get_xyz();
+}
+
 } // namespace godzilla

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -237,7 +237,7 @@ Vector::zero()
 }
 
 Scalar
-Vector::operator[](Int idx) const
+Vector::operator()(Int idx) const
 {
     _F_;
     Scalar val;

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(${PROJECT_NAME}
     MeshPartitioningOutput_test.cpp
     NaturalBC_test.cpp
     NaturalRiemannBC_test.cpp
+    NeumannProblem_test.cpp
     NonlinearProblem_test.cpp
     Object_test.cpp
     Output_test.cpp

--- a/test/src/Matrix_test.cpp
+++ b/test/src/Matrix_test.cpp
@@ -101,8 +101,8 @@ TEST(MatrixTest, mult)
 
     m.mult(x, y);
 
-    EXPECT_DOUBLE_EQ(y[0], 3.);
-    EXPECT_DOUBLE_EQ(y[1], 5.);
+    EXPECT_DOUBLE_EQ(y(0), 3.);
+    EXPECT_DOUBLE_EQ(y(1), 5.);
 
     m.destroy();
 }

--- a/test/src/NeumannProblem_test.cpp
+++ b/test/src/NeumannProblem_test.cpp
@@ -1,0 +1,213 @@
+#include "gmock/gmock.h"
+#include "TestApp.h"
+#include "FENonlinearProblem.h"
+#include "LineMesh.h"
+#include "RectangleMesh.h"
+#include "NaturalBC.h"
+#include "WeakForm.h"
+#include "BndResidualFunc.h"
+#include "BndJacobianFunc.h"
+
+using namespace godzilla;
+using namespace testing;
+
+namespace {
+
+class TestNeumannProblem : public FENonlinearProblem {
+public:
+    explicit TestNeumannProblem(const Parameters & params);
+
+protected:
+    void set_up_fields() override;
+    void set_up_weak_form() override;
+
+    const Int iu;
+};
+
+class F0 : public ResidualFunc {
+public:
+    explicit F0(const TestNeumannProblem * prob) :
+        ResidualFunc(prob),
+        u(get_field_value("u")),
+        x(get_xyz())
+    {
+    }
+
+    void
+    evaluate(Scalar f[]) const override
+    {
+        f[0] = this->u[0] + 2.0 - this->x(0) * this->x(0);
+    }
+
+protected:
+    const FieldValue & u;
+    const Point & x;
+};
+
+class F1 : public ResidualFunc {
+public:
+    explicit F1(const TestNeumannProblem * prob) :
+        ResidualFunc(prob),
+        dim(get_spatial_dimension()),
+        u_x(get_field_gradient("u"))
+    {
+    }
+
+    void
+    evaluate(Scalar f[]) const override
+    {
+        for (Int d = 0; d < this->dim; ++d)
+            f[d] = this->u_x[d];
+    }
+
+protected:
+    const Int & dim;
+    const FieldGradient & u_x;
+};
+
+class G0 : public JacobianFunc {
+public:
+    explicit G0(const TestNeumannProblem * prob) : JacobianFunc(prob) {}
+
+    void
+    evaluate(Scalar g[]) const override
+    {
+        g[0] = 1.;
+    }
+};
+
+class G3 : public JacobianFunc {
+public:
+    explicit G3(const TestNeumannProblem * prob) : JacobianFunc(prob), dim(get_spatial_dimension())
+    {
+    }
+
+    void
+    evaluate(Scalar g[]) const override
+    {
+        for (Int d = 0; d < this->dim; ++d)
+            g[d * this->dim + d] = 1.;
+    }
+
+protected:
+    const Int & dim;
+};
+
+TestNeumannProblem::TestNeumannProblem(const Parameters & params) :
+    FENonlinearProblem(params),
+    iu(0)
+{
+}
+
+void
+TestNeumannProblem::set_up_fields()
+{
+    Int order = 2;
+    set_fe(this->iu, "u", 1, order);
+}
+
+void
+TestNeumannProblem::set_up_weak_form()
+{
+    set_residual_block(this->iu, new F0(this), new F1(this));
+    set_jacobian_block(this->iu, this->iu, new G0(this), nullptr, nullptr, new G3(this));
+}
+
+class BndF0 : public BndResidualFunc {
+public:
+    explicit BndF0(const NaturalBC * bc) : BndResidualFunc(bc), n(get_normal()), x(get_xyz()) {}
+
+    void
+    evaluate(Scalar f[]) const override
+    {
+        f[0] = -2. * this->x(0) * n(0);
+    }
+
+protected:
+    const Normal & n;
+    const Point & x;
+};
+
+class BndG0 : public BndJacobianFunc {
+public:
+    explicit BndG0(const NaturalBC * bc) : BndJacobianFunc(bc) {}
+
+    void
+    evaluate(Scalar g[]) const override
+    {
+        g[0] = 0.;
+    }
+};
+
+class TestNeumannBC : public NaturalBC {
+public:
+    explicit TestNeumannBC(const Parameters & params) : NaturalBC(params), comps({ 0 }) {}
+
+    virtual const std::vector<Int> &
+    get_components() const
+    {
+        return this->comps;
+    }
+
+    virtual void
+    set_up_weak_form()
+    {
+        set_residual_block(new BndF0(this), nullptr);
+        set_jacobian_block(this->fid, new BndG0(this), nullptr, nullptr, nullptr);
+    }
+
+protected:
+    std::vector<Int> comps;
+};
+
+} // namespace
+
+TEST(NeumannProblemTest, solve)
+{
+    TestApp app;
+
+    Parameters mesh_params = RectangleMesh::parameters();
+    mesh_params.set<const App *>("_app") = &app;
+    mesh_params.set<Int>("nx") = 2;
+    mesh_params.set<Int>("ny") = 1;
+    RectangleMesh mesh(mesh_params);
+
+    Parameters prob_params = TestNeumannProblem::parameters();
+    prob_params.set<const App *>("_app") = &app;
+    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    TestNeumannProblem prob(prob_params);
+    app.problem = &prob;
+
+    Parameters bc_left_pars = TestNeumannBC::parameters();
+    bc_left_pars.set<const App *>("_app") = &app;
+    bc_left_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_left_pars.set<std::string>("_name") = "bc1";
+    bc_left_pars.set<std::string>("boundary") = "left";
+    TestNeumannBC bc_left(bc_left_pars);
+    prob.add_boundary_condition(&bc_left);
+
+    Parameters bc_right_pars = TestNeumannBC::parameters();
+    bc_right_pars.set<const App *>("_app") = &app;
+    bc_right_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_right_pars.set<std::string>("_name") = "bc2";
+    bc_right_pars.set<std::string>("boundary") = "right";
+    TestNeumannBC bc_right(bc_right_pars);
+    prob.add_boundary_condition(&bc_right);
+
+    mesh.create();
+    prob.create();
+
+    prob.solve();
+
+    bool conv = prob.converged();
+    EXPECT_EQ(conv, true);
+
+    std::vector<Scalar> sln = { 0.0625, 0.5625, 0.,     0.25,   1., 0.,   0.25, 1,
+                                0.0625, 0.5625, 0.0625, 0.5625, 0., 0.25, 1. };
+    auto x = prob.get_solution_vector();
+    EXPECT_EQ(x.get_size(), sln.size());
+    auto * xx = x.get_array();
+    for (Int i = 0; i < x.get_size(); i++)
+        EXPECT_NEAR(xx[i], sln[i], 1e-14);
+    x.restore_array(xx);
+}

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -52,7 +52,7 @@ TEST(VectorTest, set)
     Vector v = Vector::create_seq(MPI_COMM_WORLD, 10);
     v.set(21.);
     for (Int i = 0; i < 10; i++)
-        EXPECT_DOUBLE_EQ(v[i], 21.);
+        EXPECT_DOUBLE_EQ(v(i), 21.);
     v.destroy();
 }
 
@@ -60,9 +60,9 @@ TEST(VectorTest, set_values)
 {
     Vector v = Vector::create_seq(MPI_COMM_WORLD, 3);
     v.set_values({ 0, 1, 2 }, { 3, 5, 9 });
-    EXPECT_DOUBLE_EQ(v[0], 3.);
-    EXPECT_DOUBLE_EQ(v[1], 5.);
-    EXPECT_DOUBLE_EQ(v[2], 9.);
+    EXPECT_DOUBLE_EQ(v(0), 3.);
+    EXPECT_DOUBLE_EQ(v(1), 5.);
+    EXPECT_DOUBLE_EQ(v(2), 9.);
     v.destroy();
 }
 
@@ -71,9 +71,9 @@ TEST(VectorTest, set_values_local)
     // TODO: this should be tested with MPI n_proc > 1
     Vector v = Vector::create_seq(MPI_COMM_WORLD, 3);
     v.set_values_local({ 0, 1, 2 }, { 3, 5, 9 });
-    EXPECT_DOUBLE_EQ(v[0], 3.);
-    EXPECT_DOUBLE_EQ(v[1], 5.);
-    EXPECT_DOUBLE_EQ(v[2], 9.);
+    EXPECT_DOUBLE_EQ(v(0), 3.);
+    EXPECT_DOUBLE_EQ(v(1), 5.);
+    EXPECT_DOUBLE_EQ(v(2), 9.);
     v.destroy();
 }
 
@@ -86,9 +86,9 @@ TEST(VectorTest, duplicate)
     Vector dup;
     v.duplicate(dup);
     v.copy(dup);
-    EXPECT_DOUBLE_EQ(dup[0], 1.);
-    EXPECT_DOUBLE_EQ(dup[1], 3.);
-    EXPECT_DOUBLE_EQ(dup[2], 7.);
+    EXPECT_DOUBLE_EQ(dup(0), 1.);
+    EXPECT_DOUBLE_EQ(dup(1), 3.);
+    EXPECT_DOUBLE_EQ(dup(2), 7.);
     v.destroy();
 }
 
@@ -109,9 +109,9 @@ TEST(VectorTest, zero)
     v.set_value(1, 3.);
     v.set_value(2, 7.);
     v.zero();
-    EXPECT_DOUBLE_EQ(v[0], 0.);
-    EXPECT_DOUBLE_EQ(v[1], 0.);
-    EXPECT_DOUBLE_EQ(v[2], 0.);
+    EXPECT_DOUBLE_EQ(v(0), 0.);
+    EXPECT_DOUBLE_EQ(v(1), 0.);
+    EXPECT_DOUBLE_EQ(v(2), 0.);
     v.destroy();
 }
 
@@ -143,9 +143,9 @@ TEST(VectorTest, get_restore_array)
     arr[2] = 7.;
     v.restore_array(arr);
 
-    EXPECT_EQ(v[0], 3.);
-    EXPECT_EQ(v[1], 5.);
-    EXPECT_EQ(v[2], 7.);
+    EXPECT_EQ(v(0), 3.);
+    EXPECT_EQ(v(1), 5.);
+    EXPECT_EQ(v(2), 7.);
 
     v.destroy();
 }
@@ -157,9 +157,9 @@ TEST(VectorTest, abs)
     v.set_value(1, 5.);
     v.set_value(2, -7.);
     v.abs();
-    EXPECT_DOUBLE_EQ(v[0], 3.);
-    EXPECT_DOUBLE_EQ(v[1], 5.);
-    EXPECT_DOUBLE_EQ(v[2], 7.);
+    EXPECT_DOUBLE_EQ(v(0), 3.);
+    EXPECT_DOUBLE_EQ(v(1), 5.);
+    EXPECT_DOUBLE_EQ(v(2), 7.);
     v.destroy();
 }
 
@@ -169,8 +169,8 @@ TEST(VectorTest, scale)
     v.set_value(0, -3.);
     v.set_value(1, 5.);
     v.scale(-1.);
-    EXPECT_DOUBLE_EQ(v[0], 3.);
-    EXPECT_DOUBLE_EQ(v[1], -5.);
+    EXPECT_DOUBLE_EQ(v(0), 3.);
+    EXPECT_DOUBLE_EQ(v(1), -5.);
     v.destroy();
 }
 
@@ -180,8 +180,8 @@ TEST(VectorTest, normalize)
     v.set_value(0, 3.);
     v.set_value(1, 4.);
     v.normalize();
-    EXPECT_DOUBLE_EQ(v[0], 0.6);
-    EXPECT_DOUBLE_EQ(v[1], 0.8);
+    EXPECT_DOUBLE_EQ(v(0), 0.6);
+    EXPECT_DOUBLE_EQ(v(1), 0.8);
     v.destroy();
 }
 
@@ -191,8 +191,8 @@ TEST(VectorTest, shift)
     v.set_value(0, 3.);
     v.set_value(1, 4.);
     v.shift(1.);
-    EXPECT_DOUBLE_EQ(v[0], 4.);
-    EXPECT_DOUBLE_EQ(v[1], 5);
+    EXPECT_DOUBLE_EQ(v(0), 4.);
+    EXPECT_DOUBLE_EQ(v(1), 5);
     v.destroy();
 }
 
@@ -220,8 +220,8 @@ TEST(VectorTest, chop)
     v.set_value(0, 3.);
     v.set_value(1, 4.);
     v.chop(3.5);
-    EXPECT_DOUBLE_EQ(v[0], 0.);
-    EXPECT_DOUBLE_EQ(v[1], 4.);
+    EXPECT_DOUBLE_EQ(v(0), 0.);
+    EXPECT_DOUBLE_EQ(v(1), 4.);
     v.destroy();
 }
 
@@ -236,8 +236,8 @@ TEST(VectorTest, axpy)
     x.set_value(1, 5.);
 
     y.axpy(3., x);
-    EXPECT_DOUBLE_EQ(y[0], 9.);
-    EXPECT_DOUBLE_EQ(y[1], 19.);
+    EXPECT_DOUBLE_EQ(y(0), 9.);
+    EXPECT_DOUBLE_EQ(y(1), 19.);
     x.destroy();
     y.destroy();
 }
@@ -253,8 +253,8 @@ TEST(VectorTest, aypx)
     x.set_value(1, 5.);
 
     y.aypx(3., x);
-    EXPECT_DOUBLE_EQ(y[0], 11.);
-    EXPECT_DOUBLE_EQ(y[1], 17.);
+    EXPECT_DOUBLE_EQ(y(0), 11.);
+    EXPECT_DOUBLE_EQ(y(1), 17.);
 
     x.destroy();
     y.destroy();
@@ -275,8 +275,8 @@ TEST(VectorTest, pointwise_min)
     y.set_value(1, 4.);
 
     Vector::pointwise_min(w, x, y);
-    EXPECT_DOUBLE_EQ(w[0], 2.);
-    EXPECT_DOUBLE_EQ(w[1], 4.);
+    EXPECT_DOUBLE_EQ(w(0), 2.);
+    EXPECT_DOUBLE_EQ(w(1), 4.);
 
     x.destroy();
     y.destroy();
@@ -298,8 +298,8 @@ TEST(VectorTest, pointwise_max)
     y.set_value(1, 4.);
 
     Vector::pointwise_max(w, x, y);
-    EXPECT_DOUBLE_EQ(w[0], 3.);
-    EXPECT_DOUBLE_EQ(w[1], 5.);
+    EXPECT_DOUBLE_EQ(w(0), 3.);
+    EXPECT_DOUBLE_EQ(w(1), 5.);
 
     x.destroy();
     y.destroy();
@@ -321,8 +321,8 @@ TEST(VectorTest, pointwise_mult)
     y.set_value(1, 4.);
 
     Vector::pointwise_mult(w, x, y);
-    EXPECT_DOUBLE_EQ(w[0], 6.);
-    EXPECT_DOUBLE_EQ(w[1], 20.);
+    EXPECT_DOUBLE_EQ(w(0), 6.);
+    EXPECT_DOUBLE_EQ(w(1), 20.);
 
     x.destroy();
     y.destroy();
@@ -344,8 +344,8 @@ TEST(VectorTest, pointwise_divide)
     y.set_value(1, 3.);
 
     Vector::pointwise_divide(w, x, y);
-    EXPECT_DOUBLE_EQ(w[0], 4.);
-    EXPECT_DOUBLE_EQ(w[1], 6.);
+    EXPECT_DOUBLE_EQ(w(0), 4.);
+    EXPECT_DOUBLE_EQ(w(1), 6.);
 
     x.destroy();
     y.destroy();


### PR DESCRIPTION
- Using operator() instead [] for Vector, Matrix, Normal and Point
- get_xyz() is available in {Residual|Jacobian}Func
- Physical coordinates are correctly propagated into Functionals
- Unit test for surface integration
