### PR TITLE
Improving App::parse_command_line API

### DIFF
--- a/include/App.h
+++ b/include/App.h
@@ -40,7 +40,7 @@ public:
     ///
     /// @param argc Number of command line arguments
     /// @param argv Command line arguments
-    virtual void parse_command_line(int argc, char * argv[]);
+    virtual void parse_command_line(int argc, const char * const * argv);
 
     /// Run the application
     ///

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -76,7 +76,7 @@ App::create()
 }
 
 void
-App::parse_command_line(int argc, char * argv[])
+App::parse_command_line(int argc, const char * const * argv)
 {
     _F_;
     this->args.parse(argc, argv);

--- a/test/src/GodzillaApp_test.cpp
+++ b/test/src/GodzillaApp_test.cpp
@@ -47,10 +47,10 @@ REGISTER_OBJECT(MockProblem);
 TEST_F(GodzillaAppTest, run_input)
 {
     int argc = 3;
-    char * argv[] = { (char *) "godzilla",
-                      (char *) "-i",
-                      (char *) GODZILLA_UNIT_TESTS_ROOT "/assets/simple.yml",
-                      NULL };
+    const char * argv[] = { "godzilla",
+                            "-i",
+                            GODZILLA_UNIT_TESTS_ROOT "/assets/simple.yml",
+                            nullptr };
 
     mpi::Communicator comm(MPI_COMM_WORLD);
     App app("godzilla", comm);
@@ -65,10 +65,10 @@ TEST_F(GodzillaAppTest, run_input)
 TEST_F(GodzillaAppTest, run_input_non_existent_file)
 {
     int argc = 3;
-    char * argv[] = { (char *) "godzilla",
-                      (char *) "-i",
-                      (char *) GODZILLA_UNIT_TESTS_ROOT "/assets/non_existent_file.yml",
-                      NULL };
+    const char * argv[] = { "godzilla",
+                            "-i",
+                            GODZILLA_UNIT_TESTS_ROOT "/assets/non_existent_file.yml",
+                            nullptr };
 
     mpi::Communicator comm(MPI_COMM_WORLD);
     App app("godzilla", comm);
@@ -80,7 +80,7 @@ TEST_F(GodzillaAppTest, run_input_non_existent_file)
 TEST_F(GodzillaAppTest, no_colors)
 {
     int argc = 2;
-    char * argv[] = { (char *) "godzilla", (char *) "--no-colors", NULL };
+    const char * argv[] = { "godzilla", "--no-colors", nullptr };
 
     mpi::Communicator comm(MPI_COMM_WORLD);
     App app("godzilla", comm);
@@ -93,7 +93,7 @@ TEST_F(GodzillaAppTest, no_colors)
 TEST_F(GodzillaAppTest, verbose)
 {
     int argc = 3;
-    char * argv[] = { (char *) "godzilla", (char *) "--verbose", (char *) "2", NULL };
+    const char * argv[] = { "godzilla", "--verbose", "2", nullptr };
 
     mpi::Communicator comm(MPI_COMM_WORLD);
     App app("godzilla", comm);


### PR DESCRIPTION
Now, we can pass `const char *[]` into it, so that makes it more friendly.
