### PR TITLE
ExodusOutput uses application name and its version in info blocks

### DIFF
--- a/include/App.h
+++ b/include/App.h
@@ -28,6 +28,11 @@ public:
     /// @return Application name
     const std::string & get_name() const;
 
+    /// Get application version
+    ///
+    /// @return The application version as a string
+    virtual const std::string & get_version() const;
+
     /// @return Get problem this application is representing
     virtual Problem * get_problem() const;
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -48,6 +48,14 @@ App::get_name() const
     return this->name;
 }
 
+const std::string &
+App::get_version() const
+{
+    _F_;
+    static const std::string ver(GODZILLA_VERSION);
+    return ver;
+}
+
 Logger *
 App::get_logger() const
 {

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -1,5 +1,6 @@
 #include "Godzilla.h"
 #include "GodzillaConfig.h"
+#include "App.h"
 #include "CallStack.h"
 #include "ExodusIIOutput.h"
 #include "Problem.h"
@@ -604,8 +605,10 @@ ExodusIIOutput::write_info()
     _F_;
     std::time_t now = std::time(nullptr);
     std::string datetime = fmt::format("{:%d %b %Y, %H:%M:%S}", fmt::localtime(now));
-    std::string created_by =
-        fmt::format("Created by godzilla {}, on {}", GODZILLA_VERSION, datetime);
+    std::string created_by = fmt::format("Created by {} {}, on {}",
+                                         this->app->get_name(),
+                                         this->app->get_version(),
+                                         datetime);
 
     std::vector<std::string> info;
     info.push_back(created_by);


### PR DESCRIPTION
Rather than reporting that godzilla created the output file, we store
the application name and its version, because it really was the application,
not godzilla who created the file.

Closes #183
