### PR TITLE
If field component is specified it will be the name of the variable in the exodus file

### DIFF
--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -277,7 +277,7 @@ void
 NSIncompressibleProblem::set_up_fields()
 {
     _F_;
-    const char * comp_name[] = { "x", "y", "z" };
+    const char * comp_name[] = { "velocity_x", "velocity_y", "velocity_z" };
 
     PetscInt dim = this->get_dimension();
     set_fe(velocity_id, "velocity", dim, 2);

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -436,7 +436,7 @@ ExodusIIOutput::add_var_names(Int fid, std::vector<std::string> & var_names)
             if (comp_name.length() == 0)
                 s = fmt::sprintf("%s_%d", name, c);
             else
-                s = fmt::sprintf("%s_%s", name, comp_name);
+                s = fmt::sprintf("%s", comp_name);
             var_names.push_back(s);
         }
     }
@@ -457,7 +457,7 @@ ExodusIIOutput::add_aux_var_names(Int fid, std::vector<std::string> & var_names)
             if (comp_name.length() == 0)
                 s = fmt::sprintf("%s_%d", name, c);
             else
-                s = fmt::sprintf("%s_%s", name, comp_name);
+                s = fmt::sprintf("%s", comp_name);
             var_names.push_back(s);
         }
     }


### PR DESCRIPTION
This allows us to output things like 'rho', 'rhou', 'rhoE' in flow applications instead of
'U_rho', 'U_rhou', 'U_rhoE'.  On the other hand for velocity fields, we must include
the field name in the component name, i.e. 'vel_x', 'vel_y', instead of having a 'velocity'
field name with 'x' and 'y' component names.
