### PR TITLE
UnstructuredMesh changes

### DIFF
--- a/examples/heat-eqn/test/gyml/2d-explicit.gyml
+++ b/examples/heat-eqn/test/gyml/2d-explicit.gyml
@@ -21,9 +21,24 @@ auxs:
     value: 2
 
 bcs:
-  all:
+  left:
     type: DirichletBC
-    boundary: 'marker'
+    boundary: 'left'
+    value: '2*t + x*x + y*y'
+
+  right:
+    type: DirichletBC
+    boundary: 'right'
+    value: '2*t + x*x + y*y'
+
+  top:
+    type: DirichletBC
+    boundary: 'top'
+    value: '2*t + x*x + y*y'
+
+  bottom:
+    type: DirichletBC
+    boundary: 'bottom'
     value: '2*t + x*x + y*y'
 
 pps:

--- a/examples/heat-eqn/test/gyml/mms-1d.gyml
+++ b/examples/heat-eqn/test/gyml/mms-1d.gyml
@@ -28,7 +28,13 @@ auxs:
 bcs:
   left:
     type: DirichletBC
-    boundary: 'marker'
+    boundary: 'left'
+    value: [ 'exact_fn(t,x,y,z)' ]
+    value_t: [ '1' ]
+
+  right:
+    type: DirichletBC
+    boundary: 'right'
     value: [ 'exact_fn(t,x,y,z)' ]
     value_t: [ '1' ]
 

--- a/examples/ns-incomp/test/gyml/mms-2d.gyml
+++ b/examples/ns-incomp/test/gyml/mms-2d.gyml
@@ -38,10 +38,40 @@ ics:
     value: 'x + y - 1'
 
 bcs:
-  vel_bc:
+  vel_bc_left:
     type: DirichletBC
     field: 'velocity'
-    boundary: 'marker'
+    boundary: 'left'
+    value: [
+      't + x * x + y * y',
+      't + 2.0 * x * x - 2.0 * x * y'
+    ]
+    value_t: ['1', '1']
+
+  vel_bc_right:
+    type: DirichletBC
+    field: 'velocity'
+    boundary: 'right'
+    value: [
+      't + x * x + y * y',
+      't + 2.0 * x * x - 2.0 * x * y'
+    ]
+    value_t: ['1', '1']
+
+  vel_bc_top:
+    type: DirichletBC
+    field: 'velocity'
+    boundary: 'top'
+    value: [
+      't + x * x + y * y',
+      't + 2.0 * x * x - 2.0 * x * y'
+    ]
+    value_t: ['1', '1']
+
+  vel_bc_bottom:
+    type: DirichletBC
+    field: 'velocity'
+    boundary: 'bottom'
     value: [
       't + x * x + y * y',
       't + 2.0 * x * x - 2.0 * x * y'

--- a/examples/poisson/test/gyml/mms-1d.gyml
+++ b/examples/poisson/test/gyml/mms-1d.gyml
@@ -18,9 +18,14 @@ ics:
     value: 0
 
 bcs:
-  all:
+  left:
     type: DirichletBC
-    boundary: 'marker'
+    boundary: 'left'
+    value: [ 'x*x' ]
+
+  right:
+    type: DirichletBC
+    boundary: 'right'
     value: [ 'x*x' ]
 
 output:

--- a/examples/poisson/test/gyml/mms-2d.gyml
+++ b/examples/poisson/test/gyml/mms-2d.gyml
@@ -21,9 +21,24 @@ ics:
     value: [ 0 ]
 
 bcs:
-  all:
+  left:
     type: DirichletBC
-    boundary: 'marker'
+    boundary: 'left'
+    value: [ 'x*x + y*y' ]
+
+  right:
+    type: DirichletBC
+    boundary: 'right'
+    value: [ 'x*x + y*y' ]
+
+  top:
+    type: DirichletBC
+    boundary: 'top'
+    value: [ 'x*x + y*y' ]
+
+  bottom:
+    type: DirichletBC
+    boundary: 'bottom'
     value: [ 'x*x + y*y' ]
 
 output:

--- a/examples/poisson/test/gyml/mms-3d.gyml
+++ b/examples/poisson/test/gyml/mms-3d.gyml
@@ -24,9 +24,34 @@ ics:
     value: 0
 
 bcs:
-  all:
+  left:
     type: DirichletBC
-    boundary: 'marker'
+    boundary: 'left'
+    value: 'x*x + y*y + z*z'
+
+  right:
+    type: DirichletBC
+    boundary: 'right'
+    value: 'x*x + y*y + z*z'
+
+  top:
+    type: DirichletBC
+    boundary: 'top'
+    value: 'x*x + y*y + z*z'
+
+  bottom:
+    type: DirichletBC
+    boundary: 'bottom'
+    value: 'x*x + y*y + z*z'
+
+  front:
+    type: DirichletBC
+    boundary: 'front'
+    value: 'x*x + y*y + z*z'
+
+  back:
+    type: DirichletBC
+    boundary: 'back'
     value: 'x*x + y*y + z*z'
 
 output:

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -290,7 +290,7 @@ protected:
 
     void create_face_set_labels(const std::map<Int, std::string> & names);
 
-    void create_face_set(Int id);
+    void create_face_set(Int id, const std::string & name);
 
     /// DM object
     DM dm;

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -134,6 +134,7 @@ BoxMesh::create_dm()
                                     this->interpolate,
                                     &this->dm));
 
+    PETSC_CHECK(DMRemoveLabel(this->dm, "marker", nullptr));
     // create user-friendly names for sides
     std::map<Int, std::string> face_set_names;
     face_set_names[1] = "back";
@@ -143,6 +144,8 @@ BoxMesh::create_dm()
     face_set_names[5] = "right";
     face_set_names[6] = "left";
     create_face_set_labels(face_set_names);
+    for (auto it : face_set_names)
+        set_face_set_name(it.first, it.second);
 }
 
 } // namespace godzilla

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -47,10 +47,8 @@ ExodusIIMesh::create_dm()
                 create_cell_set(it.first, it.second);
         }
 
-        std::map<Int, std::string> sideset_names;
         for (auto it : f.read_side_set_names())
-            sideset_names[it.first] = it.second;
-        create_face_set_labels(sideset_names);
+            set_face_set_name(it.first, it.second);
 
         f.close();
     }

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -71,11 +71,14 @@ LineMesh::create_dm()
                                     this->interpolate,
                                     &this->dm));
 
+    PETSC_CHECK(DMRemoveLabel(this->dm, "marker", nullptr));
     // create user-friendly names for sides
     std::map<Int, std::string> face_set_names;
     face_set_names[1] = "left";
     face_set_names[2] = "right";
     create_face_set_labels(face_set_names);
+    for (auto it : face_set_names)
+        set_face_set_name(it.first, it.second);
 }
 
 } // namespace godzilla

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -104,6 +104,7 @@ RectangleMesh::create_dm()
                                     this->interpolate,
                                     &this->dm));
 
+    PETSC_CHECK(DMRemoveLabel(this->dm, "marker", nullptr));
     // create user-friendly names for sides
     std::map<Int, std::string> face_set_names;
     face_set_names[1] = "bottom";
@@ -111,6 +112,8 @@ RectangleMesh::create_dm()
     face_set_names[3] = "top";
     face_set_names[4] = "left";
     create_face_set_labels(face_set_names);
+    for (auto it : face_set_names)
+        set_face_set_name(it.first, it.second);
 }
 
 } // namespace godzilla

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -301,30 +301,25 @@ UnstructuredMesh::create_face_set_labels(const std::map<Int, std::string> & name
         fs_ids.get_indices();
         for (Int i = 0; i < n_fs; i++) {
             Int id = fs_ids[i];
-            create_face_set(id);
+            create_face_set(id, names.at(id));
         }
         fs_ids.restore_indices();
         fs_ids.destroy();
-
-        for (auto & it : names)
-            set_face_set_name(it.first, it.second);
     }
 }
 
 void
-UnstructuredMesh::create_face_set(Int id)
+UnstructuredMesh::create_face_set(Int id, const std::string & name)
 {
     _F_;
     DMLabel face_sets_label = get_label("Face Sets");
-    IS is;
-    PETSC_CHECK(DMLabelGetStratumIS(face_sets_label, id, &is));
-    std::string id_str = std::to_string(id);
-    PETSC_CHECK(DMCreateLabel(this->dm, id_str.c_str()));
-    DMLabel label = get_label(id_str);
-    if (is)
-        PETSC_CHECK(DMLabelSetStratumIS(label, id, is));
-    PETSC_CHECK(ISDestroy(&is));
-    PETSC_CHECK(DMPlexLabelComplete(this->dm, label));
+    IndexSet is = IndexSet::stratum_from_label(face_sets_label, id);
+    if (!is.empty()) {
+        PETSC_CHECK(DMCreateLabel(this->dm, name.c_str()));
+        DMLabel label = get_label(name);
+        PETSC_CHECK(DMLabelSetStratumIS(label, id, (IS) is));
+    }
+    is.destroy();
 }
 
 void
@@ -340,13 +335,7 @@ UnstructuredMesh::has_face_set(const std::string & name) const
 {
     _F_;
     const auto & it = this->face_set_ids.find(name);
-    if (it != this->face_set_ids.end()) {
-        Int id = it->second;
-        return has_label(std::to_string(id));
-    }
-    else
-        // assume `name` is an ID
-        return has_label(name);
+    return it != this->face_set_ids.end();
 }
 
 DMLabel
@@ -354,13 +343,10 @@ UnstructuredMesh::get_face_set_label(const std::string & name) const
 {
     _F_;
     const auto & it = this->face_set_ids.find(name);
-    if (it != this->face_set_ids.end()) {
-        Int id = it->second;
-        return get_label(std::to_string(id));
-    }
-    else
-        // assume `name` is an ID
+    if (it != this->face_set_ids.end())
         return get_label(name);
+    else
+        return nullptr;
 }
 
 const std::string &
@@ -386,7 +372,6 @@ UnstructuredMesh::create_cell_set(Int id, const std::string & name)
     if (is)
         PETSC_CHECK(DMLabelSetStratumIS(label, id, is));
     PETSC_CHECK(ISDestroy(&is));
-    PETSC_CHECK(DMPlexLabelComplete(this->dm, label));
     this->cell_set_names[id] = name;
     this->cell_set_ids[name] = id;
 }

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -172,12 +172,12 @@ TEST_F(FENonlinearProblemTest, solve)
         prob->add_initial_condition(ic);
     }
 
-    {
+    for (auto & bnd : { "left", "right" }) {
         const std::string class_name = "DirichletBC";
         Parameters * params = Factory::get_parameters(class_name);
         params->set<const App *>("_app") = this->app;
         params->set<const DiscreteProblemInterface *>("_dpi") = prob;
-        params->set<std::string>("boundary") = "marker";
+        params->set<std::string>("boundary") = bnd;
         params->set<std::vector<std::string>>("value") = { "x*x" };
         auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc", params);
         prob->add_boundary_condition(bc);

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -27,10 +27,10 @@ TEST_F(ImplicitFENonlinearProblemTest, run)
         prob->add_initial_condition(ic);
     }
 
-    {
+    for (auto & bnd : { "left", "right" }) {
         const std::string class_name = "DirichletBC";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<std::string>("boundary") = "marker";
+        params->set<std::string>("boundary") = bnd;
         params->set<std::vector<std::string>>("value") = { "x*x" };
         params->set<const DiscreteProblemInterface *>("_dpi") = prob;
         auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc", params);

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -133,9 +133,9 @@ TEST(IndexSetTest, intersect_caching)
     RectangleMesh mesh(params);
     mesh.create();
 
-    DMLabel label1 = mesh.get_label("1");
+    DMLabel label1 = mesh.get_label("bottom");
     IndexSet is1 = IndexSet::values_from_label(label1);
-    DMLabel label2 = mesh.get_label("2");
+    DMLabel label2 = mesh.get_label("right");
     IndexSet is2 = IndexSet::values_from_label(label2);
     IndexSet isect = IndexSet::intersect_caching(is1, is2);
     EXPECT_EQ(isect.get_size(), 0);
@@ -155,9 +155,9 @@ TEST(IndexSetTest, intersect)
     RectangleMesh mesh(params);
     mesh.create();
 
-    DMLabel label1 = mesh.get_label("1");
+    DMLabel label1 = mesh.get_label("bottom");
     IndexSet is1 = IndexSet::values_from_label(label1);
-    DMLabel label2 = mesh.get_label("2");
+    DMLabel label2 = mesh.get_label("right");
     IndexSet is2 = IndexSet::values_from_label(label2);
     IndexSet isect = IndexSet::intersect(is1, is2);
     EXPECT_EQ(isect.get_size(), 0);

--- a/test/src/L2Diff_test.cpp
+++ b/test/src/L2Diff_test.cpp
@@ -20,12 +20,19 @@ TEST(L2DiffTest, compute)
     GTestFENonlinearProblem prob(prob_params);
     app.problem = &prob;
 
-    Parameters bc_params = DirichletBC::parameters();
-    bc_params.set<const App *>("_app") = &app;
-    bc_params.set<const DiscreteProblemInterface *>("_dpi") = &prob;
-    bc_params.set<std::vector<std::string>>("value") = { "x*x" };
-    bc_params.set<std::string>("boundary") = "marker";
-    DirichletBC bc(bc_params);
+    Parameters bc_left_params = DirichletBC::parameters();
+    bc_left_params.set<const App *>("_app") = &app;
+    bc_left_params.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_left_params.set<std::vector<std::string>>("value") = { "x*x" };
+    bc_left_params.set<std::string>("boundary") = "left";
+    DirichletBC bc_left(bc_left_params);
+
+    Parameters bc_right_params = DirichletBC::parameters();
+    bc_right_params.set<const App *>("_app") = &app;
+    bc_right_params.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_right_params.set<std::vector<std::string>>("value") = { "x*x" };
+    bc_right_params.set<std::string>("boundary") = "right";
+    DirichletBC bc_right(bc_right_params);
 
     Parameters ps_params = L2Diff::parameters();
     ps_params.set<const App *>("_app") = &app;
@@ -33,7 +40,8 @@ TEST(L2DiffTest, compute)
     ps_params.set<std::vector<std::string>>("value") = { "x*x" };
     L2Diff ps(ps_params);
 
-    prob.add_boundary_condition(&bc);
+    prob.add_boundary_condition(&bc_left);
+    prob.add_boundary_condition(&bc_right);
     prob.add_postprocessor(&ps);
 
     mesh.create();


### PR DESCRIPTION
- do not call DMPlexLabelComplete. It does not do what you thought it did.
- split `create_face_set` out of `create_face_set_labels`
- remove "marker" label from meshes created by "DMPlexCreateBoxMesh"
  * since we create the left/right/etc., the first of those will have the same
    face set ID as marker - this is not good for ExodusII output.
  * this may also be a problem in future with surface-restricted fields
  * this makes input files longer :-(, but things are more consistent
