### PR TITLE
Isolating WeakForm into FEProblemInterface

### DIFF
--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -15,7 +15,6 @@ class Parameters;
 class Logger;
 class UnstructuredMesh;
 class Problem;
-class WeakForm;
 class InitialCondition;
 class BoundaryCondition;
 
@@ -116,11 +115,6 @@ public:
     ///
     /// @return Local solution vector
     virtual const Vector & get_solution_vector_local() const = 0;
-
-    /// Get weak form associated with this problem
-    ///
-    /// @return The weak form associated with this problem
-    virtual WeakForm * get_weak_form() const = 0;
 
     virtual void add_boundary_essential(const std::string & name,
                                         DMLabel label,

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -39,7 +39,7 @@ public:
     std::string get_field_component_name(Int fid, Int component) const override;
     void set_field_component_name(Int fid, Int component, const std::string & name) override;
     const Vector & get_solution_vector_local() const override;
-    WeakForm * get_weak_form() const override;
+    virtual WeakForm * get_weak_form() const;
 
     /// Get number of auxiliary fields
     ///

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -24,7 +24,6 @@ public:
     std::string get_field_component_name(Int fid, Int component) const override;
     void set_field_component_name(Int fid, Int component, const std::string & name) override;
     const Vector & get_solution_vector_local() const override;
-    NO_DISCARD WeakForm * get_weak_form() const override;
 
     /// Adds a volumetric field
     ///
@@ -104,9 +103,6 @@ protected:
 
     /// Local solution vector
     Vector sln;
-
-    /// Weak form
-    WeakForm * wf;
 
     friend void __compute_flux(Int dim,
                                Int nf,

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -597,8 +597,8 @@ FENonlinearProblem::compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp)
         PetscCall(DMGetRegionNumDS(plex, s, &label, nullptr, &ds));
 
         if (s == 0) {
-            auto has_jac = get_weak_form()->has_jacobian();
-            auto has_precond = get_weak_form()->has_jacobian_preconditioner();
+            auto has_jac = this->wf->has_jacobian();
+            auto has_precond = this->wf->has_jacobian_preconditioner();
             if (has_jac && has_precond)
                 J.zero();
             Jp.zero();
@@ -654,8 +654,8 @@ FENonlinearProblem::compute_jacobian_internal(DM dm,
     PetscCall(PetscDSGetNumFields(prob, &n_fields));
     Int tot_dim;
     PetscCall(PetscDSGetTotalDimension(prob, &tot_dim));
-    auto has_jac = this->get_weak_form()->has_jacobian();
-    auto has_prec = this->get_weak_form()->has_jacobian_preconditioner();
+    auto has_jac = this->wf->has_jacobian();
+    auto has_prec = this->wf->has_jacobian_preconditioner();
     // user passed in the same matrix, avoid double contributions and only assemble the Jacobian
     if (has_jac && J == Jp)
         has_prec = PETSC_FALSE;

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -29,8 +29,7 @@ __compute_flux(Int dim,
 
 FVProblemInterface::FVProblemInterface(Problem * problem, const Parameters & params) :
     DiscreteProblemInterface(problem, params),
-    fvm(nullptr),
-    wf(nullptr)
+    fvm(nullptr)
 {
     _F_;
 }
@@ -163,13 +162,6 @@ FVProblemInterface::get_solution_vector_local() const
     _F_;
     build_local_solution_vector(this->sln);
     return this->sln;
-}
-
-WeakForm *
-FVProblemInterface::get_weak_form() const
-{
-    _F_;
-    return wf;
 }
 
 void

--- a/src/NaturalBC.cpp
+++ b/src/NaturalBC.cpp
@@ -15,11 +15,12 @@ NaturalBC::parameters()
     return params;
 }
 
-NaturalBC::NaturalBC(const Parameters & params) :
-    BoundaryCondition(params),
-    wf(this->dpi->get_weak_form())
+NaturalBC::NaturalBC(const Parameters & params) : BoundaryCondition(params), wf(nullptr)
 {
     _F_;
+    auto fepi = dynamic_cast<const FEProblemInterface *>(this->dpi);
+    if (fepi)
+        this->wf = fepi->get_weak_form();
 }
 
 void

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -177,8 +177,6 @@ TEST(ExplicitFVLinearProblemTest, api)
     EXPECT_DEATH(prob.set_field_component_name(0, 0, "x"),
                  "\\[ERROR\\] Unable to set component name for single-component field");
 
-    EXPECT_TRUE(prob.get_weak_form() == nullptr);
-
     EXPECT_DEATH(prob.add_boundary_essential("", nullptr, {}, -1, {}, nullptr, nullptr, nullptr),
                  "\\[ERROR\\] Essential BCs are not supported for FV problems");
     EXPECT_DEATH(prob.add_boundary_natural("", nullptr, {}, -1, {}, nullptr),


### PR DESCRIPTION
Now, DiscreteProblemInterface does not force users to use WeakForm.
Getting ready for templating the WeakForm class, so we can use
different forms of Residual and Jacobian functionals
