### PR TITLE
AuxiliaryField now has evaluate()

### DIFF
--- a/include/AuxiliaryField.h
+++ b/include/AuxiliaryField.h
@@ -38,6 +38,8 @@ public:
 
     virtual void * get_context();
 
+    virtual void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) = 0;
+
 protected:
     /// FE problem this object is part of
     const FEProblemInterface * fepi;

--- a/include/ConstantAuxiliaryField.h
+++ b/include/ConstantAuxiliaryField.h
@@ -15,7 +15,7 @@ public:
     void create() override;
     NO_DISCARD Int get_num_components() const override;
     NO_DISCARD PetscFunc * get_func() const override;
-    void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]);
+    void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override;
 
 protected:
     const std::vector<Real> & values;

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -80,7 +80,7 @@ public:
     ///
     /// @param name The name of the object
     /// @return Pointer to the auxiliary object
-    virtual const AuxiliaryField * get_aux(const std::string & name) const;
+    virtual AuxiliaryField * get_aux(const std::string & name) const;
 
     /// Adds a volumetric field
     ///

--- a/include/FunctionAuxiliaryField.h
+++ b/include/FunctionAuxiliaryField.h
@@ -15,7 +15,7 @@ public:
     void create() override;
     Int get_num_components() const override;
     PetscFunc * get_func() const override;
-    void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]);
+    void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override;
 
 public:
     static Parameters parameters();

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -313,7 +313,7 @@ FEProblemInterface::has_aux(const std::string & name) const
     return it != this->auxs_by_name.end();
 }
 
-const AuxiliaryField *
+AuxiliaryField *
 FEProblemInterface::get_aux(const std::string & name) const
 {
     _F_;

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -34,6 +34,10 @@ TEST_F(AuxiliaryFieldTest, api)
         {
             return nullptr;
         }
+        void
+        evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+        {
+        }
     };
 
     prob->set_aux_fe(0, "fld", 1, 1);
@@ -76,6 +80,10 @@ TEST_F(AuxiliaryFieldTest, non_existent_id)
         get_func() const
         {
             return nullptr;
+        }
+        void
+        evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+        {
         }
     };
 
@@ -120,6 +128,10 @@ TEST_F(AuxiliaryFieldTest, inconsistent_comp_number)
         {
             return nullptr;
         }
+        void
+        evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+        {
+        }
     };
 
     testing::internal::CaptureStderr();
@@ -162,6 +174,10 @@ TEST_F(AuxiliaryFieldTest, non_existent_region)
         get_func() const
         {
             return nullptr;
+        }
+        void
+        evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+        {
         }
     };
 


### PR DESCRIPTION
FEProblemInterface::get_aux returns a pointer to an AuxiliaryField. Removing the
const pointer as a return type, so we can call evaluate() without doing
const_cast.
