### PR TITLE
Fixing linking of the library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,8 +118,6 @@ target_link_libraries(
         ${HDF5_LIBRARIES}
         muParser
         exodusIIcpp
-        blas
-        lapack
 )
 if (GODZILLA_WITH_MPI)
     target_link_libraries(${PROJECT_NAME} PRIVATE MPI::MPI_CXX)


### PR DESCRIPTION
A leftover blas and lapack were linked. This caused troubles on linux.
And we were not checking for BLAS/LAPACK, so this error showed up during linking.
However, proper fix is to remove this, since we don't really need it.
