### PR TITLE
Adding FENonlinearProblem::compute_boundary()

### DIFF
--- a/include/FENonlinearProblem.h
+++ b/include/FENonlinearProblem.h
@@ -18,9 +18,11 @@ public:
     explicit FENonlinearProblem(const Parameters & parameters);
 
     void create() override;
-
     PetscErrorCode compute_residual(const Vector & x, Vector & f) override;
     PetscErrorCode compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp) override;
+
+    /// Method for computing boundary values
+    virtual PetscErrorCode compute_boundary(Vector & x);
 
 protected:
     void init() override;


### PR DESCRIPTION
In case users need to override how boundary values are computed. By default,
we call `DMPlexInsertBoundaryValues`.
