### PR TITLE
DenseMatrix can be initialized from a DenseMatrixSymm

### DIFF
--- a/include/DenseMatrix.h
+++ b/include/DenseMatrix.h
@@ -10,6 +10,9 @@ namespace godzilla {
 template <typename T, Int N>
 class DenseVector;
 
+template <typename T, Int N>
+class DenseMatrixSymm;
+
 /// Dense matrix with `ROWS` rows and `COLS` columns
 ///
 /// Entries are stored in column-major format
@@ -20,6 +23,14 @@ template <typename T, Int ROWS, Int COLS = ROWS>
 class DenseMatrix {
 public:
     DenseMatrix() {};
+
+    DenseMatrix(const DenseMatrixSymm<Real, ROWS> & m)
+    {
+        assert(COLS == ROWS);
+        for (Int i = 0; i < ROWS; i++)
+            for (Int j = 0; j < COLS; j++)
+                set(i, j) = m(i, j);
+    }
 
     /// Get the number of rows
     ///
@@ -221,6 +232,15 @@ public:
     operator*(const DenseMatrix<T, COLS, ROWS2> & x) const
     {
         return mult(x);
+    }
+
+    void
+    operator=(const DenseMatrixSymm<Real, ROWS> & m)
+    {
+        assert(COLS == ROWS);
+        for (Int i = 0; i < ROWS; i++)
+            for (Int j = 0; j < COLS; j++)
+                set(i, j) = m(i, j);
     }
 
     /// Get access to the underlying data

--- a/test/src/DenseMatrix_test.cpp
+++ b/test/src/DenseMatrix_test.cpp
@@ -1,5 +1,6 @@
 #include "gmock/gmock.h"
 #include "DenseMatrix.h"
+#include "DenseMatrixSymm.h"
 #include "DenseVector.h"
 #include "Types.h"
 
@@ -258,4 +259,35 @@ TEST(DenseMatrixTest, mult_mat)
     EXPECT_EQ(m(1, 1), -8.);
     EXPECT_EQ(m(1, 2), -22.);
     EXPECT_EQ(m(1, 3), -16.);
+}
+
+TEST(DenseMatrixTest, copy_ctor)
+{
+    DenseMatrixSymm<Real, 3> symm({ 1, -1, 2, 3, -2, -1 });
+    DenseMatrix<Real, 3> a(symm);
+    EXPECT_EQ(a(0, 0), 1);
+    EXPECT_EQ(a(0, 1), -1);
+    EXPECT_EQ(a(0, 2), 3);
+    EXPECT_EQ(a(1, 0), -1);
+    EXPECT_EQ(a(1, 1), 2);
+    EXPECT_EQ(a(1, 2), -2);
+    EXPECT_EQ(a(2, 0), 3);
+    EXPECT_EQ(a(2, 1), -2);
+    EXPECT_EQ(a(2, 2), -1);
+}
+
+TEST(DenseMatrixTest, op_assign)
+{
+    DenseMatrixSymm<Real, 3> symm({ 1, -1, 2, 3, -2, -1 });
+    DenseMatrix<Real, 3> a;
+    a = symm;
+    EXPECT_EQ(a(0, 0), 1);
+    EXPECT_EQ(a(0, 1), -1);
+    EXPECT_EQ(a(0, 2), 3);
+    EXPECT_EQ(a(1, 0), -1);
+    EXPECT_EQ(a(1, 1), 2);
+    EXPECT_EQ(a(1, 2), -2);
+    EXPECT_EQ(a(2, 0), 3);
+    EXPECT_EQ(a(2, 1), -2);
+    EXPECT_EQ(a(2, 2), -1);
 }


### PR DESCRIPTION
This is handy when using `DMPlexMatSetClosure` which expects array with NxN
entries (which DenseMatrixSymm does not have).
