### PR TITLE
Linear interpolation throws error when x is not monotonic

### DIFF
--- a/include/LinearInterpolation.h
+++ b/include/LinearInterpolation.h
@@ -24,6 +24,9 @@ public:
     /// @param y Dependent values
     void create(const std::vector<Real> & x, const std::vector<Real> & y);
 
+    /// Check that the supplied values are consistent
+    void check() const;
+
     /// Sample the interpolation at a point
     ///
     /// @params x Point where we sample the interpolation
@@ -31,9 +34,6 @@ public:
     Real sample(Real x);
 
 protected:
-    /// Check that the supplied values are consistent
-    void check();
-
     /// Independent values
     std::vector<Real> x;
     /// Dependent values

--- a/include/PiecewiseLinear.h
+++ b/include/PiecewiseLinear.h
@@ -13,6 +13,8 @@ class PiecewiseLinear : public Function {
 public:
     explicit PiecewiseLinear(const Parameters & params);
 
+    void check() override;
+
     void register_callback(mu::Parser & parser) override;
 
     /// Evaluate this function at point 'x'

--- a/src/LinearInterpolation.cpp
+++ b/src/LinearInterpolation.cpp
@@ -1,6 +1,6 @@
 #include "CallStack.h"
 #include "LinearInterpolation.h"
-#include "Error.h"
+#include "fmt/printf.h"
 
 namespace godzilla {
 
@@ -15,7 +15,6 @@ LinearInterpolation::LinearInterpolation(const std::vector<Real> & ax,
     y(ay)
 {
     _F_;
-    check();
 }
 
 void
@@ -24,28 +23,26 @@ LinearInterpolation::create(const std::vector<Real> & x, const std::vector<Real>
     _F_;
     this->x = x;
     this->y = y;
-    check();
 }
 
 void
-LinearInterpolation::check()
+LinearInterpolation::check() const
 {
     _F_;
     if (this->x.size() != this->y.size())
-        godzilla::error("LinearInterpolation: size of 'x' ({}) does not match size of 'y' ({}).",
-                        this->x.size(),
-                        this->y.size());
+        throw std::domain_error(fmt::format("Size of 'x' ({}) does not match size of 'y' ({}).",
+                                            this->x.size(),
+                                            this->y.size()));
 
     if (this->x.size() < 2)
-        godzilla::error("LinearInterpolation: Size of 'x' is {}. It must be 2 or more.",
-                        this->x.size());
+        throw std::domain_error(
+            fmt::format("Size of 'x' is {}. It must be 2 or more.", this->x.size()));
     else {
         // check monotonicity
         for (std::size_t i = 0; i < this->x.size() - 1; i++) {
             if (this->x[i] >= this->x[i + 1])
-                godzilla::error(
-                    "LinearInterpolation: Values in 'x' must be increasing. Failed at index '{}'.",
-                    i);
+                throw std::domain_error(
+                    fmt::format("Values in 'x' must be increasing. Failed at index '{}'.", i + 1));
         }
     }
 }

--- a/src/LinearInterpolation.cpp
+++ b/src/LinearInterpolation.cpp
@@ -41,9 +41,8 @@ LinearInterpolation::check()
                         this->x.size());
     else {
         // check monotonicity
-        Real a = this->x[0];
-        for (std::size_t i = 1; i < this->x.size(); i++) {
-            if (this->x[i] <= a)
+        for (std::size_t i = 0; i < this->x.size() - 1; i++) {
+            if (this->x[i] >= this->x[i + 1])
                 godzilla::error(
                     "LinearInterpolation: Values in 'x' must be increasing. Failed at index '{}'.",
                     i);

--- a/src/PiecewiseLinear.cpp
+++ b/src/PiecewiseLinear.cpp
@@ -36,6 +36,19 @@ PiecewiseLinear::register_callback(mu::Parser & parser)
     parser.DefineFunUserData(get_name(), piecewise_linear_function_eval, this);
 }
 
+void
+PiecewiseLinear::check()
+{
+    _F_;
+    Function::check();
+    try {
+        this->linpol.check();
+    }
+    catch (std::exception & e) {
+        log_error(e.what());
+    }
+}
+
 Real
 PiecewiseLinear::evaluate(Real x)
 {

--- a/test/src/LinearInterpolation_test.cpp
+++ b/test/src/LinearInterpolation_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "Godzilla.h"
 #include "LinearInterpolation.h"
 
@@ -52,26 +52,32 @@ TEST(LinearInterpolationTest, single_interval)
 
 TEST(LinearInterpolationTest, single_point)
 {
-    std::vector<Real> x = { 1 };
-    std::vector<Real> y = { 0 };
-    EXPECT_DEATH(LinearInterpolation(x, y),
-                 "\\[ERROR\\] LinearInterpolation: Size of 'x' is 1. It must be 2 or more.");
+    EXPECT_THAT(
+        []() {
+            LinearInterpolation ipol({ 1 }, { 0 });
+            ipol.check();
+        },
+        testing::ThrowsMessage<std::domain_error>("Size of 'x' is 1. It must be 2 or more."));
 }
 
 TEST(LinearInterpolationTest, unequal_sizes)
 {
-    std::vector<Real> x = { 1, 2 };
-    std::vector<Real> y = { 0, 2, 3 };
-    EXPECT_DEATH(
-        LinearInterpolation(x, y),
-        "\\[ERROR\\] LinearInterpolation: size of 'x' \\(2\\) does not match size of 'y' \\(3\\)");
+    EXPECT_THAT(
+        []() {
+            LinearInterpolation ipol({ 1, 2 }, { 0, 2, 3 });
+            ipol.check();
+        },
+        testing::ThrowsMessage<std::domain_error>(
+            "Size of 'x' (2) does not match size of 'y' (3)."));
 }
 
 TEST(LinearInterpolationTest, non_increasing)
 {
-    std::vector<Real> x = { 1, 2, 1 };
-    std::vector<Real> y = { 0, 2, 3 };
-    EXPECT_DEATH(
-        LinearInterpolation(x, y),
-        "\\[ERROR\\] LinearInterpolation: Values in 'x' must be increasing. Failed at index '2'.");
+    EXPECT_THAT(
+        []() {
+            LinearInterpolation ipol({ 1, 2, 1 }, { 0, 2, 3 });
+            ipol.check();
+        },
+        testing::ThrowsMessage<std::domain_error>(
+            "Values in 'x' must be increasing. Failed at index '2'."));
 }

--- a/test/src/PiecewiseLinear_test.cpp
+++ b/test/src/PiecewiseLinear_test.cpp
@@ -22,3 +22,23 @@ TEST(PiecewiseLinearTest, eval)
     parser.SetExpr("ipol(0)");
     EXPECT_EQ(parser.Eval(), 3.);
 }
+
+TEST(PiecewiseLinearTest, check)
+{
+    testing::internal::CaptureStderr();
+
+    TestApp app;
+
+    Parameters params = PiecewiseLinear::parameters();
+    params.set<const App *>("_app") = &app;
+    params.set<std::string>("_name") = "ipol";
+    params.set<std::vector<Real>>("x") = { 1., 2. };
+    params.set<std::vector<Real>>("y") = { 3., 1., 2. };
+    PiecewiseLinear obj(params);
+    obj.check();
+
+    app.check_integrity();
+    EXPECT_THAT(
+        testing::internal::GetCapturedStderr(),
+        testing::HasSubstr("[ERROR] ipol: Size of 'x' (2) does not match size of 'y' (3)."));
+}


### PR DESCRIPTION
- Fixing monotonicity check
- LinearInterpolation::check uses exceptions to notify the caller about problems
