### PR TITLE
Adding mesh iterators

### DIFF
--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -13,6 +13,102 @@ namespace godzilla {
 ///
 class UnstructuredMesh : public Mesh {
 public:
+    struct Iterator {
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = Int;
+
+        explicit Iterator(Int idx) : idx(idx) {}
+
+        const value_type &
+        operator*() const
+        {
+            return this->idx;
+        }
+
+        /// Prefix increment
+        Iterator &
+        operator++()
+        {
+            this->idx++;
+            return *this;
+        }
+
+        /// Postfix increment
+        Iterator
+        operator++(int)
+        {
+            Iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        friend bool
+        operator==(const Iterator & a, const Iterator & b)
+        {
+            return a.idx == b.idx;
+        };
+
+        friend bool
+        operator!=(const Iterator & a, const Iterator & b)
+        {
+            return a.idx != b.idx;
+        };
+
+    private:
+        Int idx;
+    };
+
+    Iterator vertex_begin() const;
+    Iterator vertex_end() const;
+
+    Iterator cell_begin() const;
+    Iterator cell_end() const;
+
+    /// Contiguous range of indices
+    struct Range {
+        Range() : first(-1), last(-1) {}
+        Range(Int first, Int last) : first(first), last(last) {}
+
+        Iterator
+        begin() const
+        {
+            return Iterator(this->first);
+        }
+
+        Iterator
+        end() const
+        {
+            return Iterator(this->last);
+        }
+
+        /// Get the number of indices in the range
+        Int
+        size() const
+        {
+            return last - first;
+        }
+
+        Int
+        get_first() const
+        {
+            return first;
+        }
+
+        Int
+        get_last() const
+        {
+            return last;
+        }
+
+    private:
+        /// First index
+        Int first;
+        /// Last index (not included in the range)
+        Int last;
+    };
+
+    //
+
     explicit UnstructuredMesh(const Parameters & parameters);
     ~UnstructuredMesh() override;
 
@@ -46,9 +142,8 @@ public:
 
     /// Get range of vertex indices
     ///
-    /// @param first First vertex index
-    /// @param last Last vertex index plus one
-    void get_vertex_idx_range(Int & first, Int & last) const;
+    /// @return Range of vertex indices
+    Range get_vertex_range() const;
 
     /// Return the number of mesh elements (interior)
     NO_DISCARD virtual Int get_num_elements() const;
@@ -58,15 +153,13 @@ public:
 
     /// Get range of element indices (interior only)
     ///
-    /// @param first First element index
-    /// @param last Last element index plus one
-    void get_element_idx_range(Int & first, Int & last) const;
+    /// @return Range of element indices
+    Range get_element_range() const;
 
     /// Get range of all element indices (interior + ghosted)
     ///
-    /// @param first First element index
-    /// @param last Last element index plus one
-    void get_all_element_idx_range(Int & first, Int & last) const;
+    /// @param Range of all element indices (interior + ghosted)
+    Range get_all_element_range() const;
 
     /// Get index set with all elements
     ///

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -91,52 +91,49 @@ Int
 UnstructuredMesh::get_num_vertices() const
 {
     _F_;
-    Int first, last;
-    get_vertex_idx_range(first, last);
-    return last - first;
+    return get_vertex_range().size();
 }
 
-void
-UnstructuredMesh::get_vertex_idx_range(Int & first, Int & last) const
+UnstructuredMesh::Range
+UnstructuredMesh::get_vertex_range() const
 {
-    _F_;
+    Int first, last;
     PETSC_CHECK(DMPlexGetHeightStratum(this->dm, this->dim, &first, &last));
+    return { first, last };
 }
 
 Int
 UnstructuredMesh::get_num_elements() const
 {
     _F_;
-    Int first, last;
-    get_element_idx_range(first, last);
-    return last - first;
+    return get_element_range().size();
 }
 
 Int
 UnstructuredMesh::get_num_all_elements() const
 {
     _F_;
-    Int first, last;
-    get_all_element_idx_range(first, last);
-    return last - first;
+    return get_all_element_range().size();
 }
 
-void
-UnstructuredMesh::get_element_idx_range(Int & first, Int & last) const
+UnstructuredMesh::Range
+UnstructuredMesh::get_element_range() const
 {
-    _F_;
+    Int first, last;
     PETSC_CHECK(DMPlexGetHeightStratum(this->dm, 0, &first, &last));
     Int gc_first, gc_last;
     PETSC_CHECK(DMPlexGetGhostCellStratum(this->dm, &gc_first, &gc_last));
     if (gc_first != -1)
         last = gc_first;
+    return { first, last };
 }
 
-void
-UnstructuredMesh::get_all_element_idx_range(Int & first, Int & last) const
+UnstructuredMesh::Range
+UnstructuredMesh::get_all_element_range() const
 {
-    _F_;
+    Int first, last;
     PETSC_CHECK(DMPlexGetHeightStratum(this->dm, 0, &first, &last));
+    return { first, last };
 }
 
 IndexSet
@@ -424,6 +421,38 @@ UnstructuredMesh::get_num_elem_nodes(DMPolytopeType elem_type)
     default:
         error("Unsupported type.");
     }
+}
+
+UnstructuredMesh::Iterator
+UnstructuredMesh::vertex_begin() const
+{
+    Int idx;
+    PETSC_CHECK(DMPlexGetHeightStratum(this->dm, this->dim, &idx, nullptr));
+    return Iterator(idx);
+}
+
+UnstructuredMesh::Iterator
+UnstructuredMesh::vertex_end() const
+{
+    Int idx;
+    PETSC_CHECK(DMPlexGetHeightStratum(this->dm, this->dim, nullptr, &idx));
+    return Iterator(idx);
+}
+
+UnstructuredMesh::Iterator
+UnstructuredMesh::cell_begin() const
+{
+    Int idx;
+    PETSC_CHECK(DMPlexGetHeightStratum(this->dm, 0, &idx, nullptr));
+    return Iterator(idx);
+}
+
+UnstructuredMesh::Iterator
+UnstructuredMesh::cell_end() const
+{
+    Int idx;
+    PETSC_CHECK(DMPlexGetHeightStratum(this->dm, 0, nullptr, &idx));
+    return Iterator(idx);
 }
 
 } // namespace godzilla

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -58,10 +58,13 @@ TEST(UnstructuredMeshTest, api)
     EXPECT_EQ(mesh.get_num_vertices(), 3);
     EXPECT_EQ(mesh.get_num_elements(), 2);
 
-    Int first, last;
-    mesh.get_element_idx_range(first, last);
-    EXPECT_EQ(first, 0);
-    EXPECT_EQ(last, 2);
+    auto elem_range = mesh.get_element_range();
+    EXPECT_EQ(elem_range.get_first(), 0);
+    EXPECT_EQ(elem_range.get_last(), 2);
+
+    auto vtx_range = mesh.get_vertex_range();
+    EXPECT_EQ(vtx_range.get_first(), 2);
+    EXPECT_EQ(vtx_range.get_last(), 5);
 
     EXPECT_EQ(mesh.get_partition_overlap(), 1);
 
@@ -85,13 +88,12 @@ TEST(UnstructuredMeshTest, api_ghosted)
     EXPECT_EQ(mesh.get_num_elements(), 2);
     EXPECT_EQ(mesh.get_num_all_elements(), 4);
 
-    Int first, last;
-    mesh.get_element_idx_range(first, last);
-    EXPECT_EQ(first, 0);
-    EXPECT_EQ(last, 2);
-    mesh.get_all_element_idx_range(first, last);
-    EXPECT_EQ(first, 0);
-    EXPECT_EQ(last, 4);
+    auto elem_range = mesh.get_element_range();
+    EXPECT_EQ(elem_range.get_first(), 0);
+    EXPECT_EQ(elem_range.get_last(), 2);
+    auto all_elem_range = mesh.get_all_element_range();
+    EXPECT_EQ(all_elem_range.get_first(), 0);
+    EXPECT_EQ(all_elem_range.get_last(), 4);
 
     EXPECT_EQ(mesh.get_partition_overlap(), 1);
 


### PR DESCRIPTION
Now, we can do range-based for-loops on vertices and cells via:
```
for (auto eid: mesh->get_element_range()) {
   // eid is element ID
}
```

Closes #209
