### PR TITLE
muParser must be compiled with position independent flag

### DIFF
--- a/contrib/muParser/CMakeLists.txt
+++ b/contrib/muParser/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(${PROJECT_NAME}
         muParserTokenReader.cpp
 )
 
+set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 install(
     DIRECTORY
         ${PROJECT_SOURCE_DIR}


### PR DESCRIPTION
Since it is static library it needs this flag to prevent linking errors
