### PR TITLE
Improvements on DenseXYZ classes

### DIFF
--- a/include/DenseMatrix.h
+++ b/include/DenseMatrix.h
@@ -217,6 +217,18 @@ public:
         return set(row, col);
     }
 
+    /// Multiply this matrix with a scalar value
+    ///
+    /// @param alpha Value to multiply with
+    /// @return Resulting matrix
+    DenseMatrix<T, COLS, ROWS>
+    operator*(Real alpha) const
+    {
+        DenseMatrix<T, COLS, ROWS> m(*this);
+        m.scale(alpha);
+        return m;
+    }
+
     /// Multiply this matrix with a vector
     ///
     /// @param rhs Vector to multiply with

--- a/include/DenseMatrix.h
+++ b/include/DenseMatrix.h
@@ -386,4 +386,17 @@ DenseMatrix<Real, 3>::inv() const
     return inv;
 }
 
+//
+
+template <typename T, Int M, Int N = M>
+inline DenseMatrix<T, M, N>
+operator*(Real alpha, const DenseMatrix<T, M, N> & a)
+{
+    DenseMatrix<T, M, N> res;
+    for (Int i = 0; i < M; i++)
+        for (Int j = 0; j < N; j++)
+            res(i, j) = alpha * a(i, j);
+    return res;
+}
+
 } // namespace godzilla

--- a/include/DenseMatrix.h
+++ b/include/DenseMatrix.h
@@ -106,14 +106,14 @@ public:
     void
     zero()
     {
-        set_val(0.);
+        set_values(0.);
     }
 
     /// Set `alpha` into all matrix entries, i.e. mat[i, j] = alpha
     ///
     /// @param alpha Value to set into matrix entries
     void
-    set_val(const T & alpha)
+    set_values(const T & alpha)
     {
         for (Int i = 0; i < ROWS * COLS; i++)
             this->data[i] = alpha;

--- a/include/DenseMatrixSymm.h
+++ b/include/DenseMatrixSymm.h
@@ -245,4 +245,17 @@ DenseMatrixSymm<Real, 3>::det() const
             this->data[1] * this->data[1] * this->data[5]);
 }
 
+//
+
+template <typename T, Int N>
+inline DenseMatrixSymm<T, N>
+operator*(Real alpha, const DenseMatrixSymm<T, N> & a)
+{
+    DenseMatrixSymm<T, N> res;
+    for (Int i = 0; i < N; i++)
+        for (Int j = i; j < N; j++)
+            res(i, j) = alpha * a(i, j);
+    return res;
+}
+
 } // namespace godzilla

--- a/include/DenseMatrixSymm.h
+++ b/include/DenseMatrixSymm.h
@@ -165,6 +165,18 @@ public:
         return set(row, col);
     }
 
+    /// Multiply this matrix with a scalar value
+    ///
+    /// @param alpha Value to multiply with
+    /// @return Resulting matrix
+    DenseMatrixSymm<T, DIM>
+    operator*(Real alpha) const
+    {
+        DenseMatrixSymm<T, DIM> m(*this);
+        m.scale(alpha);
+        return m;
+    }
+
     DenseVector<T, DIM>
     operator*(const DenseVector<T, DIM> & rhs) const
     {

--- a/include/DenseVector.h
+++ b/include/DenseVector.h
@@ -64,14 +64,14 @@ public:
     void
     zero()
     {
-        set_val(0.);
+        set_values(0.);
     }
 
     /// Set `alpha` into all vector elements, i.e. vec[i] = alpha
     ///
     /// @param alpha Constant to set into vector elements
     void
-    set_val(const T & alpha)
+    set_values(const T & alpha)
     {
         for (Int i = 0; i < N; i++)
             this->data[i] = alpha;

--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -2,9 +2,12 @@
 
 #include "petscds.h"
 #include "Types.h"
+#include "UnstructuredMesh.h"
 #include "Vector.h"
+#include "Matrix.h"
 #include "Section.h"
-#include "DiscreteProblemInterface.h"
+#include "DenseMatrix.h"
+#include "DenseMatrixSymm.h"
 
 namespace godzilla {
 
@@ -163,6 +166,15 @@ protected:
     /// @param sln Global solution vector
     void build_local_solution_vector(const Vector & sln) const;
 
+    template <Int N>
+    void set_closure(Vector & v, Int point, const DenseVector<Real, N> & vec, InsertMode mode);
+
+    template <Int N>
+    void set_closure(Matrix & A, Int point, const DenseMatrix<Real, N> & mat, InsertMode mode);
+
+    template <Int N>
+    void set_closure(Matrix & A, Int point, const DenseMatrixSymm<Real, N> & mat, InsertMode mode);
+
     /// Problem this interface is part of
     Problem * problem;
 
@@ -184,5 +196,43 @@ protected:
     /// Object that manages a discrete system
     PetscDS ds;
 };
+
+template <Int N>
+void
+DiscreteProblemInterface::set_closure(Vector & v,
+                                      Int point,
+                                      const DenseVector<Real, N> & vec,
+                                      InsertMode mode)
+{
+    DM dm = this->unstr_mesh->get_dm();
+    PETSC_CHECK(DMPlexVecSetClosure(dm, this->section, v, point, vec.get_data(), mode));
+}
+
+template <Int N>
+void
+DiscreteProblemInterface::set_closure(Matrix & A,
+                                      Int point,
+                                      const DenseMatrix<Real, N> & mat,
+                                      InsertMode mode)
+{
+    DM dm = this->unstr_mesh->get_dm();
+    Section global_section = this->unstr_mesh->get_global_section();
+    PETSC_CHECK(
+        DMPlexMatSetClosure(dm, this->section, global_section, A, point, mat.get_data(), mode));
+}
+
+template <Int N>
+void
+DiscreteProblemInterface::set_closure(Matrix & A,
+                                      Int point,
+                                      const DenseMatrixSymm<Real, N> & mat,
+                                      InsertMode mode)
+{
+    DM dm = this->unstr_mesh->get_dm();
+    Section global_section = this->unstr_mesh->get_global_section();
+    DenseMatrix<Real, N> m = mat;
+    PETSC_CHECK(
+        DMPlexMatSetClosure(dm, this->section, global_section, A, point, m.get_data(), mode));
+}
 
 } // namespace godzilla

--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -102,7 +102,7 @@ public:
     /// @param point Point
     /// @param fid Field ID
     /// @return The offset
-    virtual Int get_field_dof(Int point, Int fid) const = 0;
+    virtual Int get_field_dof(Int point, Int fid) const;
 
     /// Gets a local vector with the coordinates associated with this problem's mesh
     ///

--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -3,6 +3,7 @@
 #include "petscds.h"
 #include "Types.h"
 #include "Vector.h"
+#include "Section.h"
 #include "DiscreteProblemInterface.h"
 
 namespace godzilla {
@@ -170,6 +171,9 @@ protected:
 
     /// Logger object
     Logger * logger;
+
+    /// Section
+    Section section;
 
     /// Initial conditions in the problem
     std::vector<InitialCondition *> ics;

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -38,7 +38,6 @@ public:
     Int get_field_order(Int fid) const override;
     std::string get_field_component_name(Int fid, Int component) const override;
     void set_field_component_name(Int fid, Int component, const std::string & name) override;
-    Int get_field_dof(Int point, Int fid) const override;
     const Vector & get_solution_vector_local() const override;
     WeakForm * get_weak_form() const override;
 

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -8,7 +8,6 @@
 #include "petscfe.h"
 #include "CallStack.h"
 #include "DiscreteProblemInterface.h"
-#include "Section.h"
 #include "DependencyEvaluator.h"
 #include "FieldValue.h"
 #include "Error.h"
@@ -311,9 +310,6 @@ protected:
                                        Scalar u_t[]);
 
     Int get_next_id(const std::vector<Int> & ids) const;
-
-    /// Section
-    Section section;
 
     /// Quadrature order
     Int qorder;

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -2,7 +2,6 @@
 
 #include "GodzillaConfig.h"
 #include "DiscreteProblemInterface.h"
-#include "Section.h"
 
 namespace godzilla {
 
@@ -79,9 +78,6 @@ protected:
                               Int n_consts,
                               const Scalar constants[],
                               Scalar flux[]) = 0;
-
-    /// PETSc section
-    Section section;
 
     /// Field information
     struct FieldInfo {

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -23,7 +23,6 @@ public:
     Int get_field_order(Int fid) const override;
     std::string get_field_component_name(Int fid, Int component) const override;
     void set_field_component_name(Int fid, Int component, const std::string & name) override;
-    NO_DISCARD Int get_field_dof(Int point, Int fid) const override;
     const Vector & get_solution_vector_local() const override;
     NO_DISCARD WeakForm * get_weak_form() const override;
 

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -156,6 +156,15 @@ DiscreteProblemInterface::set_up_initial_guess()
         set_initial_guess_from_ics();
 }
 
+Int
+DiscreteProblemInterface::get_field_dof(Int point, Int fid) const
+{
+    _F_;
+    Int offset;
+    PETSC_CHECK(PetscSectionGetFieldOffset(this->section, point, fid, &offset));
+    return offset;
+}
+
 Vector
 DiscreteProblemInterface::get_coordinates_local() const
 {

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -2,7 +2,6 @@
 #include "CallStack.h"
 #include "App.h"
 #include "DiscreteProblemInterface.h"
-#include "UnstructuredMesh.h"
 #include "Problem.h"
 #include "Logger.h"
 #include "InitialCondition.h"

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -47,6 +47,7 @@ DiscreteProblemInterface::init()
     set_up_ds();
     set_up_initial_conditions();
     set_up_boundary_conditions();
+    this->section = this->unstr_mesh->get_local_section();
 }
 
 void

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -261,15 +261,6 @@ FEProblemInterface::set_field_component_name(Int fid, Int component, const std::
 }
 
 Int
-FEProblemInterface::get_field_dof(Int point, Int fid) const
-{
-    _F_;
-    Int offset;
-    PETSC_CHECK(PetscSectionGetFieldOffset(this->section, point, fid, &offset));
-    return offset;
-}
-
-Int
 FEProblemInterface::get_num_aux_fields() const
 {
     _F_;

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -102,7 +102,6 @@ FEProblemInterface::init()
     _F_;
     DiscreteProblemInterface::init();
 
-    this->section = this->unstr_mesh->get_local_section();
     DM dm = this->unstr_mesh->get_dm();
     DM cdm = dm;
     while (cdm) {

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -44,8 +44,6 @@ void
 FVProblemInterface::init()
 {
     DiscreteProblemInterface::init();
-
-    this->section = this->unstr_mesh->get_local_section();
 }
 
 Int

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -157,15 +157,6 @@ FVProblemInterface::set_field_component_name(Int fid, Int component, const std::
         error("Field with ID = '%d' does not exist.", fid);
 }
 
-Int
-FVProblemInterface::get_field_dof(Int point, Int fid) const
-{
-    _F_;
-    Int offset;
-    PETSC_CHECK(PetscSectionGetFieldOffset(this->section, point, fid, &offset));
-    return offset;
-}
-
 const Vector &
 FVProblemInterface::get_solution_vector_local() const
 {

--- a/test/src/DenseMatrixSymm_test.cpp
+++ b/test/src/DenseMatrixSymm_test.cpp
@@ -191,3 +191,18 @@ TEST(DenseMatrixSymmTest, mult_mat)
     EXPECT_EQ(m(2, 1), -5.);
     EXPECT_EQ(m(2, 2), 21.);
 }
+
+TEST(DenseMatrixSymmTest, op_mult_scalar_pre)
+{
+    DenseMatrixSymm<Real, 3> m({ 1, 2, 3, 4, 5, 6 });
+    auto res = 2. * m;
+    EXPECT_EQ(res(0, 0), 2.);
+    EXPECT_EQ(res(0, 1), 4.);
+    EXPECT_EQ(res(0, 2), 8.);
+    EXPECT_EQ(res(1, 0), 4.);
+    EXPECT_EQ(res(1, 1), 6.);
+    EXPECT_EQ(res(1, 2), 10.);
+    EXPECT_EQ(res(2, 0), 8.);
+    EXPECT_EQ(res(2, 1), 10.);
+    EXPECT_EQ(res(2, 2), 12.);
+}

--- a/test/src/DenseMatrixSymm_test.cpp
+++ b/test/src/DenseMatrixSymm_test.cpp
@@ -14,6 +14,27 @@ TEST(DenseMatrixSymmTest, dimensions)
     EXPECT_EQ(m.get_num_cols(), 3);
 }
 
+TEST(DenseMatrixSymmTest, zero)
+{
+    DenseMatrixSymm<Real, 3> m;
+    m.set(0, 0) = 1.;
+    m.set(0, 1) = 0.;
+    m.set(0, 2) = 3.;
+    m.set(1, 1) = -1.;
+    m.set(1, 2) = 4.;
+    m.set(2, 2) = 2.;
+    m.zero();
+    EXPECT_EQ(m(0, 0), 0.);
+    EXPECT_EQ(m(0, 1), 0.);
+    EXPECT_EQ(m(0, 2), 0.);
+    EXPECT_EQ(m(1, 0), 0.);
+    EXPECT_EQ(m(1, 1), 0.);
+    EXPECT_EQ(m(1, 2), 0.);
+    EXPECT_EQ(m(2, 0), 0.);
+    EXPECT_EQ(m(2, 1), 0.);
+    EXPECT_EQ(m(2, 2), 0.);
+}
+
 TEST(DenseMatrixSymmTest, set)
 {
     DenseMatrixSymm<Real, 3> m;

--- a/test/src/DenseMatrixSymm_test.cpp
+++ b/test/src/DenseMatrixSymm_test.cpp
@@ -99,6 +99,21 @@ TEST(DenseMatrixSymmTest, mult)
     EXPECT_EQ(res(2), 7.);
 }
 
+TEST(DenseMatrixSymmTest, op_mult_scalar)
+{
+    DenseMatrixSymm<Real, 3> m({ 1, 2, 3, 4, 5, 6 });
+    auto res = m * 2.;
+    EXPECT_EQ(res(0, 0), 2.);
+    EXPECT_EQ(res(0, 1), 4.);
+    EXPECT_EQ(res(0, 2), 8.);
+    EXPECT_EQ(res(1, 0), 4.);
+    EXPECT_EQ(res(1, 1), 6.);
+    EXPECT_EQ(res(1, 2), 10.);
+    EXPECT_EQ(res(2, 0), 8.);
+    EXPECT_EQ(res(2, 1), 10.);
+    EXPECT_EQ(res(2, 2), 12.);
+}
+
 TEST(DenseMatrixSymmTest, op_mult)
 {
     DenseMatrixSymm<Real, 3> m({ 1, 1, 1, 0, 1, 1 });

--- a/test/src/DenseMatrixSymm_test.cpp
+++ b/test/src/DenseMatrixSymm_test.cpp
@@ -7,6 +7,13 @@
 using namespace godzilla;
 using namespace testing;
 
+TEST(DenseMatrixSymmTest, dimensions)
+{
+    DenseMatrixSymm<Real, 3> m;
+    EXPECT_EQ(m.get_num_rows(), 3);
+    EXPECT_EQ(m.get_num_cols(), 3);
+}
+
 TEST(DenseMatrixSymmTest, set)
 {
     DenseMatrixSymm<Real, 3> m;

--- a/test/src/DenseMatrix_test.cpp
+++ b/test/src/DenseMatrix_test.cpp
@@ -77,6 +77,25 @@ TEST(DenseMatrixTest, mult)
     EXPECT_EQ(res(2), 7.);
 }
 
+TEST(DenseMatrixTest, op_mult_scalar)
+{
+    DenseMatrix<Real, 3> m;
+    m.set_row(0, { 2, 1, 0 });
+    m.set_row(1, { -1, -2, 4 });
+    m.set_row(2, { 0, 3, -1 });
+
+    auto res = m * 2.;
+    EXPECT_EQ(res(0, 0), 4.);
+    EXPECT_EQ(res(0, 1), 2.);
+    EXPECT_EQ(res(0, 2), 0.);
+    EXPECT_EQ(res(1, 0), -2.);
+    EXPECT_EQ(res(1, 1), -4.);
+    EXPECT_EQ(res(1, 2), 8.);
+    EXPECT_EQ(res(2, 0), 0.);
+    EXPECT_EQ(res(2, 1), 6.);
+    EXPECT_EQ(res(2, 2), -2.);
+}
+
 TEST(DenseMatrixTest, op_mult)
 {
     DenseMatrix<Real, 3> m;

--- a/test/src/DenseMatrix_test.cpp
+++ b/test/src/DenseMatrix_test.cpp
@@ -7,6 +7,21 @@
 using namespace godzilla;
 using namespace testing;
 
+TEST(DenseMatrixTest, zero)
+{
+    DenseMatrix<Real, 2> m;
+    m.set(0, 0) = 1.;
+    m.set(0, 1) = -2.;
+    m.set(1, 0) = 2.;
+    m.set(1, 1) = -1.;
+    m.zero();
+
+    EXPECT_EQ(m(0, 0), 0.);
+    EXPECT_EQ(m(0, 1), 0.);
+    EXPECT_EQ(m(1, 0), 0.);
+    EXPECT_EQ(m(1, 1), 0.);
+}
+
 TEST(DenseMatrixTest, set)
 {
     DenseMatrix<Real, 2> m;

--- a/test/src/DenseMatrix_test.cpp
+++ b/test/src/DenseMatrix_test.cpp
@@ -320,3 +320,21 @@ TEST(DenseMatrixTest, op_assign)
     EXPECT_EQ(a(2, 1), -2);
     EXPECT_EQ(a(2, 2), -1);
 }
+
+TEST(DenseMatrixTest, op_mult_scalar_pre)
+{
+    DenseMatrix<Real, 3> m;
+    m.set_row(0, { 2, 1, 0 });
+    m.set_row(1, { 1, 2, -1 });
+    m.set_row(2, { 0, -1, 2 });
+    auto res = 3. * m;
+    EXPECT_EQ(res(0, 0), 6.);
+    EXPECT_EQ(res(0, 1), 3.);
+    EXPECT_EQ(res(0, 2), 0.);
+    EXPECT_EQ(res(1, 0), 3.);
+    EXPECT_EQ(res(1, 1), 6.);
+    EXPECT_EQ(res(1, 2), -3.);
+    EXPECT_EQ(res(2, 0), 0.);
+    EXPECT_EQ(res(2, 1), -3.);
+    EXPECT_EQ(res(2, 2), 6.);
+}

--- a/test/src/DenseMatrix_test.cpp
+++ b/test/src/DenseMatrix_test.cpp
@@ -35,6 +35,16 @@ TEST(DenseMatrixTest, set2)
     EXPECT_EQ(m(1, 1), -1.);
 }
 
+TEST(DenseMatrixTest, set_values)
+{
+    DenseMatrix<Real, 2> m;
+    m.set_values(3.);
+    EXPECT_EQ(m(0, 0), 3.);
+    EXPECT_EQ(m(0, 1), 3.);
+    EXPECT_EQ(m(1, 0), 3.);
+    EXPECT_EQ(m(1, 1), 3.);
+}
+
 TEST(DenseMatrixTest, scale)
 {
     DenseMatrix<Real, 3> m;

--- a/test/src/DenseVector_test.cpp
+++ b/test/src/DenseVector_test.cpp
@@ -30,10 +30,10 @@ TEST(DenseVectorTest, zero)
     EXPECT_EQ(a(2), 0.);
 }
 
-TEST(DenseVectorTest, set_val)
+TEST(DenseVectorTest, set_values)
 {
     DenseVector<Real, 3> a;
-    a.set_val(2.);
+    a.set_values(2.);
     EXPECT_EQ(a(0), 2.);
     EXPECT_EQ(a(1), 2.);
     EXPECT_EQ(a(2), 2.);


### PR DESCRIPTION
- Moving section into DiscreteProblemInterface
- Moving get_field_dof into DiscreteProblemInterface
- Adding DiscreteProblemInterface::set_closure
- DenseMatrix::set_val -> DenseMatrix::set_values
- DenseVector::set_val -> DenseVector::set_values
- Adding operator*(Real alpha) to DenseMatrix and DenseMatrixSymm
- DenseMatrix and DenseMatrixSymm can be pre-multiplied by a scalar value
- Adding a test for DenseMatrix::zero()
- Adding a test for dimensions of DenseMatrixSymm
- Adding a test for DenseMatrixSymm::zero()
