### PR TITLE
Better names for mat and mat_transpose

### DIFF
--- a/include/DenseVector.h
+++ b/include/DenseVector.h
@@ -464,7 +464,7 @@ DenseVector<Real, 3>::cross(const DenseVector<Real, 3> & a) const
 /// @return DenseMatrix with values from `a`
 template <typename T, Int N, Int M>
 inline DenseMatrix<T, N, M>
-mat(const DenseVector<DenseVector<T, M>, N> & a)
+mat_row(const DenseVector<DenseVector<T, M>, N> & a)
 {
     DenseMatrix<T, N, M> res;
     for (Int i = 0; i < N; i++)
@@ -482,7 +482,7 @@ mat(const DenseVector<DenseVector<T, M>, N> & a)
 /// @return Transposed DenseMatrix with values from `a`
 template <typename T, Int N, Int M>
 inline DenseMatrix<T, M, N>
-mat_transpose(const DenseVector<DenseVector<T, M>, N> & a)
+mat_col(const DenseVector<DenseVector<T, M>, N> & a)
 {
     DenseMatrix<T, M, N> res;
     for (Int i = 0; i < N; i++)

--- a/test/src/DenseVector_test.cpp
+++ b/test/src/DenseVector_test.cpp
@@ -318,7 +318,7 @@ TEST(DenseVectorTest, op_unary_minus)
     EXPECT_EQ(b(2), -3.);
 }
 
-TEST(DenseVectorTest, mat)
+TEST(DenseVectorTest, mat_row)
 {
     DenseVector<DenseVector<Real, 3>, 2> A;
     A(0)(0) = -2;
@@ -328,7 +328,7 @@ TEST(DenseVectorTest, mat)
     A(1)(1) = -1;
     A(1)(2) = 2;
 
-    DenseMatrix<Real, 2, 3> m = mat(A);
+    DenseMatrix<Real, 2, 3> m = mat_row(A);
     EXPECT_EQ(m(0, 0), -2.);
     EXPECT_EQ(m(0, 1), 5.);
     EXPECT_EQ(m(0, 2), 3.);
@@ -337,7 +337,7 @@ TEST(DenseVectorTest, mat)
     EXPECT_EQ(m(1, 2), 2.);
 }
 
-TEST(DenseVectorTest, mat_transpose)
+TEST(DenseVectorTest, mat_col)
 {
     DenseVector<DenseVector<Real, 3>, 2> A;
     A(0)(0) = -2;
@@ -347,7 +347,7 @@ TEST(DenseVectorTest, mat_transpose)
     A(1)(1) = -1;
     A(1)(2) = 2;
 
-    DenseMatrix<Real, 3, 2> m = mat_transpose(A);
+    DenseMatrix<Real, 3, 2> m = mat_col(A);
 
     EXPECT_EQ(m(0, 0), -2.);
     EXPECT_EQ(m(0, 1), 1.);


### PR DESCRIPTION
mat -> mat_row - vectors are stored in rows
mat_transpose -> mat_col - verctors are stored in columns
