### PR TITLE
Refactoring transient capability

### DIFF
--- a/include/ExplicitFELinearProblem.h
+++ b/include/ExplicitFELinearProblem.h
@@ -12,6 +12,8 @@ public:
     explicit ExplicitFELinearProblem(const Parameters & params);
     ~ExplicitFELinearProblem() override;
 
+    Real get_time() const override;
+    Int get_step_num() const override;
     void create() override;
     void check() override;
     bool converged() override;

--- a/include/ExplicitFVLinearProblem.h
+++ b/include/ExplicitFVLinearProblem.h
@@ -18,6 +18,8 @@ public:
     void check() override;
     bool converged() override;
     void solve() override;
+    Real get_time() const override;
+    Int get_step_num() const override;
 
     virtual PetscErrorCode compute_rhs(Real time, const Vector & x, Vector & F);
 

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -95,7 +95,7 @@ public:
 
     virtual const Real & get_time_shift() const;
 
-    virtual const Real & get_time() const;
+    virtual const Real & get_assembly_time() const;
 
     virtual const Normal & get_normal() const;
 

--- a/include/ImplicitFENonlinearProblem.h
+++ b/include/ImplicitFENonlinearProblem.h
@@ -14,6 +14,8 @@ public:
     void check() override;
     bool converged() override;
     void solve() override;
+    Real get_time() const override;
+    Int get_step_num() const override;
 
     virtual PetscErrorCode
     compute_ifunction(Real time, const Vector & X, const Vector & X_t, Vector & F);

--- a/include/PrintInterface.h
+++ b/include/PrintInterface.h
@@ -52,7 +52,6 @@ public:
                    const unsigned int & verbosity_level,
                    std::string prefix);
 
-protected:
     /// Print a message on a terminal
     ///
     /// @param level Verbosity level. If application verbose level is higher than this number, the

--- a/include/Problem.h
+++ b/include/Problem.h
@@ -40,12 +40,12 @@ public:
     /// Get simulation time. For steady-state simulations, time is always 0
     ///
     /// @return Simulation time
-    const Real & get_time() const;
+    virtual Real get_time() const;
 
     /// Get time step number
     ///
     /// @return Time step number
-    const Int & get_step_num() const;
+    virtual Int get_step_num() const;
 
     /// Get list of functions
     ///
@@ -152,16 +152,8 @@ protected:
     /// postprocessor names
     std::vector<std::string> pps_names;
 
-    /// Simulation time
-    Real time;
-
-    /// Time step number
-    Int step_num;
-
 public:
     static Parameters parameters();
-
-    friend class TransientProblemInterface;
 };
 
 } // namespace godzilla

--- a/include/TransientProblemInterface.h
+++ b/include/TransientProblemInterface.h
@@ -85,6 +85,10 @@ protected:
     const Real & dt;
     /// Converged reason
     TSConvergedReason converged_reason;
+    /// Simulation time
+    Real time;
+    /// Time step number
+    Int step_num;
 
 public:
     static Parameters parameters();

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -72,6 +72,20 @@ ExplicitFELinearProblem::~ExplicitFELinearProblem()
     this->ksp = nullptr;
 }
 
+Real
+ExplicitFELinearProblem::get_time() const
+{
+    _F_;
+    return this->time;
+}
+
+Int
+ExplicitFELinearProblem::get_step_num() const
+{
+    _F_;
+    return this->step_num;
+}
+
 void
 ExplicitFELinearProblem::init()
 {

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -47,6 +47,20 @@ ExplicitFVLinearProblem::~ExplicitFVLinearProblem()
     this->ksp = nullptr;
 }
 
+Real
+ExplicitFVLinearProblem::get_time() const
+{
+    _F_;
+    return this->time;
+}
+
+Int
+ExplicitFVLinearProblem::get_step_num() const
+{
+    _F_;
+    return this->step_num;
+}
+
 void
 ExplicitFVLinearProblem::init()
 {

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -714,7 +714,7 @@ FEProblemInterface::get_time_shift() const
 }
 
 const Real &
-FEProblemInterface::get_time() const
+FEProblemInterface::get_assembly_time() const
 {
     _F_;
     return this->asmbl.time;

--- a/src/Functional.cpp
+++ b/src/Functional.cpp
@@ -68,7 +68,7 @@ const Real &
 Functional::get_time() const
 {
     _F_;
-    return get_fe_problem()->get_time();
+    return get_fe_problem()->get_assembly_time();
 }
 
 } // namespace godzilla

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -104,6 +104,20 @@ ImplicitFENonlinearProblem::~ImplicitFENonlinearProblem()
     this->ksp = nullptr;
 }
 
+Real
+ImplicitFENonlinearProblem::get_time() const
+{
+    _F_;
+    return this->time;
+}
+
+Int
+ImplicitFENonlinearProblem::get_step_num() const
+{
+    _F_;
+    return this->step_num;
+}
+
 void
 ImplicitFENonlinearProblem::init()
 {

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -20,9 +20,7 @@ Problem::Problem(const Parameters & parameters) :
     Object(parameters),
     PrintInterface(this),
     mesh(get_param<Mesh *>("_mesh")),
-    default_output_on(Output::ON_NONE),
-    time(0.),
-    step_num(0)
+    default_output_on(Output::ON_NONE)
 {
 }
 
@@ -72,18 +70,18 @@ Problem::get_dimension() const
     return this->mesh->get_dimension();
 }
 
-const Real &
+Real
 Problem::get_time() const
 {
     _F_;
-    return this->time;
+    return 0.;
 }
 
-const Int &
+Int
 Problem::get_step_num() const
 {
     _F_;
-    return this->step_num;
+    return 0;
 }
 
 const std::vector<Function *> &

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -59,7 +59,9 @@ TransientProblemInterface::TransientProblemInterface(Problem * problem, const Pa
     end_time(params.get<Real>("end_time")),
     num_steps(params.get<Int>("num_steps")),
     dt(params.get<Real>("dt")),
-    converged_reason(TS_CONVERGED_ITERATING)
+    converged_reason(TS_CONVERGED_ITERATING),
+    time(0.),
+    step_num(0)
 {
     _F_;
 }
@@ -136,7 +138,7 @@ TransientProblemInterface::create()
     if (this->tpi_params.is_param_valid("num_steps"))
         PETSC_CHECK(TSSetMaxSteps(this->ts, this->num_steps));
     set_time_step(this->dt);
-    PETSC_CHECK(TSSetStepNumber(this->ts, this->problem->get_step_num()));
+    PETSC_CHECK(TSSetStepNumber(this->ts, this->step_num));
     PETSC_CHECK(TSSetExactFinalTime(this->ts, TS_EXACTFINALTIME_MATCHSTEP));
     if (this->ts_adaptor)
         this->ts_adaptor->create();
@@ -174,8 +176,8 @@ PetscErrorCode
 TransientProblemInterface::post_step()
 {
     _F_;
-    PETSC_CHECK(TSGetTime(this->ts, &this->problem->time));
-    PETSC_CHECK(TSGetStepNumber(this->ts, &this->problem->step_num));
+    PETSC_CHECK(TSGetTime(this->ts, &this->time));
+    PETSC_CHECK(TSGetStepNumber(this->ts, &this->step_num));
     Vector sln = get_solution();
     PETSC_CHECK(VecCopy(sln, this->problem->get_solution_vector()));
     this->problem->compute_postprocessors();

--- a/test/src/BndJacobianFunc_test.cpp
+++ b/test/src/BndJacobianFunc_test.cpp
@@ -41,7 +41,7 @@ public:
                 (const));
     MOCK_METHOD(const FieldValue &, get_field_dot, (const std::string & field_name), (const));
     MOCK_METHOD(const Real &, get_time_shift, (), (const));
-    MOCK_METHOD(const Real &, get_time, (), (const));
+    MOCK_METHOD(const Real &, get_assembly_time, (), (const));
     MOCK_METHOD(const Normal &, get_normal, (), (const));
     MOCK_METHOD(const Point &, get_xyz, (), (const));
 
@@ -127,7 +127,7 @@ TEST(BndJacobianFuncTest, test)
     FieldGradient grad(1);
     EXPECT_CALL(prob, get_field_gradient(_)).Times(1).WillOnce(ReturnRef(grad));
     Real time;
-    EXPECT_CALL(prob, get_time()).Times(1).WillOnce(ReturnRef(time));
+    EXPECT_CALL(prob, get_assembly_time()).Times(1).WillOnce(ReturnRef(time));
     Real time_shift;
     EXPECT_CALL(prob, get_time_shift()).Times(1).WillOnce(ReturnRef(time_shift));
     Normal n(1);

--- a/test/src/BndResidualFunc_test.cpp
+++ b/test/src/BndResidualFunc_test.cpp
@@ -41,7 +41,7 @@ public:
                 (const));
     MOCK_METHOD(const FieldValue &, get_field_dot, (const std::string & field_name), (const));
     MOCK_METHOD(const Real &, get_time_shift, (), (const));
-    MOCK_METHOD(const Real &, get_time, (), (const));
+    MOCK_METHOD(const Real &, get_assembly_time, (), (const));
     MOCK_METHOD(const Normal &, get_normal, (), (const));
     MOCK_METHOD(const Point &, get_xyz, (), (const));
 
@@ -129,7 +129,7 @@ TEST(BndResidualFuncTest, test)
     FieldValue dot;
     EXPECT_CALL(prob, get_field_dot(_)).Times(1).WillOnce(ReturnRef(dot));
     Real time;
-    EXPECT_CALL(prob, get_time()).Times(1).WillOnce(ReturnRef(time));
+    EXPECT_CALL(prob, get_assembly_time()).Times(1).WillOnce(ReturnRef(time));
     Normal n(1);
     EXPECT_CALL(prob, get_normal()).Times(1).WillOnce(ReturnRef(n));
     Point coord(1);

--- a/test/src/JacobianFunc_test.cpp
+++ b/test/src/JacobianFunc_test.cpp
@@ -21,7 +21,7 @@ public:
                 (const));
     MOCK_METHOD(const FieldValue &, get_field_dot, (const std::string & field_name), (const));
     MOCK_METHOD(const Real &, get_time_shift, (), (const));
-    MOCK_METHOD(const Real &, get_time, (), (const));
+    MOCK_METHOD(const Real &, get_assembly_time, (), (const));
     MOCK_METHOD(const Normal &, get_normal, (), (const));
     MOCK_METHOD(const Point &, get_xyz, (), (const));
 
@@ -93,7 +93,7 @@ TEST(JacobianFuncTest, test)
     FieldGradient grad(1);
     EXPECT_CALL(prob, get_field_gradient(_)).Times(1).WillOnce(ReturnRef(grad));
     Real time;
-    EXPECT_CALL(prob, get_time()).Times(1).WillOnce(ReturnRef(time));
+    EXPECT_CALL(prob, get_assembly_time()).Times(1).WillOnce(ReturnRef(time));
     Real time_shift;
     EXPECT_CALL(prob, get_time_shift()).Times(1).WillOnce(ReturnRef(time_shift));
 

--- a/test/src/ResidualFunc_test.cpp
+++ b/test/src/ResidualFunc_test.cpp
@@ -21,7 +21,7 @@ public:
                 (const));
     MOCK_METHOD(const FieldValue &, get_field_dot, (const std::string & field_name), (const));
     MOCK_METHOD(const Real &, get_time_shift, (), (const));
-    MOCK_METHOD(const Real &, get_time, (), (const));
+    MOCK_METHOD(const Real &, get_assembly_time, (), (const));
     MOCK_METHOD(const Normal &, get_normal, (), (const));
     MOCK_METHOD(const Point &, get_xyz, (), (const));
 
@@ -95,7 +95,7 @@ TEST(ResidualFuncTest, test)
     FieldValue dot;
     EXPECT_CALL(prob, get_field_dot(_)).Times(1).WillOnce(ReturnRef(dot));
     Real time;
-    EXPECT_CALL(prob, get_time()).Times(1).WillOnce(ReturnRef(time));
+    EXPECT_CALL(prob, get_assembly_time()).Times(1).WillOnce(ReturnRef(time));
 
     TestF res(&prob);
 }


### PR DESCRIPTION
For transient problems, time and step_num are in `TransientProblemInterface`.
Problem still returns time snd step_num, but does not return a reference
any more. It just reports back 0 for time and step_num, is the problem
is not transient. User code must override get_time() and get_step_num()
when inheriting from TransientProblemInterface.
