### PR TITLE
Changing format strings for printing errors/warnings/logs

### DIFF
--- a/include/DenseMatrix.h
+++ b/include/DenseMatrix.h
@@ -194,7 +194,7 @@ public:
     Real
     det() const
     {
-        error("Determinant is not implemented for %dx%d matrices, yet.", ROWS, ROWS);
+        error("Determinant is not implemented for {}x{} matrices, yet.", ROWS, ROWS);
     }
 
     /// Compute inverse of this matrix
@@ -203,7 +203,7 @@ public:
     DenseMatrix<Real, COLS>
     inv() const
     {
-        error("Inverse is not implemented for %dx%d matrices, yet.", ROWS, ROWS);
+        error("Inverse is not implemented for {}x{} matrices, yet.", ROWS, ROWS);
     }
 
     /// Compute transpose

--- a/include/DenseMatrixSymm.h
+++ b/include/DenseMatrixSymm.h
@@ -139,7 +139,7 @@ public:
     Real
     det() const
     {
-        error("Determinant is not implemented for %dx%d matrices, yet.", DIM, DIM);
+        error("Determinant is not implemented for {}x{} matrices, yet.", DIM, DIM);
     }
 
     /// Compute transpose

--- a/include/DenseVector.h
+++ b/include/DenseVector.h
@@ -116,7 +116,7 @@ public:
     DenseVector<Real, N>
     cross(const DenseVector<Real, N> &) const
     {
-        error("Cross product in %d dimensions is not unique.", N);
+        error("Cross product in {} dimensions is not unique.", N);
     }
 
     template <Int M>

--- a/include/DependencyEvaluator.h
+++ b/include/DependencyEvaluator.h
@@ -117,7 +117,7 @@ DependencyEvaluator::declare_value(const std::string & val_name)
     }
     else {
         if (it->second->is_declared())
-            error("Trying to declare an already existing value '%s'.", val_name);
+            error("Trying to declare an already existing value '{}'.", val_name);
         else {
             auto val = dynamic_cast<Value<T> *>(const_cast<ValueBase *>(it->second));
             return val->set();
@@ -153,7 +153,7 @@ DependencyEvaluator::create_functional(const std::string & name, const Parameter
         this->functionals[name] = fnl;
     }
     else
-        error("Functional with name '%s' already exists.", name);
+        error("Functional with name '{}' already exists.", name);
 }
 
 } // namespace godzilla

--- a/include/Error.h
+++ b/include/Error.h
@@ -11,15 +11,15 @@ namespace godzilla {
 
 namespace internal {
 
-template <typename... Args>
+template <typename... T>
 void
-error_printf(const char * s, Args... args)
+error_print(fmt::format_string<T...> format, T... args)
 {
-    fmt::fprintf(stderr, "%s", (const char *) Terminal::Color::red);
-    fmt::fprintf(stderr, "[ERROR] ");
-    fmt::fprintf(stderr, s, std::forward<Args>(args)...);
-    fmt::fprintf(stderr, "%s", (const char *) Terminal::Color::normal);
-    fmt::fprintf(stderr, "\n");
+    fmt::print(stderr, "{}", (const char *) Terminal::Color::red);
+    fmt::print(stderr, "[ERROR] ");
+    fmt::print(stderr, format, std::forward<T>(args)...);
+    fmt::print(stderr, "{}", (const char *) Terminal::Color::normal);
+    fmt::print(stderr, "\n");
 }
 
 /// Terminate the run
@@ -33,11 +33,11 @@ void check_mpi_error(int ierr, const char * file, int line);
 
 } // namespace internal
 
-template <typename... Args>
+template <typename... T>
 [[noreturn]] void
-error(const char * format, Args &&... args)
+error(fmt::format_string<T...> format, T... args)
 {
-    internal::error_printf(format, std::forward<Args>(args)...);
+    internal::error_print(format, std::forward<T>(args)...);
     internal::terminate();
 }
 

--- a/include/Factory.h
+++ b/include/Factory.h
@@ -69,7 +69,7 @@ public:
     {
         auto it = classes.find(class_name);
         if (it == classes.end())
-            error("Getting valid_params for object '%s' failed.  Object is not registered.",
+            error("Getting valid_params for object '{}' failed.  Object is not registered.",
                   class_name);
 
         Entry & entry = it->second;
@@ -89,7 +89,7 @@ public:
     {
         auto it = classes.find(class_name);
         if (it == classes.end())
-            error("Trying to create object of unregistered type '%s'.", class_name);
+            error("Trying to create object of unregistered type '{}'.", class_name);
         else {
             parameters.set<std::string>("_type") = class_name;
             parameters.set<std::string>("_name") = name;
@@ -97,7 +97,7 @@ public:
             auto entry = it->second;
             T * object = dynamic_cast<T *>(entry.build_ptr(parameters));
             if (object == nullptr)
-                error("Instantiation of object '%s:[%s]' failed.", name, class_name);
+                error("Instantiation of object '{}:[{}]' failed.", name, class_name);
             objects.push_back(object);
             return object;
         }

--- a/include/Logger.h
+++ b/include/Logger.h
@@ -14,40 +14,40 @@ public:
     Logger();
 
     /// Log an error
-    template <typename... Args>
+    template <typename... T>
     void
-    error(const char * s, Args... args)
+    error(fmt::format_string<T...> format, T... args)
     {
-        error(std::string(""), s, std::forward<Args>(args)...);
+        error(std::string(""), format, std::forward<T>(args)...);
     }
 
-    template <typename... Args>
+    template <typename... T>
     void
-    error(const std::string & prefix, const char * s, Args... args)
+    error(const std::string & prefix, fmt::format_string<T...> format, T... args)
     {
         std::string str =
-            format_msg(Terminal::Color::red, "[ERROR]", prefix, s, std::forward<Args>(args)...);
+            format_msg(Terminal::Color::red, "[ERROR]", prefix, format, std::forward<T>(args)...);
         this->entries.push_back(str);
         this->num_errors++;
     }
 
     /// Log a warning
-    template <typename... Args>
+    template <typename... T>
     void
-    warning(const char * s, Args... args)
+    warning(fmt::format_string<T...> format, T... args)
     {
-        warning(std::string(""), s, std::forward<Args>(args)...);
+        warning(std::string(""), format, std::forward<T>(args)...);
     }
 
-    template <typename... Args>
+    template <typename... T>
     void
-    warning(const std::string & prefix, const char * s, Args... args)
+    warning(const std::string & prefix, fmt::format_string<T...> format, T... args)
     {
         std::string str = format_msg(Terminal::Color::yellow,
                                      "[WARNING]",
                                      prefix,
-                                     s,
-                                     std::forward<Args>(args)...);
+                                     format,
+                                     std::forward<T>(args)...);
         this->entries.push_back(str);
         this->num_warnings++;
     }
@@ -71,20 +71,20 @@ public:
     void print() const;
 
 protected:
-    template <typename... Args>
+    template <typename... T>
     std::string
     format_msg(const Terminal::Color & color,
                const char * title,
                const std::string & prefix,
-               const char * format,
-               Args... args)
+               fmt::format_string<T...> format,
+               T... args)
     {
         std::string str;
-        str += fmt::sprintf("%s%s ", color, title);
+        str += fmt::format("{}{} ", color, title);
         if (prefix.length() > 0)
-            str += fmt::sprintf("%s: ", prefix);
-        str += fmt::sprintf(format, std::forward<Args>(args)...);
-        str += fmt::sprintf("%s", Terminal::Color::normal);
+            str += fmt::format("{}: ", prefix);
+        str += fmt::format(format, std::forward<T>(args)...);
+        str += fmt::format("{}", Terminal::Color::normal);
         return str;
     }
 

--- a/include/LoggingInterface.h
+++ b/include/LoggingInterface.h
@@ -15,19 +15,19 @@ public:
     }
 
     /// Log an error
-    template <typename... Args>
+    template <typename... T>
     void
-    log_error(const char * s, Args... args)
+    log_error(fmt::format_string<T...> format, T... args)
     {
-        this->logger->error(this->prefix, s, std::forward<Args>(args)...);
+        this->logger->error(this->prefix, format, std::forward<T>(args)...);
     }
 
     /// Log a warning
-    template <typename... Args>
+    template <typename... T>
     void
-    log_warning(const char * s, Args... args)
+    log_warning(fmt::format_string<T...> format, T... args)
     {
-        this->logger->warning(this->prefix, s, std::forward<Args>(args)...);
+        this->logger->warning(this->prefix, format, std::forward<T>(args)...);
     }
 
 protected:

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -102,7 +102,7 @@ public:
     get(const std::string & name) const
     {
         if (!this->has<T>(name))
-            error("No parameter '%s' found.", name);
+            error("No parameter '{}' found.", name);
 
         auto it = this->params.find(name);
         return dynamic_cast<Parameter<T> *>(it->second)->get();

--- a/include/PrintInterface.h
+++ b/include/PrintInterface.h
@@ -29,14 +29,14 @@ protected:
     ///              message will be printed.
     /// @param format String specifying how to interpret the data
     /// @param ... Arguments specifying data to print
-    template <typename... Args>
+    template <typename... T>
     void
-    lprintf(unsigned int level, const char * format, Args &&... args) const
+    lprintf(unsigned int level, fmt::format_string<T...> format, T... args) const
     {
         if (level <= this->verbosity_level && this->proc_id == 0) {
-            fmt::fprintf(stdout, "%s: ", this->prefix.c_str());
-            fmt::fprintf(stdout, format, std::forward<Args>(args)...);
-            fmt::fprintf(stdout, "\n");
+            fmt::print(stdout, "{}: ", this->prefix);
+            fmt::print(stdout, format, std::forward<T>(args)...);
+            fmt::print(stdout, "\n");
         }
     }
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -144,7 +144,7 @@ App::run_input_file()
         run_problem();
     }
     else
-        error("Unable to open '%s' for reading. Make sure it exists and you have read permissions.",
+        error("Unable to open '{}' for reading. Make sure it exists and you have read permissions.",
               this->input_file_name);
 }
 

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -40,7 +40,7 @@ AuxiliaryField::create()
             this->block_id = mesh->get_cell_set_id(this->region);
         }
         else
-            log_error("Region '%s' does not exists. Typo?", this->region);
+            log_error("Region '{}' does not exists. Typo?", this->region);
     }
 }
 

--- a/src/CSVOutput.cpp
+++ b/src/CSVOutput.cpp
@@ -56,7 +56,7 @@ CSVOutput::output_step()
     if (this->pps_names.empty())
         return;
 
-    lprintf(9, "Output to file: %s", this->file_name);
+    lprintf(9, "Output to file: {}", this->file_name);
 
     if (!this->has_header) {
         write_header();

--- a/src/CSVOutput.cpp
+++ b/src/CSVOutput.cpp
@@ -71,7 +71,7 @@ CSVOutput::open_file()
     _F_;
     this->f = fopen(this->file_name.c_str(), "w");
     if (this->f == nullptr)
-        log_error("Unable to open '%s' for writing: %s.", this->file_name, strerror(errno));
+        log_error("Unable to open '{}' for writing: {}.", this->file_name, strerror(errno));
 }
 
 void

--- a/src/DependencyEvaluator.cpp
+++ b/src/DependencyEvaluator.cpp
@@ -28,7 +28,7 @@ DependencyEvaluator::get_functional(const std::string & name) const
     if (it != this->functionals.end())
         return *it->second;
     else
-        error("No functional with name '%s' found. Typo?", name);
+        error("No functional with name '{}' found. Typo?", name);
 }
 
 } // namespace godzilla

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -84,8 +84,8 @@ DiscreteProblemInterface::set_up_initial_conditions()
                 if (ic_nc == field_nc)
                     ics_by_fields[fid] = ic;
                 else
-                    this->logger->error("Initial condition '%s' operates on %d components, but is "
-                                        "set on a field with %d components.",
+                    this->logger->error("Initial condition '{}' operates on {} components, but is "
+                                        "set on a field with {} components.",
                                         ic->get_name(),
                                         ic_nc,
                                         field_nc);
@@ -93,13 +93,13 @@ DiscreteProblemInterface::set_up_initial_conditions()
             else
                 // TODO: improve this error message
                 this->logger->error(
-                    "Initial condition '%s' is being applied to a field that already "
+                    "Initial condition '{}' is being applied to a field that already "
                     "has an initial condition.",
                     ic->get_name());
         }
     }
     else
-        this->logger->error("Provided %d field(s), but %d initial condition(s).", n_fields, n_ics);
+        this->logger->error("Provided {} field(s), but {} initial condition(s).", n_fields, n_ics);
 }
 
 void
@@ -114,7 +114,7 @@ DiscreteProblemInterface::set_up_boundary_conditions()
         if (!exists) {
             no_errors = false;
             this->logger->error(
-                "Boundary condition '%s' is set on boundary '%s' which does not exist in the mesh.",
+                "Boundary condition '{}' is set on boundary '{}' which does not exist in the mesh.",
                 bc->get_name(),
                 bnd_name);
         }

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -26,9 +26,9 @@ void
 mem_check(int line, const char *, const char * file, void * var)
 {
     if (var == nullptr) {
-        error_printf("Out of memory");
-        error_printf("");
-        error_printf("  Location: %s:%d", file, line);
+        error_print("Out of memory");
+        error_print("");
+        error_print("  Location: {}:{}", file, line);
         print_call_stack();
         terminate();
     }
@@ -38,9 +38,9 @@ void
 check_petsc_error(int ierr, const char * file, int line)
 {
     if (ierr) {
-        error_printf("PETSc error: %d", ierr);
-        error_printf("");
-        error_printf("  Location: %s:%d", file, line);
+        error_print("PETSc error: {}", ierr);
+        error_print("");
+        error_print("  Location: {}:{}", file, line);
         print_call_stack();
         terminate();
     }
@@ -50,9 +50,9 @@ void
 check_mpi_error(int ierr, const char * file, int line)
 {
     if (ierr) {
-        error_printf("MPI error: %d", ierr);
-        error_printf("");
-        error_printf("  Location: %s:%d", file, line);
+        error_print("MPI error: {}", ierr);
+        error_print("");
+        error_print("  Location: {}:{}", file, line);
         print_call_stack();
         terminate();
     }

--- a/src/EssentialBC.cpp
+++ b/src/EssentialBC.cpp
@@ -68,7 +68,7 @@ EssentialBC::create()
             if (this->dpi->has_field_by_name(field_name))
                 this->fid = this->dpi->get_field_id(field_name);
             else
-                log_error("Field '%s' does not exists. Typo?", field_name);
+                log_error("Field '{}' does not exists. Typo?", field_name);
         }
         else
             log_error("Use the 'field' parameter to assign this boundary condition to an existing "

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -24,7 +24,7 @@ void
 ExodusIIMesh::create_dm()
 {
     _F_;
-    lprintf(9, "Loading mesh '%s'", this->file_name);
+    lprintf(9, "Loading mesh '{}'", this->file_name);
     PETSC_CHECK(DMPlexCreateExodusFromFile(get_comm(),
                                            this->file_name.c_str(),
                                            this->interpolate,

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -175,7 +175,7 @@ ExodusIIOutput::create()
             else if (pp_names.count(name) == 1)
                 this->global_var_names.push_back(name);
             else
-                log_error("Variable '%s' specified in 'variables' parameter does not exist. Typo?",
+                log_error("Variable '{}' specified in 'variables' parameter does not exist. Typo?",
                           name);
         }
     }
@@ -218,7 +218,7 @@ ExodusIIOutput::open_file()
     _F_;
     this->exo = new exodusIIcpp::File(this->file_name, exodusIIcpp::FileAccess::WRITE);
     if (!this->exo->is_opened())
-        error("Could not open file '%s' for writing.", get_file_name());
+        error("Could not open file '{}' for writing.", get_file_name());
 }
 
 void

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -197,7 +197,7 @@ ExodusIIOutput::output_step()
     _F_;
     // We only have fixed meshes, so no need to deal with a sequence of files
     set_file_name();
-    lprintf(9, "Output to file: %s", this->file_name);
+    lprintf(9, "Output to file: {}", this->file_name);
 
     if (this->exo == nullptr)
         open_file();

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -34,7 +34,7 @@ add_functionals(DependencyGraph<const Functional *> & g,
             if (jt != suppliers.end())
                 g.add_edge(f, jt->second);
             else
-                error("Did not find any functional which would supply '%s'.", dep);
+                error("Did not find any functional which would supply '{}'.", dep);
         }
     }
 }
@@ -159,7 +159,7 @@ FEProblemInterface::get_field_name(Int fid) const
     if (it != this->fields.end())
         return it->second.name;
     else
-        error("Field with ID = '%d' does not exist.", fid);
+        error("Field with ID = '{}' does not exist.", fid);
 }
 
 Int
@@ -170,7 +170,7 @@ FEProblemInterface::get_field_order(Int fid) const
     if (it != this->fields.end())
         return it->second.k;
     else
-        error("Field with ID = '%d' does not exist.", fid);
+        error("Field with ID = '{}' does not exist.", fid);
 }
 
 Int
@@ -181,7 +181,7 @@ FEProblemInterface::get_field_num_components(Int fid) const
     if (it != this->fields.end())
         return it->second.nc;
     else
-        error("Field with ID = '%d' does not exist.", fid);
+        error("Field with ID = '{}' does not exist.", fid);
 }
 
 Int
@@ -192,7 +192,7 @@ FEProblemInterface::get_field_id(const std::string & name) const
     if (it != this->fields_by_name.end())
         return it->second;
     else
-        error("Field '%s' does not exist. Typo?", name);
+        error("Field '{}' does not exist. Typo?", name);
 }
 
 Int
@@ -256,7 +256,7 @@ FEProblemInterface::get_field_component_name(Int fid, Int component) const
         }
     }
     else
-        error("Field with ID = '%d' does not exist.", fid);
+        error("Field with ID = '{}' does not exist.", fid);
 }
 
 void
@@ -273,7 +273,7 @@ FEProblemInterface::set_field_component_name(Int fid, Int component, const std::
             error("Unable to set component name for single-component field");
     }
     else
-        error("Field with ID = '%d' does not exist.", fid);
+        error("Field with ID = '{}' does not exist.", fid);
 }
 
 Int
@@ -302,7 +302,7 @@ FEProblemInterface::get_aux_field_name(Int fid) const
     if (it != this->aux_fields.end())
         return it->second.name;
     else
-        error("Auxiliary field with ID = '%d' does not exist.", fid);
+        error("Auxiliary field with ID = '{}' does not exist.", fid);
 }
 
 Int
@@ -313,7 +313,7 @@ FEProblemInterface::get_aux_field_num_components(Int fid) const
     if (it != this->aux_fields.end())
         return it->second.nc;
     else
-        error("Auxiliary field with ID = '%d' does not exist.", fid);
+        error("Auxiliary field with ID = '{}' does not exist.", fid);
 }
 
 Int
@@ -324,7 +324,7 @@ FEProblemInterface::get_aux_field_id(const std::string & name) const
     if (it != this->aux_fields_by_name.end())
         return it->second;
     else
-        error("Auxiliary field '%s' does not exist. Typo?", name);
+        error("Auxiliary field '{}' does not exist. Typo?", name);
 }
 
 bool
@@ -351,7 +351,7 @@ FEProblemInterface::get_aux_field_order(Int fid) const
     if (it != this->aux_fields.end())
         return it->second.k;
     else
-        error("Auxiliary field with ID = '%d' does not exist.", fid);
+        error("Auxiliary field with ID = '{}' does not exist.", fid);
 }
 
 std::string
@@ -369,7 +369,7 @@ FEProblemInterface::get_aux_field_component_name(Int fid, Int component) const
         }
     }
     else
-        error("Auxiliary field with ID = '%d' does not exist.", fid);
+        error("Auxiliary field with ID = '{}' does not exist.", fid);
 }
 
 void
@@ -386,7 +386,7 @@ FEProblemInterface::set_aux_field_component_name(Int fid, Int component, const s
             error("Unable to set component name for single-component field");
     }
     else
-        error("Auxiliary field with ID = '%d' does not exist.", fid);
+        error("Auxiliary field with ID = '{}' does not exist.", fid);
 }
 
 bool
@@ -434,7 +434,7 @@ FEProblemInterface::set_fe(Int id, const std::string & name, Int nc, Int k)
         this->fields_by_name[name] = id;
     }
     else
-        error("Cannot add field '%s' with ID = %d. ID already exists.", name, id);
+        error("Cannot add field '{}' with ID = {}. ID already exists.", name, id);
 }
 
 Int
@@ -458,7 +458,7 @@ FEProblemInterface::set_aux_fe(Int id, const std::string & name, Int nc, Int k)
         this->aux_fields_by_name[name] = id;
     }
     else
-        error("Cannot add auxiliary field '%s' with ID = %d. ID is already taken.", name, id);
+        error("Cannot add auxiliary field '{}' with ID = {}. ID is already taken.", name, id);
 }
 
 void
@@ -472,7 +472,7 @@ FEProblemInterface::add_auxiliary_field(AuxiliaryField * aux)
         this->auxs_by_name[name] = aux;
     }
     else
-        error("Cannot add auxiliary object '%s'. Name already taken.", name);
+        error("Cannot add auxiliary object '{}'. Name already taken.", name);
 }
 
 void
@@ -657,8 +657,8 @@ FEProblemInterface::set_up_auxiliary_dm(DM dm)
             }
             else {
                 no_errors = false;
-                this->logger->error("Auxiliary field '%s' has %d component(s), but is set on a "
-                                    "field with %d component(s).",
+                this->logger->error("Auxiliary field '{}' has {} component(s), but is set on a "
+                                    "field with {} component(s).",
                                     aux->get_name(),
                                     aux_nc,
                                     field_nc);
@@ -666,7 +666,7 @@ FEProblemInterface::set_up_auxiliary_dm(DM dm)
         }
         else {
             no_errors = false;
-            this->logger->error("Auxiliary field '%s' is set on auxiliary field with ID '%d', but "
+            this->logger->error("Auxiliary field '{}' is set on auxiliary field with ID '{}', but "
                                 "such ID does not exist.",
                                 aux->get_name(),
                                 fid);
@@ -715,7 +715,7 @@ FEProblemInterface::get_field_value(const std::string & field_name) const
         return this->aux_fields.at(fid).values;
     }
     else
-        error("Field '%s' does not exist. Typo?", field_name);
+        error("Field '{}' does not exist. Typo?", field_name);
 }
 
 const FieldGradient &
@@ -731,7 +731,7 @@ FEProblemInterface::get_field_gradient(const std::string & field_name) const
         return this->aux_fields.at(fid).derivs;
     }
     else
-        error("Field '%s' does not exist. Typo?", field_name);
+        error("Field '{}' does not exist. Typo?", field_name);
 }
 
 const FieldValue &
@@ -747,7 +747,7 @@ FEProblemInterface::get_field_dot(const std::string & field_name) const
         return this->aux_fields.at(fid).dots;
     }
     else
-        error("Field '%s' does not exist. Typo?", field_name);
+        error("Field '{}' does not exist. Typo?", field_name);
 }
 
 const Real &
@@ -792,7 +792,7 @@ FEProblemInterface::sort_residual_functionals(
             if (jt != suppliers.end())
                 graph.add_edge(fnl, jt->second);
             else
-                error("Did not find any functional which would supply '%'.", dep);
+                error("Did not find any functional which would supply '{}'.", dep);
         }
     }
 
@@ -838,7 +838,7 @@ FEProblemInterface::sort_jacobian_functionals(
             if (jt != suppliers.end())
                 graph.add_edge(fnl, jt->second);
             else
-                error("Did not find any functional which would supply '%'.", dep);
+                error("Did not find any functional which would supply '{}'.", dep);
         }
     }
 
@@ -891,7 +891,7 @@ FEProblemInterface::sort_functionals()
             if (suppliers.find(s) == suppliers.end())
                 suppliers[s] = fnl;
             else
-                error("Value '%s' is being supplied multiple times.", s);
+                error("Value '{}' is being supplied multiple times.", s);
         }
     }
 

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -75,7 +75,7 @@ FVProblemInterface::get_field_name(Int fid) const
             return empty_name;
     }
     else
-        error("Field with ID = '%d' does not exist.", fid);
+        error("Field with ID = '{}' does not exist.", fid);
 }
 
 Int
@@ -89,7 +89,7 @@ FVProblemInterface::get_field_num_components(Int fid) const
         return n_comps;
     }
     else
-        error("Field with ID = '%d' does not exist.", fid);
+        error("Field with ID = '{}' does not exist.", fid);
 }
 
 Int
@@ -153,7 +153,7 @@ FVProblemInterface::set_field_component_name(Int fid, Int component, const std::
             error("Unable to set component name for single-component field");
     }
     else
-        error("Field with ID = '%d' does not exist.", fid);
+        error("Field with ID = '{}' does not exist.", fid);
 }
 
 Int
@@ -252,7 +252,7 @@ FVProblemInterface::add_field(Int id, const std::string & name, Int nc)
         this->fields_by_name[name] = id;
     }
     else
-        error("Cannot add field '%s' with ID = %d. ID already exists.", name, id);
+        error("Cannot add field '{}' with ID = {}. ID already exists.", name, id);
 }
 
 void

--- a/src/FileMesh.cpp
+++ b/src/FileMesh.cpp
@@ -28,7 +28,7 @@ FileMesh::FileMesh(const Parameters & parameters) :
 
     if (!utils::path_exists(this->file_name))
         log_error(
-            "Unable to open '%s' for reading. Make sure it exists and you have read permissions.",
+            "Unable to open '{}' for reading. Make sure it exists and you have read permissions.",
             this->file_name);
 }
 

--- a/src/FunctionEvaluator.cpp
+++ b/src/FunctionEvaluator.cpp
@@ -61,7 +61,7 @@ FunctionEvaluator::evaluate(Int dim, Real time, const Real x[])
         return this->parser.Eval();
     }
     catch (mu::Parser::exception_type & e) {
-        error("Function evaluator failed: %s", e.GetMsg());
+        error("Function evaluator failed: {}", e.GetMsg());
     }
 }
 
@@ -91,7 +91,7 @@ FunctionEvaluator::evaluate(Int dim, Real time, const Real x[], Int nc, Real u[]
         return true;
     }
     catch (mu::Parser::exception_type & e) {
-        error("Function evaluator failed: %s", e.GetMsg());
+        error("Function evaluator failed: {}", e.GetMsg());
     }
 }
 

--- a/src/GYMLFile.cpp
+++ b/src/GYMLFile.cpp
@@ -128,7 +128,7 @@ GYMLFile::build_auxiliary_fields()
 
     auto * fepface = dynamic_cast<FEProblemInterface *>(this->problem);
     if (fepface == nullptr)
-        log_error("Supplied problem type '%s' does not support auxiliary fields.",
+        log_error("Supplied problem type '{}' does not support auxiliary fields.",
                   this->problem->get_type());
     else {
         for (const auto & it : auxs_root_node) {
@@ -156,7 +156,7 @@ GYMLFile::build_initial_conditions()
 
     auto * dpi = dynamic_cast<DiscreteProblemInterface *>(this->problem);
     if (dpi == nullptr)
-        log_error("Supplied problem type '%s' does not support initial conditions.",
+        log_error("Supplied problem type '{}' does not support initial conditions.",
                   this->problem->get_type());
     else {
         for (const auto & it : ics_root_node) {
@@ -184,7 +184,7 @@ GYMLFile::build_boundary_conditions()
 
     auto * dpi = dynamic_cast<DiscreteProblemInterface *>(this->problem);
     if (dpi == nullptr)
-        log_error("Supplied problem type '%s' does not support boundary conditions.",
+        log_error("Supplied problem type '{}' does not support boundary conditions.",
                   this->problem->get_type());
     else {
         for (const auto & it : bcs_root_node) {

--- a/src/GmshMesh.cpp
+++ b/src/GmshMesh.cpp
@@ -22,7 +22,7 @@ void
 GmshMesh::create_dm()
 {
     _F_;
-    lprintf(9, "Loading mesh '%s'", this->file_name);
+    lprintf(9, "Loading mesh '{}'", this->file_name);
     PetscOptionsSetValue(nullptr, "-dm_plex_gmsh_use_regions", nullptr);
     PETSC_CHECK(DMPlexCreateGmshFromFile(get_comm(),
                                          this->file_name.c_str(),

--- a/src/HDF5Output.cpp
+++ b/src/HDF5Output.cpp
@@ -62,7 +62,7 @@ HDF5Output::output_step()
     set_sequence_file_name(this->problem->get_step_num());
     PETSC_CHECK(PetscViewerFileSetName(this->viewer, this->file_name.c_str()));
 
-    lprintf(9, "Output to file: %s", this->file_name);
+    lprintf(9, "Output to file: {}", this->file_name);
     DM dm = this->problem->get_dm();
     PETSC_CHECK(DMView(dm, this->viewer));
     auto vec = this->problem->get_solution_vector();

--- a/src/InitialCondition.cpp
+++ b/src/InitialCondition.cpp
@@ -49,7 +49,7 @@ InitialCondition::create()
             if (this->dpi->has_field_by_name(field_name))
                 this->fid = this->dpi->get_field_id(field_name);
             else
-                log_error("Field '%s' does not exists. Typo?", field_name);
+                log_error("Field '{}' does not exists. Typo?", field_name);
         }
         else
             log_error(

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -27,7 +27,7 @@ bool
 InputFile::parse(const std::string & file_name)
 {
     _F_;
-    lprintf(9, "Parsing input file '%s'", file_name);
+    lprintf(9, "Parsing input file '{}'", file_name);
     try {
         this->root = YAML::LoadFile(file_name);
         return true;

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -33,7 +33,7 @@ InputFile::parse(const std::string & file_name)
         return true;
     }
     catch (YAML::ParserException & e) {
-        log_error("Failed to parse the input file: %s", e.what() + 10);
+        log_error("Failed to parse the input file: {}", e.what() + 10);
         return false;
     }
 }
@@ -132,7 +132,7 @@ InputFile::build_params(const YAML::Node & parent, const std::string & name)
     _F_;
     YAML::Node node = parent[name];
     if (!node)
-        error("Missing '%s' block.", name);
+        error("Missing '{}' block.", name);
 
     std::set<std::string> unused_param_names;
     if (node.IsMap()) {
@@ -142,10 +142,10 @@ InputFile::build_params(const YAML::Node & parent, const std::string & name)
 
     YAML::Node type = node["type"];
     if (!type)
-        error("%s: No 'type' specified.", name);
+        error("{}: No 'type' specified.", name);
     const std::string & class_name = type.as<std::string>();
     if (!Factory::is_registered(class_name))
-        error("%s: Type '%s' is not a registered object.", name, class_name);
+        error("{}: Type '{}' is not a registered object.", name, class_name);
     unused_param_names.erase("type");
 
     Parameters * params = Factory::get_parameters(class_name);
@@ -231,11 +231,11 @@ InputFile::read_bool_value(const std::string & param_name, const YAML::Node & va
         else if (validation::in(str, { "off", "false", "no" }))
             val = false;
         else
-            log_error("Parameter '%s' must be either 'on', 'off', 'true', 'false', 'yes' or 'no'.",
+            log_error("Parameter '{}' must be either 'on', 'off', 'true', 'false', 'yes' or 'no'.",
                       param_name);
     }
     else
-        log_error("Parameter '%s' must be either 'on', 'off', 'true', 'false', 'yes' or 'no'.",
+        log_error("Parameter '{}' must be either 'on', 'off', 'true', 'false', 'yes' or 'no'.",
                   param_name);
 
     return val;
@@ -252,7 +252,7 @@ InputFile::read_vector_value(const std::string & param_name, const YAML::Node & 
     else if (val_node.IsSequence())
         vec = val_node.as<std::vector<T>>();
     else
-        log_error("Parameter '%s' must be either a single value or a vector of values.",
+        log_error("Parameter '{}' must be either a single value or a vector of values.",
                   param_name);
 
     return vec;
@@ -272,7 +272,7 @@ InputFile::read_map_value(const std::string & param_name, const YAML::Node & val
         }
     }
     else
-        log_error("Parameter '%s' must be a map.", param_name);
+        log_error("Parameter '{}' must be a map.", param_name);
 
     return map;
 }
@@ -293,12 +293,12 @@ InputFile::check_params(const Parameters * params,
     }
 
     if (!missing_pars.empty())
-        log_error("%s: Missing required parameters:%s", name, missing_pars);
+        log_error("{}: Missing required parameters:{}", name, missing_pars);
     else
         this->valid_param_object_names.insert(name);
 
     if (!unused_param_names.empty())
-        log_warning("%s: Following parameters were not used: %s",
+        log_warning("{}: Following parameters were not used: {}",
                     name,
                     fmt::to_string(fmt::join(unused_param_names, ", ")));
 }

--- a/src/L2FieldDiff.cpp
+++ b/src/L2FieldDiff.cpp
@@ -56,11 +56,11 @@ L2FieldDiff::create()
         for (const auto & it : this->funcs) {
             const auto & fld_name = it.first;
             if (!this->fepi->has_field_by_name(fld_name))
-                log_error("Field '%s' does not exists. Typo?", fld_name);
+                log_error("Field '{}' does not exists. Typo?", fld_name);
         }
     }
     else
-        log_error("Provided %d functions for %d fields. You must supply the same number of "
+        log_error("Provided {} functions for {} fields. You must supply the same number of "
                   "functions as you have fields.",
                   this->funcs.size(),
                   n_fields);

--- a/src/LinearInterpolation.cpp
+++ b/src/LinearInterpolation.cpp
@@ -32,12 +32,12 @@ LinearInterpolation::check()
 {
     _F_;
     if (this->x.size() != this->y.size())
-        godzilla::error("LinearInterpolation: size of 'x' (%d) does not match size of 'y' (%d).",
+        godzilla::error("LinearInterpolation: size of 'x' ({}) does not match size of 'y' ({}).",
                         this->x.size(),
                         this->y.size());
 
     if (this->x.size() < 2)
-        godzilla::error("LinearInterpolation: Size of 'x' is %d. It must be 2 or more.",
+        godzilla::error("LinearInterpolation: Size of 'x' is {}. It must be 2 or more.",
                         this->x.size());
     else {
         // check monotonicity
@@ -45,7 +45,7 @@ LinearInterpolation::check()
         for (std::size_t i = 1; i < this->x.size(); i++) {
             if (this->x[i] <= a)
                 godzilla::error(
-                    "LinearInterpolation: Values in 'x' must be increasing. Failed at index '%d'.",
+                    "LinearInterpolation: Values in 'x' must be increasing. Failed at index '{}'.",
                     i);
         }
     }

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -150,7 +150,7 @@ PetscErrorCode
 LinearProblem::ksp_monitor_callback(Int it, Real rnorm)
 {
     _F_;
-    lprintf(8, "%d Linear residual: %e", it, rnorm);
+    lprintf(8, "{} Linear residual: {:e}", it, rnorm);
     return 0;
 }
 

--- a/src/NaturalBC.cpp
+++ b/src/NaturalBC.cpp
@@ -42,7 +42,7 @@ NaturalBC::create()
             if (this->dpi->has_field_by_name(field_name))
                 this->fid = this->dpi->get_field_id(field_name);
             else
-                log_error("Field '%s' does not exists. Typo?", field_name);
+                log_error("Field '{}' does not exists. Typo?", field_name);
         }
         else
             log_error("Use the 'field' parameter to assign this boundary condition to an existing "

--- a/src/NaturalRiemannBC.cpp
+++ b/src/NaturalRiemannBC.cpp
@@ -52,7 +52,7 @@ NaturalRiemannBC::create()
             if (this->dpi->has_field_by_name(field_name))
                 this->fid = this->dpi->get_field_id(field_name);
             else
-                log_error("Field '%s' does not exists. Typo?", field_name);
+                log_error("Field '{}' does not exists. Typo?", field_name);
         }
         else
             log_error("Use the 'field' parameter to assign this boundary condition to an existing "

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -244,14 +244,14 @@ NonlinearProblem::set_up_solver_parameters()
 PetscErrorCode
 NonlinearProblem::snes_monitor_callback(Int it, Real norm)
 {
-    lprintf(7, "%d Non-linear residual: %e", it, norm);
+    lprintf(7, "{} Non-linear residual: {:e}", it, norm);
     return 0;
 }
 
 PetscErrorCode
 NonlinearProblem::ksp_monitor_callback(Int it, Real rnorm)
 {
-    lprintf(8, "    %d Linear residual: %e", it, rnorm);
+    lprintf(8, "    {} Linear residual: {:e}", it, rnorm);
     return 0;
 }
 

--- a/src/PerfLog.cpp
+++ b/src/PerfLog.cpp
@@ -19,7 +19,7 @@ PerfLog::register_event(const char * name)
         return event_id;
     }
     else
-        error("PerfLog event '%s' is already registered.", name);
+        error("PerfLog event '{}' is already registered.", name);
 }
 
 PetscLogEvent
@@ -36,7 +36,7 @@ PerfLog::get_event_id(const char * name)
     if (event_id != -1)
         return event_id;
     else
-        error("Event '%s' was not registered.", name);
+        error("Event '{}' was not registered.", name);
 }
 
 PetscLogEvent
@@ -55,7 +55,7 @@ PerfLog::register_stage(const char * name)
         return stage_id;
     }
     else
-        error("PerfLog stage '%s' is already registered.", name);
+        error("PerfLog stage '{}' is already registered.", name);
 }
 
 PetscLogStage
@@ -72,7 +72,7 @@ PerfLog::get_stage_id(const char * name)
     if (stage_id != -1)
         return stage_id;
     else
-        error("Stage '%s' was not registered.", name);
+        error("Stage '{}' was not registered.", name);
 }
 
 PetscLogStage

--- a/src/TecplotOutput.cpp
+++ b/src/TecplotOutput.cpp
@@ -161,7 +161,7 @@ TecplotOutput::create()
             else if (aux_field_names.count(name) == 1)
                 this->aux_field_var_names.push_back(name);
             else
-                log_error("Variable '%s' specified in 'variables' parameter does not exist. Typo?",
+                log_error("Variable '{}' specified in 'variables' parameter does not exist. Typo?",
                           name);
         }
     }
@@ -225,7 +225,7 @@ TecplotOutput::open_file()
     const char * mode = this->format == BINARY ? "wb" : "w";
     this->file = std::fopen(this->file_name.c_str(), mode);
     if (this->file == nullptr)
-        error("Could not open file '%s' for writing.", get_file_name());
+        error("Could not open file '{}' for writing.", get_file_name());
 }
 
 void

--- a/src/TecplotOutput.cpp
+++ b/src/TecplotOutput.cpp
@@ -203,7 +203,7 @@ TecplotOutput::output_step()
     _F_;
     // We only have fixed meshes, so no need to deal with a sequence of files
     set_file_name();
-    lprintf(9, "Output to file: %s", this->file_name);
+    lprintf(9, "Output to file: {}", this->file_name);
 
     if (this->file == nullptr)
         open_file();

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -147,7 +147,7 @@ TransientProblemInterface::ts_monitor_callback(Int stepi, Real t, Vec x)
     _F_;
     Real dt;
     PETSC_CHECK(TSGetTimeStep(this->ts, &dt));
-    this->problem->lprintf(6, "%d Time %f dt = %f", stepi, t, dt);
+    this->problem->lprintf(6, "{} Time {:f} dt = {:f}", stepi, t, dt);
     return 0;
 }
 

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -371,7 +371,7 @@ UnstructuredMesh::get_face_set_name(Int id) const
     if (it != this->face_set_names.end())
         return it->second;
     else
-        error("Face set ID '%d' does not exist.", id);
+        error("Face set ID '{}' does not exist.", id);
 }
 
 void
@@ -399,7 +399,7 @@ UnstructuredMesh::get_cell_set_name(Int id) const
     if (it != this->cell_set_names.end())
         return it->second;
     else
-        error("Cell set ID '%d' does not exist.", id);
+        error("Cell set ID '{}' does not exist.", id);
 }
 
 Int
@@ -410,7 +410,7 @@ UnstructuredMesh::get_cell_set_id(const std::string & name) const
     if (it != this->cell_set_ids.end())
         return it->second;
     else
-        error("Cell set '%s' does not exist.", name);
+        error("Cell set '{}' does not exist.", name);
 }
 
 Int
@@ -489,7 +489,7 @@ UnstructuredMesh::get_num_cell_nodes(DMPolytopeType elem_type)
     case DM_POLYTOPE_HEXAHEDRON:
         return 8;
     default:
-        error("Unsupported type '%s'.", get_polytope_type_str(elem_type));
+        error("Unsupported type '{}'.", get_polytope_type_str(elem_type));
     }
 }
 

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -86,8 +86,8 @@ UnstructuredMesh::create()
     PETSC_CHECK(DMGetDimension(this->dm, &this->dim));
 
     lprintf(9, "Information:");
-    lprintf(9, "- vertices: %d", get_num_vertices());
-    lprintf(9, "- elements: %d", get_num_cells());
+    lprintf(9, "- vertices: {}", get_num_vertices());
+    lprintf(9, "- elements: {}", get_num_cells());
 }
 
 bool

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -61,7 +61,7 @@ VTKOutput::output_step()
     set_sequence_file_name(this->problem->get_step_num());
     PETSC_CHECK(PetscViewerFileSetName(this->viewer, this->file_name.c_str()));
 
-    lprintf(9, "Output to file: %s", this->file_name);
+    lprintf(9, "Output to file: {}", this->file_name);
     DM dm = this->problem->get_dm();
     PETSC_CHECK(DMView(dm, this->viewer));
     auto vec = this->problem->get_solution_vector();


### PR DESCRIPTION
- error/warning/logger use {} instead of %
- PrintingInterface uses {} instead of %

Closes #229
