### PR TITLE
Allow `DenseVector` to be multiplied by a `DenseVector<DenseVector>`

### DIFF
--- a/include/DenseVector.h
+++ b/include/DenseVector.h
@@ -217,6 +217,16 @@ public:
         return res;
     }
 
+    template <Int M>
+    DenseVector<T, M>
+    operator*(const DenseVector<DenseVector<T, N>, M> & a) const
+    {
+        DenseVector<T, M> res;
+        for (Int j = 0; j < M; j++)
+            res(j) = *this * a(j);
+        return res;
+    }
+
     T
     operator*(const DenseVector<T, N> & a) const
     {

--- a/test/src/DenseVector_test.cpp
+++ b/test/src/DenseVector_test.cpp
@@ -155,6 +155,22 @@ TEST(DenseVectorTest, op_mult_mat)
     EXPECT_EQ(x(2), 1.);
 }
 
+TEST(DenseVectorTest, op_mult_vecvec)
+{
+    DenseVector<Real, 2> a({ 2., 3. });
+    DenseVector<DenseVector<Real, 2>, 3> b;
+    b(0)(0) = 4.;
+    b(0)(1) = 0.;
+    b(1)(0) = 2.;
+    b(1)(1) = -3.;
+    b(2)(0) = -1.;
+    b(2)(1) = 1.;
+    DenseVector<Real, 3> x = a * b;
+    EXPECT_EQ(x(0), 8.);
+    EXPECT_EQ(x(1), -5.);
+    EXPECT_EQ(x(2), 1.);
+}
+
 TEST(DenseVectorTest, op_mult_vec)
 {
     DenseVector<Real, 3> a({ 2., 3., 4. });


### PR DESCRIPTION
This is equivalent to `vec * mat`, where `mat` is represented as a vector of
vectors (typically gradients of shape functions can be stored like that).
