### PR TITLE
LinearProblem::compute_{rhs|operators} has empty implementation

### DIFF
--- a/include/LinearProblem.h
+++ b/include/LinearProblem.h
@@ -22,9 +22,9 @@ public:
     /// true if solve converged, otherwise false
     virtual bool converged();
     /// Method to compute right-hand side. Called from the PETsc callback
-    virtual PetscErrorCode compute_rhs(Vector & b) = 0;
+    virtual PetscErrorCode compute_rhs(Vector & b);
     /// Method to compute operators. Called from the PETsc callback
-    virtual PetscErrorCode compute_operators(Matrix & A, Matrix & B) = 0;
+    virtual PetscErrorCode compute_operators(Matrix & A, Matrix & B);
 
 protected:
     /// Initialize the problem

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -193,4 +193,18 @@ LinearProblem::solve()
     PETSC_CHECK(KSPGetConvergedReason(this->ksp, &this->converged_reason));
 }
 
+PetscErrorCode
+LinearProblem::compute_rhs(Vector & b)
+{
+    _F_;
+    return 0;
+}
+
+PetscErrorCode
+LinearProblem::compute_operators(Matrix & A, Matrix & B)
+{
+    _F_;
+    return 0;
+}
+
 } // namespace godzilla

--- a/test/src/LinearProblem_test.cpp
+++ b/test/src/LinearProblem_test.cpp
@@ -50,8 +50,6 @@ TEST_F(LinearProblemTest, run)
             return true;
         }
         MOCK_METHOD(void, on_final, ());
-        MOCK_METHOD(PetscErrorCode, compute_rhs, (Vector & b));
-        MOCK_METHOD(PetscErrorCode, compute_operators, (Matrix & A, Matrix & B));
     };
 
     auto mesh = gMesh1d();
@@ -65,6 +63,11 @@ TEST_F(LinearProblemTest, run)
     EXPECT_CALL(prob, solve);
     EXPECT_CALL(prob, on_final);
     prob.run();
+
+    Vector b;
+    EXPECT_EQ(prob.compute_rhs(b), 0);
+    Matrix A;
+    EXPECT_EQ(prob.compute_operators(A, A), 0);
 }
 
 // 1D


### PR DESCRIPTION
This mirrors what we do in NonlinearProblem and makes our life simpler when
we inherit from `LinearProblem` and some other class like
TransientProblemInterface.
