### PR TITLE
Removing `const` qualifier from some XYZProblemInterface API

### DIFF
--- a/examples/burgers-eqn/src/BurgersEquation.cpp
+++ b/examples/burgers-eqn/src/BurgersEquation.cpp
@@ -12,7 +12,7 @@ namespace {
 
 class F1 : public ResidualFunc {
 public:
-    explicit F1(const BurgersEquation * prob) :
+    explicit F1(BurgersEquation * prob) :
         ResidualFunc(prob),
         visc(prob->get_viscosity()),
         u(get_field_value("u")),

--- a/examples/heat-eqn/src/HeatEquationExplicit.cpp
+++ b/examples/heat-eqn/src/HeatEquationExplicit.cpp
@@ -10,7 +10,7 @@ namespace {
 
 class Residual0 : public ResidualFunc {
 public:
-    explicit Residual0(const FEProblemInterface * fepi) :
+    explicit Residual0(FEProblemInterface * fepi) :
         ResidualFunc(fepi),
         ffn(get_field_value("forcing_fn"))
     {
@@ -28,7 +28,7 @@ protected:
 
 class Residual1 : public ResidualFunc {
 public:
-    explicit Residual1(const FEProblemInterface * fepi) :
+    explicit Residual1(FEProblemInterface * fepi) :
         ResidualFunc(fepi),
         dim(get_spatial_dimension()),
         T_x(get_field_gradient("temp"))

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -11,7 +11,7 @@ namespace {
 
 class Residual0 : public ResidualFunc {
 public:
-    explicit Residual0(const FEProblemInterface * fepi) :
+    explicit Residual0(FEProblemInterface * fepi) :
         ResidualFunc(fepi),
         T_t(get_field_dot("temp")),
         q_ppp(get_field_value("q_ppp"))
@@ -31,7 +31,7 @@ protected:
 
 class Residual1 : public ResidualFunc {
 public:
-    explicit Residual1(const FEProblemInterface * fepi) :
+    explicit Residual1(FEProblemInterface * fepi) :
         ResidualFunc(fepi),
         dim(get_spatial_dimension()),
         T_x(get_field_gradient("temp"))
@@ -52,9 +52,7 @@ protected:
 
 class Jacobian0 : public JacobianFunc {
 public:
-    explicit Jacobian0(const FEProblemInterface * fepi) :
-        JacobianFunc(fepi),
-        T_t_shift(get_time_shift())
+    explicit Jacobian0(FEProblemInterface * fepi) : JacobianFunc(fepi), T_t_shift(get_time_shift())
     {
     }
 
@@ -70,9 +68,7 @@ protected:
 
 class Jacobian3 : public JacobianFunc {
 public:
-    explicit Jacobian3(const FEProblemInterface * fepi) :
-        JacobianFunc(fepi),
-        dim(get_spatial_dimension())
+    explicit Jacobian3(FEProblemInterface * fepi) : JacobianFunc(fepi), dim(get_spatial_dimension())
     {
     }
 

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -15,7 +15,7 @@ namespace {
 
 class ResidualVeloc0 : public ResidualFunc {
 public:
-    explicit ResidualVeloc0(const NSIncompressibleProblem * prob) :
+    explicit ResidualVeloc0(NSIncompressibleProblem * prob) :
         ResidualFunc(prob),
         n_comp(get_spatial_dimension()),
         dim(get_spatial_dimension()),
@@ -50,7 +50,7 @@ protected:
 
 class ResidualVeloc1 : public ResidualFunc {
 public:
-    explicit ResidualVeloc1(const NSIncompressibleProblem * prob) :
+    explicit ResidualVeloc1(NSIncompressibleProblem * prob) :
         ResidualFunc(prob),
         n_comp(get_spatial_dimension()),
         dim(get_spatial_dimension()),
@@ -81,7 +81,7 @@ protected:
 
 class ResidualPress0 : public ResidualFunc {
 public:
-    explicit ResidualPress0(const NSIncompressibleProblem * prob) :
+    explicit ResidualPress0(NSIncompressibleProblem * prob) :
         ResidualFunc(prob),
         dim(get_spatial_dimension()),
         vel_x(get_field_gradient("velocity"))
@@ -103,7 +103,7 @@ protected:
 
 class ResidualPress1 : public ResidualFunc {
 public:
-    explicit ResidualPress1(const NSIncompressibleProblem * prob) :
+    explicit ResidualPress1(NSIncompressibleProblem * prob) :
         ResidualFunc(prob),
         dim(get_spatial_dimension())
     {
@@ -122,7 +122,7 @@ protected:
 
 class JacobianVV0 : public JacobianFunc {
 public:
-    explicit JacobianVV0(const NSIncompressibleProblem * prob) :
+    explicit JacobianVV0(NSIncompressibleProblem * prob) :
         JacobianFunc(prob),
         dim(get_spatial_dimension()),
         vel_x(get_field_gradient("velocity")),
@@ -155,7 +155,7 @@ protected:
 
 class JacobianVV1 : public JacobianFunc {
 public:
-    explicit JacobianVV1(const NSIncompressibleProblem * prob) :
+    explicit JacobianVV1(NSIncompressibleProblem * prob) :
         JacobianFunc(prob),
         dim(get_spatial_dimension()),
         vel(get_field_value("velocity"))
@@ -186,7 +186,7 @@ protected:
 
 class JacobianPV1 : public JacobianFunc {
 public:
-    explicit JacobianPV1(const NSIncompressibleProblem * prob) :
+    explicit JacobianPV1(NSIncompressibleProblem * prob) :
         JacobianFunc(prob),
         dim(get_spatial_dimension())
     {
@@ -205,7 +205,7 @@ protected:
 
 class JacobianVP2 : public JacobianFunc {
 public:
-    explicit JacobianVP2(const NSIncompressibleProblem * prob) :
+    explicit JacobianVP2(NSIncompressibleProblem * prob) :
         JacobianFunc(prob),
         dim(get_spatial_dimension())
     {
@@ -224,7 +224,7 @@ protected:
 
 class JacobianVV3 : public JacobianFunc {
 public:
-    explicit JacobianVV3(const NSIncompressibleProblem * prob) :
+    explicit JacobianVV3(NSIncompressibleProblem * prob) :
         JacobianFunc(prob),
         n_comp(get_spatial_dimension()),
         dim(get_spatial_dimension()),

--- a/examples/poisson/include/PoissonPDE.h
+++ b/examples/poisson/include/PoissonPDE.h
@@ -8,11 +8,7 @@ using namespace godzilla;
 
 class Residual0 : public ResidualFunc {
 public:
-    Residual0(const FEProblemInterface * fepi) :
-        ResidualFunc(fepi),
-        ffn(get_field_value("forcing_fn"))
-    {
-    }
+    Residual0(FEProblemInterface * fepi) : ResidualFunc(fepi), ffn(get_field_value("forcing_fn")) {}
 
     void
     evaluate(PetscScalar f[]) const override
@@ -26,7 +22,7 @@ protected:
 
 class Residual1 : public ResidualFunc {
 public:
-    Residual1(const FEProblemInterface * fepi) :
+    Residual1(FEProblemInterface * fepi) :
         ResidualFunc(fepi),
         dim(get_spatial_dimension()),
         u_x(get_field_gradient("u"))
@@ -47,7 +43,7 @@ protected:
 
 class Jacobian3 : public JacobianFunc {
 public:
-    Jacobian3(const FEProblemInterface * fepi) : JacobianFunc(fepi), dim(get_spatial_dimension()) {}
+    Jacobian3(FEProblemInterface * fepi) : JacobianFunc(fepi), dim(get_spatial_dimension()) {}
 
     void
     evaluate(PetscScalar g[]) const override

--- a/include/AuxiliaryField.h
+++ b/include/AuxiliaryField.h
@@ -64,7 +64,7 @@ protected:
     const UnstructuredMesh * mesh;
 
     /// Discrete problem this object is part of
-    const DiscreteProblemInterface * dpi;
+    DiscreteProblemInterface * dpi;
 
     /// Field name
     const std::string & field;

--- a/include/AuxiliaryField.h
+++ b/include/AuxiliaryField.h
@@ -53,7 +53,7 @@ protected:
     /// Get mesh this auxiliary field is defined on
     ///
     /// @return Mesh this auxiliary field is defined on
-    const UnstructuredMesh * get_mesh() const;
+    UnstructuredMesh * get_mesh() const;
 
     /// Get problem this auxiliary field is part of
     ///
@@ -61,7 +61,7 @@ protected:
     const Problem * get_problem() const;
 
     /// Unstructured mesh this field is defined on
-    const UnstructuredMesh * mesh;
+    UnstructuredMesh * mesh;
 
     /// Discrete problem this object is part of
     DiscreteProblemInterface * dpi;

--- a/include/BoundaryCondition.h
+++ b/include/BoundaryCondition.h
@@ -35,13 +35,13 @@ protected:
     /// Get mesh this boundary condition is associated with
     ///
     /// @return Mesh this boundary condition is associated with
-    const UnstructuredMesh * get_mesh() const;
+    UnstructuredMesh * get_mesh() const;
 
     /// Get problem this auxiliary field is part of
     const Problem * get_problem() const;
 
     /// Unstructured mesh this field is defined on
-    const UnstructuredMesh * mesh;
+    UnstructuredMesh * mesh;
 
     /// Discrete problem this object is part of
     DiscreteProblemInterface * dpi;

--- a/include/BoundaryCondition.h
+++ b/include/BoundaryCondition.h
@@ -26,7 +26,7 @@ public:
     /// Get DiscreteProblemInterface
     ///
     /// @return Discrete problem this BC is part of
-    NO_DISCARD virtual const DiscreteProblemInterface * get_discrete_problem_interface() const;
+    NO_DISCARD virtual DiscreteProblemInterface * get_discrete_problem_interface() const;
 
     /// Set up this boundary condition
     virtual void set_up() = 0;
@@ -44,7 +44,7 @@ protected:
     const UnstructuredMesh * mesh;
 
     /// Discrete problem this object is part of
-    const DiscreteProblemInterface * dpi;
+    DiscreteProblemInterface * dpi;
 
     /// List of boundary names
     const std::string & boundary;

--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -216,13 +216,13 @@ public:
                                         const std::vector<Int> & components,
                                         PetscFunc * fn,
                                         PetscFunc * fn_t,
-                                        void * context) const;
+                                        void * context);
     virtual void add_boundary_natural(const std::string & name,
                                       const Label & label,
                                       const std::vector<Int> & ids,
                                       Int field,
                                       const std::vector<Int> & components,
-                                      void * context) const;
+                                      void * context);
     virtual void add_boundary_natural_riemann(const std::string & name,
                                               const Label & label,
                                               const std::vector<Int> & ids,
@@ -230,7 +230,7 @@ public:
                                               const std::vector<Int> & components,
                                               PetscNaturalRiemannBCFunc * fn,
                                               PetscNaturalRiemannBCFunc * fn_t,
-                                              void * context) const;
+                                              void * context);
 
     template <Int N>
     void set_closure(const Vector & v,

--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -291,7 +291,7 @@ protected:
     Problem * problem;
 
     /// Unstructured mesh
-    const UnstructuredMesh * unstr_mesh;
+    UnstructuredMesh * unstr_mesh;
 
     /// Logger object
     Logger * logger;

--- a/include/ExodusIIOutput.h
+++ b/include/ExodusIIOutput.h
@@ -64,7 +64,7 @@ protected:
     /// FE problem interface (convenience pointer)
     const DiscreteProblemInterface * dpi;
     /// Unstructured mesh
-    const UnstructuredMesh * mesh;
+    UnstructuredMesh * mesh;
     /// ExodusII file
     exodusIIcpp::File * exo;
     /// Step number

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -181,7 +181,7 @@ protected:
                                       const std::vector<Int> & components,
                                       PetscNaturalRiemannBCFunc * fn,
                                       PetscNaturalRiemannBCFunc * fn_t,
-                                      void * context) const override;
+                                      void * context) override;
 
     /// Set up quadrature
     virtual void set_up_quadrature();

--- a/include/FVProblemInterface.h
+++ b/include/FVProblemInterface.h
@@ -76,13 +76,13 @@ protected:
                                 const std::vector<Int> & components,
                                 PetscFunc * fn,
                                 PetscFunc * fn_t,
-                                void * context) const override;
+                                void * context) override;
     void add_boundary_natural(const std::string & name,
                               const Label & label,
                               const std::vector<Int> & ids,
                               Int field,
                               const std::vector<Int> & components,
-                              void * context) const override;
+                              void * context) override;
 
     /// Compute auxiliary fields
     ///

--- a/include/InitialCondition.h
+++ b/include/InitialCondition.h
@@ -36,7 +36,7 @@ public:
 
 protected:
     /// Discrete problem this object is part of
-    const DiscreteProblemInterface * dpi;
+    DiscreteProblemInterface * dpi;
 
     /// Field ID this initial condition is attached to
     Int fid;

--- a/include/JacobianFunc.h
+++ b/include/JacobianFunc.h
@@ -12,7 +12,7 @@ class FEProblemInterface;
 
 class JacobianFunc : public Functional {
 public:
-    explicit JacobianFunc(const FEProblemInterface * fepi, const std::string & region = "");
+    explicit JacobianFunc(FEProblemInterface * fepi, const std::string & region = "");
 
     /// Evaluate this functional
     ///

--- a/include/Problem.h
+++ b/include/Problem.h
@@ -33,7 +33,7 @@ public:
     /// Return solution vector
     virtual const Vector & get_solution_vector() const = 0;
     /// Get mesh this problem is using
-    virtual const Mesh * get_mesh() const;
+    virtual Mesh * get_mesh() const;
     /// Get problem spatial dimension
     virtual Int get_dimension() const;
 
@@ -134,7 +134,7 @@ protected:
     virtual void on_final();
 
     /// Mesh
-    const Mesh * mesh;
+    Mesh * mesh;
 
     /// List of functions
     std::vector<Function *> functions;

--- a/include/ResidualFunc.h
+++ b/include/ResidualFunc.h
@@ -8,7 +8,7 @@ class FEProblemInterface;
 
 class ResidualFunc : public Functional {
 public:
-    ResidualFunc(const FEProblemInterface * fepi, const std::string & region = "");
+    ResidualFunc(FEProblemInterface * fepi, const std::string & region = "");
 
     /// Evaluate this functional
     ///

--- a/include/TecplotOutput.h
+++ b/include/TecplotOutput.h
@@ -52,7 +52,7 @@ protected:
     /// FE problem interface (convenience pointer)
     const DiscreteProblemInterface * dpi;
     /// Unstructured mesh
-    const UnstructuredMesh * mesh;
+    UnstructuredMesh * mesh;
     /// Variable names to be stored
     const std::vector<std::string> & variable_names;
 

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -28,10 +28,10 @@ AuxiliaryField::AuxiliaryField(const Parameters & params) :
     fid(-1),
     block_id(-1)
 {
-    this->mesh = dynamic_cast<const UnstructuredMesh *>(get_problem()->get_mesh());
+    this->mesh = dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh());
 }
 
-const UnstructuredMesh *
+UnstructuredMesh *
 AuxiliaryField::get_mesh() const
 {
     _F_;

--- a/src/BndJacobianFunc.cpp
+++ b/src/BndJacobianFunc.cpp
@@ -6,7 +6,7 @@
 namespace godzilla {
 
 BndJacobianFunc::BndJacobianFunc(const BoundaryCondition * bc) :
-    JacobianFunc(dynamic_cast<const FEProblemInterface *>(bc->get_discrete_problem_interface()))
+    JacobianFunc(dynamic_cast<FEProblemInterface *>(bc->get_discrete_problem_interface()))
 {
 }
 

--- a/src/BndResidualFunc.cpp
+++ b/src/BndResidualFunc.cpp
@@ -6,7 +6,7 @@
 namespace godzilla {
 
 BndResidualFunc::BndResidualFunc(const BoundaryCondition * bc) :
-    ResidualFunc(dynamic_cast<const FEProblemInterface *>(bc->get_discrete_problem_interface()))
+    ResidualFunc(dynamic_cast<FEProblemInterface *>(bc->get_discrete_problem_interface()))
 {
 }
 

--- a/src/BoundaryCondition.cpp
+++ b/src/BoundaryCondition.cpp
@@ -25,10 +25,10 @@ BoundaryCondition::BoundaryCondition(const Parameters & params) :
     boundary(get_param<std::string>("boundary"))
 {
     _F_;
-    this->mesh = dynamic_cast<const UnstructuredMesh *>(get_problem()->get_mesh());
+    this->mesh = dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh());
 }
 
-const UnstructuredMesh *
+UnstructuredMesh *
 BoundaryCondition::get_mesh() const
 {
     _F_;

--- a/src/BoundaryCondition.cpp
+++ b/src/BoundaryCondition.cpp
@@ -13,7 +13,7 @@ BoundaryCondition::parameters()
 {
     Parameters params = Object::parameters();
     params.add_required_param<std::string>("boundary", "Boundary name");
-    params.add_private_param<const DiscreteProblemInterface *>("_dpi", nullptr);
+    params.add_private_param<DiscreteProblemInterface *>("_dpi", nullptr);
     return params;
 }
 
@@ -21,7 +21,7 @@ BoundaryCondition::BoundaryCondition(const Parameters & params) :
     Object(params),
     PrintInterface(this),
     mesh(nullptr),
-    dpi(get_param<const DiscreteProblemInterface *>("_dpi")),
+    dpi(get_param<DiscreteProblemInterface *>("_dpi")),
     boundary(get_param<std::string>("boundary"))
 {
     _F_;
@@ -47,7 +47,7 @@ BoundaryCondition::get_boundary() const
     return this->boundary;
 }
 
-const DiscreteProblemInterface *
+DiscreteProblemInterface *
 BoundaryCondition::get_discrete_problem_interface() const
 {
     _F_;

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -15,7 +15,7 @@ namespace godzilla {
 
 DiscreteProblemInterface::DiscreteProblemInterface(Problem * problem, const Parameters & params) :
     problem(problem),
-    unstr_mesh(dynamic_cast<const UnstructuredMesh *>(problem->get_mesh())),
+    unstr_mesh(dynamic_cast<UnstructuredMesh *>(problem->get_mesh())),
     logger(params.get<const App *>("_app")->get_logger()),
     ds(nullptr),
     dm_aux(nullptr),

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -251,7 +251,7 @@ DiscreteProblemInterface::add_boundary_essential(const std::string & name,
                                                  const std::vector<Int> & components,
                                                  PetscFunc * fn,
                                                  PetscFunc * fn_t,
-                                                 void * context) const
+                                                 void * context)
 {
     PETSC_CHECK(PetscDSAddBoundary(this->ds,
                                    DM_BC_ESSENTIAL,
@@ -274,7 +274,7 @@ DiscreteProblemInterface::add_boundary_natural(const std::string & name,
                                                const std::vector<Int> & ids,
                                                Int field,
                                                const std::vector<Int> & components,
-                                               void * context) const
+                                               void * context)
 {
     PETSC_CHECK(PetscDSAddBoundary(this->ds,
                                    DM_BC_NATURAL,
@@ -299,7 +299,7 @@ DiscreteProblemInterface::add_boundary_natural_riemann(const std::string & name,
                                                        const std::vector<Int> & components,
                                                        PetscNaturalRiemannBCFunc * fn,
                                                        PetscNaturalRiemannBCFunc * fn_t,
-                                                       void * context) const
+                                                       void * context)
 {
     _F_;
     PETSC_CHECK(PetscDSAddBoundary(this->ds,

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -105,8 +105,7 @@ ExodusIIOutput::ExodusIIOutput(const Parameters & params) :
     FileOutput(params),
     variable_names(get_param<std::vector<std::string>>("variables")),
     dpi(dynamic_cast<const DiscreteProblemInterface *>(this->problem)),
-    mesh(this->problem ? dynamic_cast<const UnstructuredMesh *>(this->problem->get_mesh())
-                       : nullptr),
+    mesh(this->problem ? dynamic_cast<UnstructuredMesh *>(this->problem->get_mesh()) : nullptr),
     exo(nullptr),
     step_num(1),
     mesh_stored(false)

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -25,7 +25,7 @@ namespace {
 
 class G0Identity : public JacobianFunc {
 public:
-    explicit G0Identity(const ExplicitFELinearProblem * prob) :
+    explicit G0Identity(ExplicitFELinearProblem * prob) :
         JacobianFunc(prob),
         n_comp(prob->get_field_num_components(0))
     {

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -1821,7 +1821,7 @@ FEProblemInterface::add_boundary_natural_riemann(const std::string & name,
                                                  const std::vector<Int> & components,
                                                  PetscNaturalRiemannBCFunc * fn,
                                                  PetscNaturalRiemannBCFunc * fn_t,
-                                                 void * context) const
+                                                 void * context)
 {
     _F_;
     error("Natural Riemann BCs are not supported for FE problems");

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -540,7 +540,7 @@ FVProblemInterface::add_boundary_essential(const std::string & name,
                                            const std::vector<Int> & components,
                                            PetscFunc * fn,
                                            PetscFunc * fn_t,
-                                           void * context) const
+                                           void * context)
 {
     _F_;
     error("Essential BCs are not supported for FV problems");
@@ -552,7 +552,7 @@ FVProblemInterface::add_boundary_natural(const std::string & name,
                                          const std::vector<Int> & ids,
                                          Int field,
                                          const std::vector<Int> & components,
-                                         void * context) const
+                                         void * context)
 {
     _F_;
     error("Natural BCs are not supported for FV problems");

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -351,7 +351,7 @@ void
 FVProblemInterface::create()
 {
     _F_;
-    const_cast<UnstructuredMesh *>(this->unstr_mesh)->construct_ghost_cells();
+    this->unstr_mesh->construct_ghost_cells();
     set_up_fields();
     DiscreteProblemInterface::create();
 }

--- a/src/GYMLFile.cpp
+++ b/src/GYMLFile.cpp
@@ -158,7 +158,7 @@ GYMLFile::build_initial_conditions()
         for (const auto & it : ics_node.values()) {
             Block blk = get_block(ics_node, it.first.as<std::string>());
             Parameters * params = build_params(blk);
-            params->set<const DiscreteProblemInterface *>("_dpi") = dpi;
+            params->set<DiscreteProblemInterface *>("_dpi") = dpi;
             const auto & class_name = params->get<std::string>("_type");
             auto ic = Factory::create<InitialCondition>(class_name, blk.name(), params);
             dpi->add_initial_condition(ic);
@@ -183,7 +183,7 @@ GYMLFile::build_boundary_conditions()
         for (const auto & it : bcs_node.values()) {
             Block blk = get_block(bcs_node, it.first.as<std::string>());
             Parameters * params = build_params(blk);
-            params->set<const DiscreteProblemInterface *>("_dpi") = dpi;
+            params->set<DiscreteProblemInterface *>("_dpi") = dpi;
             const auto & class_name = params->get<std::string>("_type");
             auto bc = Factory::create<BoundaryCondition>(class_name, blk.name(), params);
             dpi->add_boundary_condition(bc);

--- a/src/HDF5Output.cpp
+++ b/src/HDF5Output.cpp
@@ -50,7 +50,7 @@ void
 HDF5Output::check()
 {
     _F_;
-    const auto * mesh = dynamic_cast<const UnstructuredMesh *>(this->problem->get_mesh());
+    const auto * mesh = dynamic_cast<UnstructuredMesh *>(this->problem->get_mesh());
     if (mesh == nullptr)
         log_error("HDF5 output works only with unstructured meshes.");
 }

--- a/src/InitialCondition.cpp
+++ b/src/InitialCondition.cpp
@@ -21,14 +21,14 @@ InitialCondition::parameters()
 {
     Parameters params = Object::parameters();
     params.add_param<std::string>("field", "", "Field name");
-    params.add_private_param<const DiscreteProblemInterface *>("_dpi", nullptr);
+    params.add_private_param<DiscreteProblemInterface *>("_dpi", nullptr);
     return params;
 }
 
 InitialCondition::InitialCondition(const Parameters & params) :
     Object(params),
     PrintInterface(this),
-    dpi(get_param<const DiscreteProblemInterface *>("_dpi")),
+    dpi(get_param<DiscreteProblemInterface *>("_dpi")),
     fid(-1)
 {
     _F_;

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -149,7 +149,7 @@ InputFile::build_problem()
     auto node = get_block(this->root, "problem");
     Parameters * params = build_params(node);
     const auto & class_name = params->get<std::string>("_type");
-    params->set<const Mesh *>("_mesh") = this->mesh;
+    params->set<Mesh *>("_mesh") = this->mesh;
     this->problem = Factory::create<Problem>(class_name, "problem", params);
     add_object(this->problem);
 }

--- a/src/JacobianFunc.cpp
+++ b/src/JacobianFunc.cpp
@@ -4,8 +4,8 @@
 
 namespace godzilla {
 
-JacobianFunc::JacobianFunc(const FEProblemInterface * fepi, const std::string & region) :
-    Functional(const_cast<FEProblemInterface *>(fepi), region)
+JacobianFunc::JacobianFunc(FEProblemInterface * fepi, const std::string & region) :
+    Functional(fepi, region)
 {
 }
 

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -80,7 +80,7 @@ void
 LinearProblem::create()
 {
     _F_;
-    const_cast<Mesh *>(this->mesh)->distribute();
+    get_mesh()->distribute();
     init();
     allocate_objects();
     set_up_matrix_properties();

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -115,7 +115,7 @@ void
 NonlinearProblem::create()
 {
     _F_;
-    const_cast<Mesh *>(this->mesh)->distribute();
+    get_mesh()->distribute();
     init();
     allocate_objects();
     set_up_matrix_properties();

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -12,14 +12,14 @@ Parameters
 Problem::parameters()
 {
     Parameters params = Object::parameters();
-    params.add_private_param<const Mesh *>("_mesh", nullptr);
+    params.add_private_param<Mesh *>("_mesh", nullptr);
     return params;
 }
 
 Problem::Problem(const Parameters & parameters) :
     Object(parameters),
     PrintInterface(this),
-    mesh(get_param<const Mesh *>("_mesh")),
+    mesh(get_param<Mesh *>("_mesh")),
     default_output_on(Output::ON_NONE),
     time(0.),
     step_num(0)
@@ -58,7 +58,7 @@ Problem::create()
         out->create();
 }
 
-const Mesh *
+Mesh *
 Problem::get_mesh() const
 {
     _F_;

--- a/src/ResidualFunc.cpp
+++ b/src/ResidualFunc.cpp
@@ -2,8 +2,8 @@
 
 namespace godzilla {
 
-ResidualFunc::ResidualFunc(const FEProblemInterface * fepi, const std::string & region) :
-    Functional(const_cast<FEProblemInterface *>(fepi), region)
+ResidualFunc::ResidualFunc(FEProblemInterface * fepi, const std::string & region) :
+    Functional(fepi, region)
 {
 }
 

--- a/src/TecplotOutput.cpp
+++ b/src/TecplotOutput.cpp
@@ -80,8 +80,7 @@ TecplotOutput::TecplotOutput(const Parameters & params) :
     FileOutput(params),
     format(BINARY),
     dpi(dynamic_cast<const DiscreteProblemInterface *>(this->problem)),
-    mesh(this->problem ? dynamic_cast<const UnstructuredMesh *>(this->problem->get_mesh())
-                       : nullptr),
+    mesh(this->problem ? dynamic_cast<UnstructuredMesh *>(this->problem->get_mesh()) : nullptr),
     variable_names(get_param<std::vector<std::string>>("variables")),
     file(nullptr),
     header_written(false),

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -49,7 +49,7 @@ void
 VTKOutput::check()
 {
     _F_;
-    const auto * mesh = dynamic_cast<const UnstructuredMesh *>(this->problem->get_mesh());
+    const auto * mesh = dynamic_cast<UnstructuredMesh *>(this->problem->get_mesh());
     if (mesh == nullptr)
         log_error("VTK output works only with unstructured meshes.");
 }

--- a/test/include/FENonlinearProblem_test.h
+++ b/test/include/FENonlinearProblem_test.h
@@ -25,7 +25,7 @@ public:
         {
             const std::string class_name = "GTestFENonlinearProblem";
             Parameters * params = Factory::get_parameters(class_name);
-            params->set<const Mesh *>("_mesh") = this->mesh;
+            params->set<Mesh *>("_mesh") = this->mesh;
             this->prob =
                 this->app->build_object<GTestFENonlinearProblem>(class_name, "prob", params);
         }
@@ -58,7 +58,7 @@ public:
         {
             const std::string class_name = "GTest2FieldsFENonlinearProblem";
             Parameters * params = Factory::get_parameters(class_name);
-            params->set<const Mesh *>("_mesh") = this->mesh;
+            params->set<Mesh *>("_mesh") = this->mesh;
             this->prob =
                 this->app->build_object<GTest2FieldsFENonlinearProblem>(class_name, "prob", params);
         }

--- a/test/include/ImplicitFENonlinearProblem_test.h
+++ b/test/include/ImplicitFENonlinearProblem_test.h
@@ -22,7 +22,7 @@ public:
     {
         const std::string class_name = "GTestImplicitFENonlinearProblem";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const Mesh *>("_mesh") = mesh;
+        params->set<Mesh *>("_mesh") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 20;
         params->set<Real>("dt") = 5;

--- a/test/include/LinearProblem_test.h
+++ b/test/include/LinearProblem_test.h
@@ -89,7 +89,7 @@ protected:
     {
         const std::string class_name = "G1DTestLinearProblem";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const Mesh *>("_mesh") = mesh;
+        params->set<Mesh *>("_mesh") = mesh;
         return this->app->build_object<G1DTestLinearProblem>(class_name, "problem", params);
     }
 
@@ -98,7 +98,7 @@ protected:
     {
         const std::string class_name = "G2DTestLinearProblem";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const Mesh *>("_mesh") = mesh;
+        params->set<Mesh *>("_mesh") = mesh;
         return this->app->build_object<G2DTestLinearProblem>(class_name, "problem", params);
     }
 
@@ -107,7 +107,7 @@ protected:
     {
         const std::string class_name = "G3DTestLinearProblem";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const Mesh *>("_mesh") = mesh;
+        params->set<Mesh *>("_mesh") = mesh;
         return this->app->build_object<G3DTestLinearProblem>(class_name, "problem", params);
     }
 };

--- a/test/src/BasicTSAdapt_test.cpp
+++ b/test/src/BasicTSAdapt_test.cpp
@@ -23,7 +23,7 @@ TEST(BasicTSAdapt, api)
     {
         const std::string class_name = "GTestImplicitFENonlinearProblem";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const Mesh *>("_mesh") = mesh;
+        params->set<Mesh *>("_mesh") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 1;
         params->set<Real>("dt") = 0.1;

--- a/test/src/BndJacobianFunc_test.cpp
+++ b/test/src/BndJacobianFunc_test.cpp
@@ -101,7 +101,7 @@ TEST(BndJacobianFuncTest, test)
 
     Parameters prob_pars = GTestProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 20;
     prob_pars.set<Real>("dt") = 5;

--- a/test/src/BndJacobianFunc_test.cpp
+++ b/test/src/BndJacobianFunc_test.cpp
@@ -110,7 +110,7 @@ TEST(BndJacobianFuncTest, test)
 
     Parameters bc_pars = NaturalBC::parameters();
     bc_pars.set<const App *>("_app") = &app;
-    bc_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_pars.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_pars.set<std::string>("field") = "u";
     bc_pars.set<std::string>("boundary") = "marker";
     TestBC bc(bc_pars);

--- a/test/src/BndResidualFunc_test.cpp
+++ b/test/src/BndResidualFunc_test.cpp
@@ -101,7 +101,7 @@ TEST(BndResidualFuncTest, test)
 
     Parameters prob_pars = GTestProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 20;
     prob_pars.set<Real>("dt") = 5;

--- a/test/src/BndResidualFunc_test.cpp
+++ b/test/src/BndResidualFunc_test.cpp
@@ -110,7 +110,7 @@ TEST(BndResidualFuncTest, test)
 
     Parameters bc_pars = NaturalBC::parameters();
     bc_pars.set<const App *>("_app") = &app;
-    bc_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_pars.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_pars.set<std::string>("field") = "u";
     bc_pars.set<std::string>("boundary") = "marker";
     TestBC bc(bc_pars);

--- a/test/src/BoundaryCondition_test.cpp
+++ b/test/src/BoundaryCondition_test.cpp
@@ -32,7 +32,7 @@ TEST_F(BoundaryConditionTest, api)
 {
     Parameters params = BoundaryCondition::parameters();
     params.set<const App *>("_app") = this->app;
-    params.set<const DiscreteProblemInterface *>("_dpi") = this->prob;
+    params.set<DiscreteProblemInterface *>("_dpi") = this->prob;
     params.set<std::string>("_name") = "obj";
     params.set<std::string>("boundary") = "side1";
     MockBoundaryCondition bc(params);

--- a/test/src/ConstantAuxiliaryField_test.cpp
+++ b/test/src/ConstantAuxiliaryField_test.cpp
@@ -17,7 +17,7 @@ TEST(ConstantAuxiliaryFieldTest, create)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
     prob.set_aux_fe(0, "aux1", 1, 1);
 
@@ -56,7 +56,7 @@ TEST(ConstantAuxiliaryFieldTest, evaluate)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
     prob.set_aux_fe(0, "aux1", 1, 1);
 

--- a/test/src/DependencyEvaluator_test.cpp
+++ b/test/src/DependencyEvaluator_test.cpp
@@ -82,7 +82,7 @@ TEST(DependencyEvaluator, create_functional)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -107,7 +107,7 @@ TEST(DependencyEvaluator, create_existing_functional)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -132,7 +132,7 @@ TEST(DependencyEvaluator, get_non_existent_functional)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -153,7 +153,7 @@ TEST(DependencyEvaluator, eval)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -197,7 +197,7 @@ TEST(DependencyEvaluator, redeclare_a_value)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -221,7 +221,7 @@ TEST(DependencyEvaluator, get_suppliers)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -255,7 +255,7 @@ TEST(DependencyEvaluator, build_dep_graph)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();

--- a/test/src/DirichletBC_test.cpp
+++ b/test/src/DirichletBC_test.cpp
@@ -19,7 +19,7 @@ TEST(DirichletBCTest, api)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem problem(prob_pars);
     app.problem = &problem;
 
@@ -61,7 +61,7 @@ TEST(DirichletBCTest, with_user_defined_fn)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem problem(prob_pars);
     app.problem = &problem;
 

--- a/test/src/DirichletBC_test.cpp
+++ b/test/src/DirichletBC_test.cpp
@@ -25,7 +25,7 @@ TEST(DirichletBCTest, api)
 
     Parameters params = DirichletBC::parameters();
     params.set<const App *>("_app") = &app;
-    params.set<const DiscreteProblemInterface *>("_dpi") = &problem;
+    params.set<DiscreteProblemInterface *>("_dpi") = &problem;
     params.set<std::vector<std::string>>("value") = { "t * (x + y + z)" };
     params.set<std::vector<std::string>>("value_t") = { "1" };
     DirichletBC obj(params);
@@ -75,7 +75,7 @@ TEST(DirichletBCTest, with_user_defined_fn)
 
     Parameters * bc_pars = Factory::get_parameters("DirichletBC");
     bc_pars->set<const App *>("_app") = &app;
-    bc_pars->set<const DiscreteProblemInterface *>("_dpi") = &problem;
+    bc_pars->set<DiscreteProblemInterface *>("_dpi") = &problem;
     bc_pars->set<std::vector<std::string>>("value") = { "ipol(x)" };
     DirichletBC * bc = app.build_object<DirichletBC>("DirichletBC", "name", bc_pars);
 

--- a/test/src/EssentialBC_test.cpp
+++ b/test/src/EssentialBC_test.cpp
@@ -47,7 +47,7 @@ TEST(EssentialBCTest, api)
 
     Parameters params = TestEssentialBC::parameters();
     params.set<const App *>("_app") = &app;
-    params.set<const DiscreteProblemInterface *>("_dpi") = &problem;
+    params.set<DiscreteProblemInterface *>("_dpi") = &problem;
     TestEssentialBC bc(params);
 
     mesh.create();

--- a/test/src/EssentialBC_test.cpp
+++ b/test/src/EssentialBC_test.cpp
@@ -41,7 +41,7 @@ TEST(EssentialBCTest, api)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem problem(prob_pars);
     app.problem = &problem;
 

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -127,7 +127,7 @@ TEST_F(ExodusIIOutputTest, fe_check)
 
     Parameters prob_pars = TestLinearProblem::parameters();
     prob_pars.set<const App *>("_app") = this->app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     TestLinearProblem prob(prob_pars);
 
     Parameters params = ExodusIIOutput::parameters();

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -96,7 +96,7 @@ TEST(ExplicitFELinearProblemTest, solve)
 
     Parameters bc_left_pars = DirichletBC::parameters();
     bc_left_pars.set<const App *>("_app") = &app;
-    bc_left_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_left_pars.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_left_pars.set<std::string>("boundary") = "left";
     bc_left_pars.set<std::vector<std::string>>("value") = { "1" };
     DirichletBC bc_left(bc_left_pars);
@@ -104,7 +104,7 @@ TEST(ExplicitFELinearProblemTest, solve)
 
     Parameters bc_right_pars = DirichletBC::parameters();
     bc_right_pars.set<const App *>("_app") = &app;
-    bc_right_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_right_pars.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_right_pars.set<std::string>("boundary") = "right";
     bc_right_pars.set<std::vector<std::string>>("value") = { "1" };
     DirichletBC bc_right(bc_right_pars);

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -86,7 +86,7 @@ TEST(ExplicitFELinearProblemTest, solve)
 
     Parameters prob_pars = TestExplicitFELinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -138,7 +138,7 @@ TEST(ExplicitFELinearProblemTest, set_schemes)
 
     Parameters prob_pars = TestExplicitFELinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -178,7 +178,7 @@ TEST(ExplicitFELinearProblemTest, wrong_scheme)
     {
         const std::string class_name = "TestExplicitFELinearProblem";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const Mesh *>("_mesh") = mesh;
+        params->set<Mesh *>("_mesh") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 20;
         params->set<Real>("dt") = 5;

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -46,7 +46,7 @@ protected:
 
 class TestF1 : public ResidualFunc {
 public:
-    explicit TestF1(const TestExplicitFELinearProblem * prob) :
+    explicit TestF1(TestExplicitFELinearProblem * prob) :
         ResidualFunc(prob),
         u(get_field_value("u")),
         u_x(get_field_gradient("u"))

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -91,7 +91,7 @@ public:
                            const std::vector<Int> & components,
                            PetscFunc * fn,
                            PetscFunc * fn_t,
-                           void * context)
+                           void * context) override
     {
         ExplicitFVLinearProblem::add_boundary_essential(name,
                                                         label,
@@ -109,7 +109,7 @@ public:
                          const std::vector<Int> & ids,
                          Int field,
                          const std::vector<Int> & components,
-                         void * context)
+                         void * context) override
     {
         ExplicitFVLinearProblem::add_boundary_natural(name, label, ids, field, components, context);
     }
@@ -292,7 +292,7 @@ TEST(ExplicitFVLinearProblemTest, solve)
 
     Parameters bc_left_pars = TestBC::parameters();
     bc_left_pars.set<const App *>("_app") = &app;
-    bc_left_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_left_pars.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_left_pars.set<std::string>("boundary") = "left";
     bc_left_pars.set<bool>("inlet") = true;
     TestBC bc_left(bc_left_pars);
@@ -300,7 +300,7 @@ TEST(ExplicitFVLinearProblemTest, solve)
 
     Parameters bc_right_pars = TestBC::parameters();
     bc_right_pars.set<const App *>("_app") = &app;
-    bc_right_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_right_pars.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_right_pars.set<std::string>("boundary") = "right";
     bc_right_pars.set<bool>("inlet") = false;
     TestBC bc_right(bc_right_pars);

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -180,7 +180,7 @@ TEST(ExplicitFVLinearProblemTest, api)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -239,7 +239,7 @@ TEST(ExplicitFVLinearProblemTest, fields)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -282,7 +282,7 @@ TEST(ExplicitFVLinearProblemTest, solve)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -334,7 +334,7 @@ TEST(ExplicitFVLinearProblemTest, set_schemes)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -369,7 +369,7 @@ TEST(ExplicitFVLinearProblemTest, wrong_schemes)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -126,7 +126,7 @@ TEST_F(FENonlinearProblemTest, set_up_initial_guess)
 {
     Parameters ic_pars = ConstantIC::parameters();
     ic_pars.set<const App *>("_app") = app;
-    ic_pars.set<const DiscreteProblemInterface *>("_dpi") = prob;
+    ic_pars.set<DiscreteProblemInterface *>("_dpi") = prob;
     ic_pars.set<std::vector<Real>>("value") = { 0 };
     ConstantIC ic(ic_pars);
     prob->add_initial_condition(&ic);
@@ -160,7 +160,7 @@ TEST_F(FENonlinearProblemTest, solve)
     {
         const std::string class_name = "ConstantIC";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const DiscreteProblemInterface *>("_dpi") = prob;
+        params->set<DiscreteProblemInterface *>("_dpi") = prob;
         params->set<std::vector<Real>>("value") = { 0.1 };
         ic = this->app->build_object<InitialCondition>(class_name, "ic", params);
         prob->add_initial_condition(ic);
@@ -170,7 +170,7 @@ TEST_F(FENonlinearProblemTest, solve)
         const std::string class_name = "DirichletBC";
         Parameters * params = Factory::get_parameters(class_name);
         params->set<const App *>("_app") = this->app;
-        params->set<const DiscreteProblemInterface *>("_dpi") = prob;
+        params->set<DiscreteProblemInterface *>("_dpi") = prob;
         params->set<std::string>("boundary") = bnd;
         params->set<std::vector<std::string>>("value") = { "x*x" };
         auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc", params);
@@ -198,7 +198,7 @@ TEST_F(FENonlinearProblemTest, solve_no_ic)
     {
         const std::string class_name = "DirichletBC";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const DiscreteProblemInterface *>("_dpi") = prob;
+        params->set<DiscreteProblemInterface *>("_dpi") = prob;
         params->set<std::string>("boundary") = "marker";
         params->set<std::vector<std::string>>("value") = { "x*x" };
         auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc", params);
@@ -223,7 +223,7 @@ TEST_F(FENonlinearProblemTest, err_ic_comp_mismatch)
     {
         const std::string class_name = "GTest2CompIC";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const DiscreteProblemInterface *>("_dpi") = prob;
+        params->set<DiscreteProblemInterface *>("_dpi") = prob;
         auto ic = this->app->build_object<InitialCondition>(class_name, "ic", params);
         prob->add_initial_condition(ic);
     }
@@ -270,7 +270,7 @@ TEST(TwoFieldFENonlinearProblemTest, err_duplicate_ics)
     {
         const std::string class_name = "ConstantIC";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const DiscreteProblemInterface *>("_dpi") = prob;
+        params->set<DiscreteProblemInterface *>("_dpi") = prob;
         params->set<std::string>("field") = "u";
         params->set<std::vector<Real>>("value") = { 0.1 };
         auto ic = app.build_object<InitialCondition>(class_name, "ic1", params);
@@ -278,7 +278,7 @@ TEST(TwoFieldFENonlinearProblemTest, err_duplicate_ics)
     }
     const std::string class_name = "ConstantIC";
     Parameters * params = Factory::get_parameters(class_name);
-    params->set<const DiscreteProblemInterface *>("_dpi") = prob;
+    params->set<DiscreteProblemInterface *>("_dpi") = prob;
     params->set<std::string>("field") = "u";
     params->set<std::vector<Real>>("value") = { 0.2 };
     auto ic = app.build_object<InitialCondition>(class_name, "ic2", params);
@@ -328,7 +328,7 @@ TEST(TwoFieldFENonlinearProblemTest, err_not_enough_ics)
     {
         const std::string class_name = "ConstantIC";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const DiscreteProblemInterface *>("_dpi") = prob;
+        params->set<DiscreteProblemInterface *>("_dpi") = prob;
         params->set<std::vector<Real>>("value") = { 0.1 };
         auto ic = app.build_object<InitialCondition>(class_name, "ic1", params);
         prob->add_initial_condition(ic);
@@ -349,7 +349,7 @@ TEST_F(FENonlinearProblemTest, err_nonexisting_bc_bnd)
     {
         const std::string class_name = "DirichletBC";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const DiscreteProblemInterface *>("_dpi") = prob;
+        params->set<DiscreteProblemInterface *>("_dpi") = prob;
         params->set<std::string>("boundary") = "asdf";
         params->set<std::vector<std::string>>("value") = { "0.1" };
         auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc1", params);

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -264,7 +264,7 @@ TEST(TwoFieldFENonlinearProblemTest, err_duplicate_ics)
     {
         const std::string class_name = "GTest2FieldsFENonlinearProblem";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const Mesh *>("_mesh") = mesh;
+        params->set<Mesh *>("_mesh") = mesh;
         prob = app.build_object<FENonlinearProblem>(class_name, "prob", params);
     }
     {
@@ -321,7 +321,7 @@ TEST(TwoFieldFENonlinearProblemTest, err_not_enough_ics)
     {
         const std::string class_name = "GTest2FieldsFENonlinearProblem";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const Mesh *>("_mesh") = mesh;
+        params->set<Mesh *>("_mesh") = mesh;
         prob = app.build_object<FENonlinearProblem>(class_name, "prob", params);
     }
 

--- a/test/src/FunctionAuxiliaryField_test.cpp
+++ b/test/src/FunctionAuxiliaryField_test.cpp
@@ -17,7 +17,7 @@ TEST(FunctionAuxiliaryFieldTest, create)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
     prob.set_aux_fe(0, "aux1", 1, 1);
 
@@ -56,7 +56,7 @@ TEST(FunctionAuxiliaryFieldTest, evaluate)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
     prob.set_aux_fe(0, "aux1", 1, 1);
 

--- a/test/src/FunctionIC_test.cpp
+++ b/test/src/FunctionIC_test.cpp
@@ -18,7 +18,7 @@ TEST(FunctionICTest, api)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     Parameters params = FunctionIC::parameters();

--- a/test/src/FunctionIC_test.cpp
+++ b/test/src/FunctionIC_test.cpp
@@ -23,7 +23,7 @@ TEST(FunctionICTest, api)
 
     Parameters params = FunctionIC::parameters();
     params.set<const App *>("_app") = &app;
-    params.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    params.set<DiscreteProblemInterface *>("_dpi") = &prob;
     params.set<std::vector<std::string>>("value") = { "t * (x + y + z)" };
     FunctionIC obj(params);
 

--- a/test/src/GTestFENonlinearProblem.cpp
+++ b/test/src/GTestFENonlinearProblem.cpp
@@ -9,7 +9,7 @@ namespace {
 
 class F0 : public ResidualFunc {
 public:
-    explicit F0(const GTestFENonlinearProblem * prob) : ResidualFunc(prob) {}
+    explicit F0(GTestFENonlinearProblem * prob) : ResidualFunc(prob) {}
 
     void
     evaluate(Scalar f[]) const override
@@ -20,7 +20,7 @@ public:
 
 class F1 : public ResidualFunc {
 public:
-    explicit F1(const GTestFENonlinearProblem * prob) :
+    explicit F1(GTestFENonlinearProblem * prob) :
         ResidualFunc(prob),
         dim(get_spatial_dimension()),
         u_x(get_field_gradient("u"))
@@ -41,9 +41,7 @@ protected:
 
 class G3 : public JacobianFunc {
 public:
-    explicit G3(const GTestFENonlinearProblem * prob) :
-        JacobianFunc(prob),
-        dim(get_spatial_dimension())
+    explicit G3(GTestFENonlinearProblem * prob) : JacobianFunc(prob), dim(get_spatial_dimension())
     {
     }
 

--- a/test/src/GTestImplicitFENonlinearProblem.cpp
+++ b/test/src/GTestImplicitFENonlinearProblem.cpp
@@ -13,7 +13,7 @@ namespace {
 
 class F0 : public ResidualFunc {
 public:
-    explicit F0(const GTestImplicitFENonlinearProblem * prob) :
+    explicit F0(GTestImplicitFENonlinearProblem * prob) :
         ResidualFunc(prob),
         u_t(get_field_dot("u"))
     {
@@ -31,7 +31,7 @@ protected:
 
 class F1 : public ResidualFunc {
 public:
-    explicit F1(const GTestImplicitFENonlinearProblem * prob) :
+    explicit F1(GTestImplicitFENonlinearProblem * prob) :
         ResidualFunc(prob),
         dim(get_spatial_dimension()),
         u_x(get_field_gradient("u"))
@@ -52,7 +52,7 @@ protected:
 
 class G0 : public JacobianFunc {
 public:
-    explicit G0(const GTestImplicitFENonlinearProblem * prob) :
+    explicit G0(GTestImplicitFENonlinearProblem * prob) :
         JacobianFunc(prob),
         u_t_shift(get_time_shift())
     {
@@ -70,7 +70,7 @@ protected:
 
 class G3 : public JacobianFunc {
 public:
-    explicit G3(const GTestImplicitFENonlinearProblem * prob) :
+    explicit G3(GTestImplicitFENonlinearProblem * prob) :
         JacobianFunc(prob),
         dim(get_spatial_dimension())
     {

--- a/test/src/GYMLFile_test.cpp
+++ b/test/src/GYMLFile_test.cpp
@@ -101,7 +101,7 @@ GTestProblem::parameters()
                                                                       "map<str, vec<str>> doco");
     params.add_param<bool>("bool1", false, "False bool param");
     params.add_param<bool>("bool2", true, "True bool param");
-    params.add_private_param<const Mesh *>("_mesh", nullptr);
+    params.add_private_param<Mesh *>("_mesh", nullptr);
     return params;
 }
 
@@ -200,7 +200,7 @@ TEST_F(GYMLFileTest, mesh_partitioner)
     file.parse(file_name);
     file.build();
 
-    Mesh * mesh = file.get_mesh();
+    auto mesh = file.get_mesh();
     EXPECT_NE(mesh, nullptr);
     mesh->create();
 

--- a/test/src/HDF5Output_test.cpp
+++ b/test/src/HDF5Output_test.cpp
@@ -26,7 +26,7 @@ protected:
         {
             const std::string class_name = "G1DTestLinearProblem";
             Parameters * params = Factory::get_parameters(class_name);
-            params->set<const Mesh *>("_mesh") = mesh;
+            params->set<Mesh *>("_mesh") = mesh;
             this->prob = this->app->build_object<Problem>(class_name, "problem", params);
         }
     }
@@ -107,7 +107,7 @@ TEST_F(HDF5OutputTest, wrong_mesh_type)
 
     Parameters prob_pars = TestProblem::parameters();
     prob_pars.set<const App *>("_app") = this->app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     TestProblem prob(prob_pars);
 
     Parameters pars = HDF5Output::parameters();

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -21,7 +21,7 @@ TEST_F(ImplicitFENonlinearProblemTest, run)
     {
         const std::string class_name = "ConstantIC";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const DiscreteProblemInterface *>("_dpi") = prob;
+        params->set<DiscreteProblemInterface *>("_dpi") = prob;
         params->set<std::vector<Real>>("value") = { 0 };
         auto ic = this->app->build_object<InitialCondition>(class_name, "ic", params);
         prob->add_initial_condition(ic);
@@ -32,7 +32,7 @@ TEST_F(ImplicitFENonlinearProblemTest, run)
         Parameters * params = Factory::get_parameters(class_name);
         params->set<std::string>("boundary") = bnd;
         params->set<std::vector<std::string>>("value") = { "x*x" };
-        params->set<const DiscreteProblemInterface *>("_dpi") = prob;
+        params->set<DiscreteProblemInterface *>("_dpi") = prob;
         auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc", params);
         prob->add_boundary_condition(bc);
     }

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -64,7 +64,7 @@ TEST_F(ImplicitFENonlinearProblemTest, wrong_scheme)
     {
         const std::string class_name = "GTestImplicitFENonlinearProblem";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const Mesh *>("_mesh") = mesh;
+        params->set<Mesh *>("_mesh") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 20;
         params->set<Real>("dt") = 5;

--- a/test/src/InitialCondition_test.cpp
+++ b/test/src/InitialCondition_test.cpp
@@ -35,7 +35,7 @@ TEST_F(InitialConditionTest, api)
 {
     Parameters params = InitialCondition::parameters();
     params.set<const App *>("_app") = this->app;
-    params.set<const DiscreteProblemInterface *>("_dpi") = this->prob;
+    params.set<DiscreteProblemInterface *>("_dpi") = this->prob;
     params.set<std::string>("_name") = "obj";
     MockInitialCondition ic(params);
 
@@ -52,7 +52,7 @@ TEST_F(InitialConditionTest, test)
 {
     Parameters params = InitialCondition::parameters();
     params.set<const App *>("_app") = this->app;
-    params.set<const DiscreteProblemInterface *>("_dpi") = this->prob;
+    params.set<DiscreteProblemInterface *>("_dpi") = this->prob;
     params.set<std::string>("_name") = "obj";
     params.set<std::string>("field") = "u";
     MockInitialCondition ic(params);
@@ -73,7 +73,7 @@ TEST_F(InitialCondition2FieldTest, no_field_param)
 
     Parameters params = InitialCondition::parameters();
     params.set<const App *>("_app") = this->app;
-    params.set<const DiscreteProblemInterface *>("_dpi") = this->prob;
+    params.set<DiscreteProblemInterface *>("_dpi") = this->prob;
     params.set<std::string>("_name") = "obj";
     MockInitialCondition ic(params);
 
@@ -96,7 +96,7 @@ TEST_F(InitialCondition2FieldTest, non_existing_field)
 
     Parameters params = InitialCondition::parameters();
     params.set<const App *>("_app") = this->app;
-    params.set<const DiscreteProblemInterface *>("_dpi") = this->prob;
+    params.set<DiscreteProblemInterface *>("_dpi") = this->prob;
     params.set<std::string>("_name") = "obj";
     params.set<std::string>("field") = "asdf";
     MockInitialCondition ic(params);

--- a/test/src/JacobianFunc_test.cpp
+++ b/test/src/JacobianFunc_test.cpp
@@ -40,7 +40,7 @@ protected:
 
 class TestJ : public JacobianFunc {
 public:
-    explicit TestJ(const GTestProblem * prob) :
+    explicit TestJ(GTestProblem * prob) :
         JacobianFunc(prob),
         dim(get_spatial_dimension()),
         u(get_field_value("u")),

--- a/test/src/JacobianFunc_test.cpp
+++ b/test/src/JacobianFunc_test.cpp
@@ -77,7 +77,7 @@ TEST(JacobianFuncTest, test)
 
     Parameters prob_pars = GTestProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 20;
     prob_pars.set<Real>("dt") = 5;

--- a/test/src/L2Diff_test.cpp
+++ b/test/src/L2Diff_test.cpp
@@ -22,14 +22,14 @@ TEST(L2DiffTest, compute)
 
     Parameters bc_left_params = DirichletBC::parameters();
     bc_left_params.set<const App *>("_app") = &app;
-    bc_left_params.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_left_params.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_left_params.set<std::vector<std::string>>("value") = { "x*x" };
     bc_left_params.set<std::string>("boundary") = "left";
     DirichletBC bc_left(bc_left_params);
 
     Parameters bc_right_params = DirichletBC::parameters();
     bc_right_params.set<const App *>("_app") = &app;
-    bc_right_params.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_right_params.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_right_params.set<std::vector<std::string>>("value") = { "x*x" };
     bc_right_params.set<std::string>("boundary") = "right";
     DirichletBC bc_right(bc_right_params);

--- a/test/src/L2Diff_test.cpp
+++ b/test/src/L2Diff_test.cpp
@@ -16,7 +16,7 @@ TEST(L2DiffTest, compute)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
     app.problem = &prob;
 

--- a/test/src/LinearProblem_test.cpp
+++ b/test/src/LinearProblem_test.cpp
@@ -57,7 +57,7 @@ TEST_F(LinearProblemTest, run)
 
     Parameters prob_pars = LinearProblem::parameters();
     prob_pars.set<const App *>("_app") = this->app;
-    prob_pars.set<const Mesh *>("_mesh") = mesh;
+    prob_pars.set<Mesh *>("_mesh") = mesh;
     MockLinearProblem prob(prob_pars);
 
     EXPECT_CALL(prob, solve);

--- a/test/src/MeshPartitioningOutput_test.cpp
+++ b/test/src/MeshPartitioningOutput_test.cpp
@@ -46,7 +46,7 @@ TEST(MeshPartitioningOutputTest, get_file_ext)
 
     Parameters prob_params = G1DTestLinearProblem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     G1DTestLinearProblem prob(prob_params);
 
     Parameters params = MeshPartitioningOutput::parameters();
@@ -70,7 +70,7 @@ TEST(MeshPartitioningOutputTest, output)
 
     Parameters prob_params = G1DTestLinearProblem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     G1DTestLinearProblem prob(prob_params);
 
     Parameters params = MeshPartitioningOutput::parameters();

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -45,7 +45,7 @@ TEST(NaturalBCTest, api)
 
     Parameters params = NaturalBC::parameters();
     params.set<const App *>("_app") = &app;
-    params.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    params.set<DiscreteProblemInterface *>("_dpi") = &prob;
     params.set<std::string>("boundary") = "left";
     MockNaturalBC bc(params);
 
@@ -132,7 +132,7 @@ TEST(NaturalBCTest, fe)
 
     Parameters bc_params = TestNaturalBC::parameters();
     bc_params.set<const App *>("_app") = &app;
-    bc_params.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_params.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_params.set<std::string>("_name") = "bc1";
     bc_params.set<std::string>("boundary") = "left";
     TestNaturalBC bc(bc_params);

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -20,7 +20,7 @@ TEST(NaturalBCTest, api)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
     app.problem = &prob;
 
@@ -125,7 +125,7 @@ TEST(NaturalBCTest, fe)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
     app.problem = &prob;
     prob.set_aux_fe(0, "aux1", 1, 1);

--- a/test/src/NaturalRiemannBC_test.cpp
+++ b/test/src/NaturalRiemannBC_test.cpp
@@ -74,7 +74,7 @@ TEST(NaturalRiemannBCTest, api)
 
     Parameters bc_pars = TestBC::parameters();
     bc_pars.set<const App *>("_app") = &app;
-    bc_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_pars.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_pars.set<std::string>("boundary") = "left";
     TestBC bc(bc_pars);
     prob.add_boundary_condition(&bc);

--- a/test/src/NaturalRiemannBC_test.cpp
+++ b/test/src/NaturalRiemannBC_test.cpp
@@ -65,7 +65,7 @@ TEST(NaturalRiemannBCTest, api)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;

--- a/test/src/NeumannProblem_test.cpp
+++ b/test/src/NeumannProblem_test.cpp
@@ -27,7 +27,7 @@ protected:
 
 class F0 : public ResidualFunc {
 public:
-    explicit F0(const TestNeumannProblem * prob) :
+    explicit F0(TestNeumannProblem * prob) :
         ResidualFunc(prob),
         u(get_field_value("u")),
         x(get_xyz())
@@ -47,7 +47,7 @@ protected:
 
 class F1 : public ResidualFunc {
 public:
-    explicit F1(const TestNeumannProblem * prob) :
+    explicit F1(TestNeumannProblem * prob) :
         ResidualFunc(prob),
         dim(get_spatial_dimension()),
         u_x(get_field_gradient("u"))
@@ -68,7 +68,7 @@ protected:
 
 class G0 : public JacobianFunc {
 public:
-    explicit G0(const TestNeumannProblem * prob) : JacobianFunc(prob) {}
+    explicit G0(TestNeumannProblem * prob) : JacobianFunc(prob) {}
 
     void
     evaluate(Scalar g[]) const override
@@ -79,9 +79,7 @@ public:
 
 class G3 : public JacobianFunc {
 public:
-    explicit G3(const TestNeumannProblem * prob) : JacobianFunc(prob), dim(get_spatial_dimension())
-    {
-    }
+    explicit G3(TestNeumannProblem * prob) : JacobianFunc(prob), dim(get_spatial_dimension()) {}
 
     void
     evaluate(Scalar g[]) const override

--- a/test/src/NeumannProblem_test.cpp
+++ b/test/src/NeumannProblem_test.cpp
@@ -187,7 +187,7 @@ TEST(NeumannProblemTest, solve)
 
     Parameters bc_left_pars = TestNeumannBC::parameters();
     bc_left_pars.set<const App *>("_app") = &app;
-    bc_left_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_left_pars.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_left_pars.set<std::string>("_name") = "bc1";
     bc_left_pars.set<std::string>("boundary") = "left";
     TestNeumannBC bc_left(bc_left_pars);
@@ -195,7 +195,7 @@ TEST(NeumannProblemTest, solve)
 
     Parameters bc_right_pars = TestNeumannBC::parameters();
     bc_right_pars.set<const App *>("_app") = &app;
-    bc_right_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_right_pars.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_right_pars.set<std::string>("_name") = "bc2";
     bc_right_pars.set<std::string>("boundary") = "right";
     TestNeumannBC bc_right(bc_right_pars);

--- a/test/src/NeumannProblem_test.cpp
+++ b/test/src/NeumannProblem_test.cpp
@@ -181,7 +181,7 @@ TEST(NeumannProblemTest, solve)
 
     Parameters prob_params = TestNeumannProblem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     TestNeumannProblem prob(prob_params);
     app.problem = &prob;
 

--- a/test/src/NonlinearProblem_test.cpp
+++ b/test/src/NonlinearProblem_test.cpp
@@ -107,7 +107,7 @@ TEST(NonlinearProblemTest, initial_guess)
 
     Parameters prob_pars = G1DTestNonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     G1DTestNonlinearProblem prob(prob_pars);
     prob.create();
     prob.call_initial_guess();
@@ -130,7 +130,7 @@ TEST(NonlinearProblemTest, solve)
 
     Parameters prob_pars = G1DTestNonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     G1DTestNonlinearProblem prob(prob_pars);
 
     prob.create();
@@ -161,7 +161,7 @@ TEST(NonlinearProblemTest, compute_callbacks)
 
     Parameters prob_pars = NonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     NonlinearProblem prob(prob_pars);
 
     Vector x;
@@ -199,7 +199,7 @@ TEST(NonlinearProblemTest, run)
 
     Parameters prob_pars = NonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     MockNonlinearProblem prob(prob_pars);
 
     EXPECT_CALL(prob, set_up_initial_guess);
@@ -234,7 +234,7 @@ TEST(NonlinearProblemTest, line_search_type)
     for (auto & lst : ls_type) {
         Parameters prob_pars = NonlinearProblem::parameters();
         prob_pars.set<const App *>("_app") = &app;
-        prob_pars.set<const Mesh *>("_mesh") = &mesh;
+        prob_pars.set<Mesh *>("_mesh") = &mesh;
         prob_pars.set<std::string>("line_search") = lst;
         MockNonlinearProblem prob(prob_pars);
         prob.create();
@@ -267,7 +267,7 @@ TEST(NonlinearProblemTest, invalid_line_search_type)
 
     Parameters prob_pars = NonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<std::string>("line_search") = "asdf";
     MockNonlinearProblem prob(prob_pars);
     prob.create();

--- a/test/src/Problem_test.cpp
+++ b/test/src/Problem_test.cpp
@@ -101,7 +101,7 @@ TEST(ProblemTest, add_pp)
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     TestProblem problem(prob_params);
 
     Parameters pp_params = Postprocessor::parameters();
@@ -155,7 +155,7 @@ TEST(ProblemTest, local_vec)
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     TestProblem problem(prob_params);
     problem.set_local_section(create_section(mesh.get_dm()));
 
@@ -180,7 +180,7 @@ TEST(ProblemTest, global_vec)
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     TestProblem problem(prob_params);
     problem.set_local_section(create_section(mesh.get_dm()));
 
@@ -205,7 +205,7 @@ TEST(ProblemTest, create_matrix)
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     TestProblem problem(prob_params);
     problem.create();
     problem.set_local_section(create_section(mesh.get_dm()));
@@ -228,7 +228,7 @@ TEST(UnstructuredMeshTest, get_local_section)
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     TestProblem problem(prob_params);
     problem.create();
 
@@ -255,7 +255,7 @@ TEST(UnstructuredMeshTest, get_global_section)
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<const App *>("_app") = &app;
-    prob_params.set<const Mesh *>("_mesh") = &mesh;
+    prob_params.set<Mesh *>("_mesh") = &mesh;
     TestProblem problem(prob_params);
     problem.create();
 

--- a/test/src/ResidualFunc_test.cpp
+++ b/test/src/ResidualFunc_test.cpp
@@ -77,7 +77,7 @@ TEST(ResidualFuncTest, test)
 
     Parameters prob_pars = GTestProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 20;
     prob_pars.set<Real>("dt") = 5;

--- a/test/src/ResidualFunc_test.cpp
+++ b/test/src/ResidualFunc_test.cpp
@@ -40,7 +40,7 @@ protected:
 
 class TestF : public ResidualFunc {
 public:
-    explicit TestF(const GTestProblem * prob) :
+    explicit TestF(GTestProblem * prob) :
         ResidualFunc(prob),
         dim(get_spatial_dimension()),
         u(get_field_value("u")),

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -224,7 +224,7 @@ TEST(TimeSteppingAdaptor, choose)
         Parameters * params = Factory::get_parameters(class_name);
         params->set<std::string>("boundary") = "marker";
         params->set<std::vector<std::string>>("value") = { "x*x" };
-        params->set<const DiscreteProblemInterface *>("_dpi") = prob;
+        params->set<DiscreteProblemInterface *>("_dpi") = prob;
         auto bc = app.build_object<BoundaryCondition>(class_name, "bc", params);
         prob->add_boundary_condition(bc);
     }

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -169,7 +169,7 @@ TEST(TimeSteppingAdaptor, api)
     {
         const std::string class_name = "TestTSProblem";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const Mesh *>("_mesh") = mesh;
+        params->set<Mesh *>("_mesh") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 1;
         params->set<Real>("dt") = 0.1;
@@ -211,7 +211,7 @@ TEST(TimeSteppingAdaptor, choose)
     {
         const std::string class_name = "TestTSProblem";
         Parameters * params = Factory::get_parameters(class_name);
-        params->set<const Mesh *>("_mesh") = mesh;
+        params->set<Mesh *>("_mesh") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 1;
         params->set<Real>("dt") = 0.1;

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -26,7 +26,7 @@ protected:
         {
             const std::string class_name = "G1DTestLinearProblem";
             Parameters * params = Factory::get_parameters(class_name);
-            params->set<const Mesh *>("_mesh") = mesh;
+            params->set<Mesh *>("_mesh") = mesh;
             this->prob =
                 this->app->build_object<G1DTestLinearProblem>(class_name, "problem", params);
         }
@@ -110,7 +110,7 @@ TEST_F(VTKOutputTest, wrong_mesh_type)
 
     Parameters prob_pars = TestProblem::parameters();
     prob_pars.set<const App *>("_app") = this->app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     TestProblem prob(prob_pars);
 
     Parameters pars = VTKOutput::parameters();

--- a/test/src/ValueFunctional_test.cpp
+++ b/test/src/ValueFunctional_test.cpp
@@ -62,7 +62,7 @@ TEST(ValueFunctional, eval)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();

--- a/test/src/WeakForm_test.cpp
+++ b/test/src/WeakForm_test.cpp
@@ -93,7 +93,7 @@ TEST(WeakFormTest, test)
 
     Parameters bc_pars = NaturalBC::parameters();
     bc_pars.set<const App *>("_app") = &app;
-    bc_pars.set<const DiscreteProblemInterface *>("_dpi") = &prob;
+    bc_pars.set<DiscreteProblemInterface *>("_dpi") = &prob;
     bc_pars.set<std::string>("boundary") = "left";
     TestBC bc(bc_pars);
 

--- a/test/src/WeakForm_test.cpp
+++ b/test/src/WeakForm_test.cpp
@@ -33,7 +33,7 @@ protected:
 
 class TestF : public ResidualFunc {
 public:
-    explicit TestF(const GTestFENonlinearProblem * prob) : ResidualFunc(prob) {}
+    explicit TestF(GTestFENonlinearProblem * prob) : ResidualFunc(prob) {}
 
     void
     evaluate(Scalar f[]) const override
@@ -44,7 +44,7 @@ public:
 
 class BndTestF : public BndResidualFunc {
 public:
-    explicit BndTestF(const TestBC * bc) : BndResidualFunc(bc) {}
+    explicit BndTestF(TestBC * bc) : BndResidualFunc(bc) {}
 
     void
     evaluate(Scalar f[]) const override
@@ -55,7 +55,7 @@ public:
 
 class TestJ : public JacobianFunc {
 public:
-    explicit TestJ(const GTestFENonlinearProblem * prob) : JacobianFunc(prob) {}
+    explicit TestJ(GTestFENonlinearProblem * prob) : JacobianFunc(prob) {}
 
     void
     evaluate(Scalar g[]) const override
@@ -66,7 +66,7 @@ public:
 
 class BndTestJ : public BndJacobianFunc {
 public:
-    explicit BndTestJ(const TestBC * bc) : BndJacobianFunc(bc) {}
+    explicit BndTestJ(TestBC * bc) : BndJacobianFunc(bc) {}
 
     void
     evaluate(Scalar g[]) const override

--- a/test/src/WeakForm_test.cpp
+++ b/test/src/WeakForm_test.cpp
@@ -88,7 +88,7 @@ TEST(WeakFormTest, test)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<const App *>("_app") = &app;
-    prob_pars.set<const Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     Parameters bc_pars = NaturalBC::parameters();


### PR DESCRIPTION
- Removing const from DiscreteProblem::add_boundary_XYZ
- Problem holds a pointer to Mesh
- [Bnd]{Jacobian|Residual}Func takes non-const pointer to `FEProblemInterface`
