### PR TITLE
Fixing C-tyle casts

### DIFF
--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -202,8 +202,8 @@ DiscreteProblemInterface::add_boundary_essential(const std::string & name,
                                    field,
                                    components.size(),
                                    components.size() == 0 ? nullptr : components.data(),
-                                   (void (*)()) fn,
-                                   (void (*)()) fn_t,
+                                   reinterpret_cast<void (*)()>(fn),
+                                   reinterpret_cast<void (*)()>(fn_t),
                                    context,
                                    nullptr));
 }
@@ -251,8 +251,8 @@ DiscreteProblemInterface::add_boundary_natural_riemann(const std::string & name,
                                    field,
                                    components.size(),
                                    components.size() == 0 ? nullptr : components.data(),
-                                   (void (*)()) fn,
-                                   (void (*)()) fn_t,
+                                   reinterpret_cast<void (*)()>(fn),
+                                   reinterpret_cast<void (*)()>(fn_t),
                                    context,
                                    nullptr));
 }

--- a/test/src/Terminal_test.cpp
+++ b/test/src/Terminal_test.cpp
@@ -24,13 +24,13 @@ TEST(TerminalTest, ostream_operator)
 {
     std::ostringstream oss;
     oss << Terminal::Color::red;
-    EXPECT_STREQ(oss.str().c_str(), (const char *) Terminal::Color::red);
+    EXPECT_EQ(oss.str(), Terminal::Color::red.str);
 }
 
 TEST(TerminalTest, fmt_formatter)
 {
     std::string s = fmt::format("{}", Terminal::Color::red);
-    EXPECT_STREQ(s.c_str(), (const char *) Terminal::Color::red);
+    EXPECT_EQ(s, Terminal::Color::red.str);
 }
 
 TEST(TerminalTest, color_codes)


### PR DESCRIPTION
- Fixing c-tyle casting in Terminal test
- Using C++ casting instead of C.
