### PR TITLE
ExodusIIOutput can store auxiliary fields

### DIFF
--- a/examples/heat-eqn/test/gyml/2d.gyml
+++ b/examples/heat-eqn/test/gyml/2d.gyml
@@ -37,3 +37,4 @@ output:
     type: ExodusIIOutput
     file: '2d'
     on: ['initial', 'final']
+    variables: 'temp'

--- a/examples/ns-incomp/test/gyml/mms-2d.gyml
+++ b/examples/ns-incomp/test/gyml/mms-2d.gyml
@@ -51,3 +51,4 @@ bcs:
 output:
   out:
     type: ExodusIIOutput
+    variables: ['pressure', 'velocity']

--- a/examples/poisson/test/gyml/mms-1d.gyml
+++ b/examples/poisson/test/gyml/mms-1d.gyml
@@ -26,3 +26,4 @@ bcs:
 output:
   out:
     type: ExodusIIOutput
+    variables: 'u'

--- a/examples/poisson/test/gyml/mms-2d.gyml
+++ b/examples/poisson/test/gyml/mms-2d.gyml
@@ -29,3 +29,4 @@ bcs:
 output:
   out:
     type: ExodusIIOutput
+    variables: 'u'

--- a/examples/poisson/test/gyml/mms-3d.gyml
+++ b/examples/poisson/test/gyml/mms-3d.gyml
@@ -32,3 +32,4 @@ bcs:
 output:
   out:
     type: ExodusIIOutput
+    variables: 'u'

--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -89,6 +89,66 @@ public:
     /// @param name Component name
     virtual void set_field_component_name(Int fid, Int component, const std::string & name) = 0;
 
+    /// Get number of auxiliary fields
+    ///
+    /// @return The number of auxiliary fields
+    virtual Int get_num_aux_fields() const = 0;
+
+    /// Get all auxiliary field names
+    ///
+    /// @return All auxiliary field names
+    virtual std::vector<std::string> get_aux_field_names() const = 0;
+
+    /// Get auxiliary field name
+    ///
+    /// @param fid Auxiliary field ID
+    /// @return Auxiliary field name
+    virtual const std::string & get_aux_field_name(Int fid) const = 0;
+
+    /// Get number of auxiliary field components
+    ///
+    /// @param fid Auxiliary field ID
+    /// @return Number of components
+    virtual Int get_aux_field_num_components(Int fid) const = 0;
+
+    /// Get auxiliary field ID
+    ///
+    /// @param name Auxiliary field name
+    /// @return Auxiliary field ID
+    virtual Int get_aux_field_id(const std::string & name) const = 0;
+
+    /// Do we have auxiliary field with specified ID
+    ///
+    /// @param fid The ID of the auxiliary field
+    /// @return True if the auxiliary field exists, otherwise False
+    virtual bool has_aux_field_by_id(Int fid) const = 0;
+
+    /// Do we have auxiliary field with specified name
+    ///
+    /// @param name The name of the auxiliary field
+    /// @return True if the auxiliary field exists, otherwise False
+    virtual bool has_aux_field_by_name(const std::string & name) const = 0;
+
+    /// Get auxiliary field order
+    ///
+    /// @param fid Auxiliary field ID
+    /// @return Auxiliary field order
+    virtual Int get_aux_field_order(Int fid) const = 0;
+
+    /// Get component name of an auxiliary field
+    ///
+    /// @param fid Auxiliary field ID
+    /// @param component Component index
+    /// @return Component name
+    virtual std::string get_aux_field_component_name(Int fid, Int component) const = 0;
+
+    /// Set the name of a component of an auxiliary field variable
+    ///
+    /// @param fid Field ID
+    /// @param component Component index
+    /// @param name Component name
+    virtual void set_aux_field_component_name(Int fid, Int component, const std::string & name) = 0;
+
     /// Add initial condition
     ///
     /// @param ic Initial condition object to add
@@ -106,6 +166,14 @@ public:
     /// @return The offset
     virtual Int get_field_dof(Int point, Int fid) const;
 
+    /// Return the offset into an array of local auxiliary Vec for the dof associated with the given
+    /// point
+    ///
+    /// @param point Point
+    /// @param fid Field ID
+    /// @return The offset
+    virtual Int get_aux_field_dof(Int point, Int fid) const = 0;
+
     /// Gets a local vector with the coordinates associated with this problem's mesh
     ///
     /// @return coordinate vector
@@ -115,6 +183,11 @@ public:
     ///
     /// @return Local solution vector
     virtual const Vector & get_solution_vector_local() const = 0;
+
+    /// Get local auxiliary solution vector
+    ///
+    /// @return Local auxiliary solution vector
+    virtual const Vector & get_aux_solution_vector_local() const = 0;
 
     virtual void add_boundary_essential(const std::string & name,
                                         DMLabel label,

--- a/include/ExodusIIOutput.h
+++ b/include/ExodusIIOutput.h
@@ -45,11 +45,12 @@ protected:
     void write_node_sets();
     void write_face_sets();
     void add_var_names(Int fid, std::vector<std::string> & var_names);
+    void add_aux_var_names(Int fid, std::vector<std::string> & var_names);
     void write_all_variable_names();
     void write_variables();
     void write_field_variables();
-    void write_nodal_variables(const Scalar * sln);
-    void write_elem_variables(const Scalar * sln);
+    void write_nodal_variables();
+    void write_elem_variables();
     void write_block_elem_variables(int blk_id,
                                     const Scalar * sln,
                                     Int n_elems_in_block = 0,
@@ -72,10 +73,14 @@ protected:
     bool mesh_stored;
     /// List of field variable names to output
     std::vector<std::string> field_var_names;
+    /// List of auxiliary field variable names to output
+    std::vector<std::string> aux_field_var_names;
     /// List of global variable names to output
     std::vector<std::string> global_var_names;
     /// List of nodal variable field IDs
     std::vector<Int> nodal_var_fids;
+    /// List of nodal auxiliary variable field IDs
+    std::vector<Int> nodal_aux_var_fids;
     /// List of nodal elemental variable field IDs
     std::vector<Int> elem_var_fids;
 

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -38,37 +38,23 @@ public:
     Int get_field_order(Int fid) const override;
     std::string get_field_component_name(Int fid, Int component) const override;
     void set_field_component_name(Int fid, Int component, const std::string & name) override;
+
+    Int get_num_aux_fields() const override;
+    std::vector<std::string> get_aux_field_names() const override;
+    const std::string & get_aux_field_name(Int fid) const override;
+    Int get_aux_field_num_components(Int fid) const override;
+    Int get_aux_field_id(const std::string & name) const override;
+    bool has_aux_field_by_id(Int fid) const override;
+    bool has_aux_field_by_name(const std::string & name) const override;
+    Int get_aux_field_order(Int fid) const override;
+    std::string get_aux_field_component_name(Int fid, Int component) const override;
+    void set_aux_field_component_name(Int fid, Int component, const std::string & name) override;
+
+    Int get_aux_field_dof(Int point, Int fid) const override;
+
     const Vector & get_solution_vector_local() const override;
+    const Vector & get_aux_solution_vector_local() const override;
     virtual WeakForm * get_weak_form() const;
-
-    /// Get number of auxiliary fields
-    ///
-    /// @return The number of auxiliary fields
-    virtual Int get_num_aux_fields() const;
-
-    /// Get auxiliary field name
-    ///
-    /// @param fid Auxiliary field ID
-    /// @return Auxiliary field name
-    virtual const std::string & get_aux_field_name(Int fid) const;
-
-    /// Get auxiliary field ID
-    ///
-    /// @param name Auxiliary field name
-    /// @param Auxiliary field ID
-    virtual Int get_aux_field_id(const std::string & name) const;
-
-    /// Do we have auxiliary field with specified ID
-    ///
-    /// @param fid The ID of the auxiliary field
-    /// @return True if the auxiliary field exists, otherwise False
-    virtual bool has_aux_field_by_id(Int fid) const;
-
-    /// Do we have auxiliary field with specified name
-    ///
-    /// @param name The name of the auxiliary field
-    /// @return True if the auxiliary field exists, otherwise False
-    virtual bool has_aux_field_by_name(const std::string & name) const;
 
     /// Check if we have an auxiliary object with a specified name
     ///
@@ -396,6 +382,9 @@ protected:
 
     /// DM for auxiliary fields
     DM dm_aux;
+
+    /// Auxiliary section
+    Section section_aux;
 
     /// Vector for auxiliary fields
     Vector a;

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -23,7 +23,22 @@ public:
     Int get_field_order(Int fid) const override;
     std::string get_field_component_name(Int fid, Int component) const override;
     void set_field_component_name(Int fid, Int component, const std::string & name) override;
+
+    Int get_num_aux_fields() const override;
+    std::vector<std::string> get_aux_field_names() const override;
+    const std::string & get_aux_field_name(Int fid) const override;
+    Int get_aux_field_num_components(Int fid) const override;
+    Int get_aux_field_id(const std::string & name) const override;
+    bool has_aux_field_by_id(Int fid) const override;
+    bool has_aux_field_by_name(const std::string & name) const override;
+    Int get_aux_field_order(Int fid) const override;
+    std::string get_aux_field_component_name(Int fid, Int component) const override;
+    void set_aux_field_component_name(Int fid, Int component, const std::string & name) override;
+
+    Int get_aux_field_dof(Int point, Int fid) const override;
+
     const Vector & get_solution_vector_local() const override;
+    const Vector & get_aux_solution_vector_local() const override;
 
     /// Adds a volumetric field
     ///

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -119,6 +119,9 @@ protected:
     /// Local solution vector
     Vector sln;
 
+    /// Local auxiliary solution vector
+    Vector a;
+
     friend void __compute_flux(Int dim,
                                Int nf,
                                const Real x[],

--- a/include/Vector.h
+++ b/include/Vector.h
@@ -22,7 +22,9 @@ public:
     void assembly_end();
 
     Scalar * get_array();
+    const Scalar * get_array_read();
     void restore_array(Scalar * arr);
+    void restore_array_read(const Scalar * arr);
 
     /// Returns the global number of elements of the vector
     Int get_size() const;

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -156,12 +156,84 @@ FVProblemInterface::set_field_component_name(Int fid, Int component, const std::
         error("Field with ID = '%d' does not exist.", fid);
 }
 
+Int
+FVProblemInterface::get_num_aux_fields() const
+{
+    error("Not implemented");
+}
+
+std::vector<std::string>
+FVProblemInterface::get_aux_field_names() const
+{
+    error("Not implemented");
+}
+
+const std::string &
+FVProblemInterface::get_aux_field_name(Int fid) const
+{
+    error("Not implemented");
+}
+
+Int
+FVProblemInterface::get_aux_field_num_components(Int fid) const
+{
+    error("Not implemented");
+}
+
+Int
+FVProblemInterface::get_aux_field_id(const std::string & name) const
+{
+    error("Not implemented");
+}
+
+bool
+FVProblemInterface::has_aux_field_by_id(Int fid) const
+{
+    error("Not implemented");
+}
+
+bool
+FVProblemInterface::has_aux_field_by_name(const std::string & name) const
+{
+    error("Not implemented");
+}
+
+Int
+FVProblemInterface::get_aux_field_order(Int fid) const
+{
+    error("Not implemented");
+}
+
+std::string
+FVProblemInterface::get_aux_field_component_name(Int fid, Int component) const
+{
+    error("Not implemented");
+}
+
+void
+FVProblemInterface::set_aux_field_component_name(Int fid, Int component, const std::string & name)
+{
+    error("Not implemented");
+}
+
+Int
+FVProblemInterface::get_aux_field_dof(Int point, Int fid) const
+{
+    error("Not implemented");
+}
+
 const Vector &
 FVProblemInterface::get_solution_vector_local() const
 {
     _F_;
     build_local_solution_vector(this->sln);
     return this->sln;
+}
+
+const Vector &
+FVProblemInterface::get_aux_solution_vector_local() const
+{
+    error("Not implemented");
 }
 
 void

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -165,7 +165,7 @@ FVProblemInterface::get_num_aux_fields() const
 std::vector<std::string>
 FVProblemInterface::get_aux_field_names() const
 {
-    error("Not implemented");
+    return {};
 }
 
 const std::string &
@@ -233,7 +233,7 @@ FVProblemInterface::get_solution_vector_local() const
 const Vector &
 FVProblemInterface::get_aux_solution_vector_local() const
 {
-    error("Not implemented");
+    return this->a;
 }
 
 void

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -261,11 +261,27 @@ Vector::get_array()
     return array;
 }
 
+const Scalar *
+Vector::get_array_read()
+{
+    _F_;
+    const Scalar * array;
+    PETSC_CHECK(VecGetArrayRead(this->vec, &array));
+    return array;
+}
+
 void
 Vector::restore_array(Scalar * array)
 {
     _F_;
     PETSC_CHECK(VecRestoreArray(this->vec, &array));
+}
+
+void
+Vector::restore_array_read(const Scalar * array)
+{
+    _F_;
+    PETSC_CHECK(VecRestoreArrayRead(this->vec, &array));
 }
 
 void


### PR DESCRIPTION
- Vector {get/restore}_array_read
- Adding API for accessing auxiliary fields via DiscreteProblemInterface
- ExodusIIOutput can store auxiliary fields
