### PR TITLE
Fixing fe::connectivity

### DIFF
--- a/include/FEGeometry.h
+++ b/include/FEGeometry.h
@@ -42,11 +42,12 @@ connectivity(const UnstructuredMesh & mesh)
 {
     _F_;
     auto n_cells = mesh.get_num_cells();
+    auto n_all_cells = mesh.get_num_all_cells();
     Array1D<DenseVector<Int, N_ELEM_NODES>> connect(n_cells);
     for (auto elem_id : mesh.get_cell_range()) {
         auto cell_conn = mesh.get_connectivity(elem_id);
         for (Int i = 0; i < N_ELEM_NODES; i++)
-            connect(elem_id)(i) = cell_conn[i] - n_cells;
+            connect(elem_id)(i) = cell_conn[i] - n_all_cells;
     }
     return connect;
 }


### PR DESCRIPTION
Using correct number of elements to remap from PETSc vertex IDs into
zero-based vertex indexing.  The shift in indexing was missing the
number of ghost cells, which would break solvers using FV machinery.
