### PR TITLE
Fixes suggested by clang-tidy, pt. 2

### DIFF
--- a/examples/burgers-eqn/src/BurgersEquation.cpp
+++ b/examples/burgers-eqn/src/BurgersEquation.cpp
@@ -23,6 +23,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         f[0] = -this->visc * this->u_x(0) + 0.5 * this->u(0) * this->u(0);
     }
 

--- a/examples/heat-eqn/src/ConvectiveHeatFluxBC.cpp
+++ b/examples/heat-eqn/src/ConvectiveHeatFluxBC.cpp
@@ -23,6 +23,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         f[0] = htc(0) * (T(0) - T_infinity(0));
     }
 
@@ -39,6 +40,7 @@ public:
     void
     evaluate(PetscScalar g[]) const override
     {
+        _F_;
         g[0] = htc(0);
     }
 

--- a/examples/heat-eqn/src/HeatEquationExplicit.cpp
+++ b/examples/heat-eqn/src/HeatEquationExplicit.cpp
@@ -19,6 +19,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         f[0] = -this->ffn(0);
     }
 
@@ -38,6 +39,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         for (PetscInt d = 0; d < this->dim; ++d)
             f[d] = -this->T_x(d);
     }

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -21,6 +21,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         f[0] = this->T_t(0) - this->q_ppp(0);
     }
 
@@ -41,6 +42,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         for (PetscInt d = 0; d < this->dim; ++d)
             f[d] = this->T_x(d);
     }
@@ -59,6 +61,7 @@ public:
     void
     evaluate(PetscScalar g[]) const override
     {
+        _F_;
         g[0] = this->T_t_shift * 1.0;
     }
 
@@ -75,6 +78,7 @@ public:
     void
     evaluate(PetscScalar g[]) const override
     {
+        _F_;
         for (PetscInt d = 0; d < this->dim; ++d)
             g[d * this->dim + d] = 1.0;
     }

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -29,6 +29,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         for (PetscInt c = 0; c < this->n_comp; ++c) {
             f[c] = this->vel_t(c);
 
@@ -63,6 +64,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         for (PetscInt comp = 0; comp < this->n_comp; ++comp) {
             for (PetscInt d = 0; d < this->dim; ++d) {
                 f[comp * this->dim + d] = 1.0 / this->Re * this->vel_x(comp * this->dim + d);
@@ -91,6 +93,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         f[0] = 0.0;
         for (PetscInt d = 0; d < this->dim; ++d)
             f[0] += this->vel_x(d * this->dim + d);
@@ -112,6 +115,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         for (PetscInt d = 0; d < this->dim; ++d)
             f[d] = 0.0;
     }
@@ -133,6 +137,7 @@ public:
     void
     evaluate(PetscScalar g[]) const override
     {
+        _F_;
         PetscInt nc_i = this->dim;
         PetscInt nc_j = this->dim;
 
@@ -165,6 +170,7 @@ public:
     void
     evaluate(PetscScalar g[]) const override
     {
+        _F_;
         PetscInt nc_i = this->dim;
         PetscInt nc_j = this->dim;
 
@@ -195,6 +201,7 @@ public:
     void
     evaluate(PetscScalar g[]) const override
     {
+        _F_;
         for (PetscInt d = 0; d < this->dim; ++d)
             g[d * this->dim + d] = 1.0;
     }
@@ -214,6 +221,7 @@ public:
     void
     evaluate(PetscScalar g[]) const override
     {
+        _F_;
         for (PetscInt d = 0; d < this->dim; ++d)
             g[d * this->dim + d] = -1.0;
     }
@@ -235,6 +243,7 @@ public:
     void
     evaluate(PetscScalar g[]) const override
     {
+        _F_;
         for (PetscInt comp_i = 0; comp_i < this->n_comp; ++comp_i) {
             for (PetscInt d = 0; d < this->dim; ++d) {
                 g[((comp_i * this->n_comp + comp_i) * this->dim + d) * this->dim + d] =

--- a/examples/poisson/include/PoissonPDE.h
+++ b/examples/poisson/include/PoissonPDE.h
@@ -13,6 +13,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         f[0] = -this->ffn(0);
     }
 
@@ -32,6 +33,7 @@ public:
     void
     evaluate(PetscScalar f[]) const override
     {
+        _F_;
         for (PetscInt d = 0; d < this->dim; ++d)
             f[d] = this->u_x(d);
     }
@@ -48,6 +50,7 @@ public:
     void
     evaluate(PetscScalar g[]) const override
     {
+        _F_;
         for (PetscInt d = 0; d < this->dim; ++d)
             g[d * this->dim + d] = 1.0;
     }

--- a/include/FEBoundary.h
+++ b/include/FEBoundary.h
@@ -113,8 +113,7 @@ private:
             Int local_idx = get_local_face_index(elem_conn, face_conn);
             auto edge_length = this->length(i);
             auto grad = (*this->grad_phi)(ie) (local_idx);
-            auto normal = fe::normal<ELEM_TYPE>(volume, edge_length, grad);
-            this->normal(i) = normal;
+            this->normal(i) = fe::normal<ELEM_TYPE>(volume, edge_length, grad);
         }
     }
 
@@ -128,8 +127,7 @@ private:
             DenseVector<Int, N_ELEM_NODES - 1> idx;
             for (Int j = 0; j < N_ELEM_NODES - 1; j++)
                 idx(j) = face_conn[j] - n_cells;
-            auto coords = this->coords->get_values(idx);
-            auto edge_length = fe::face_area<ELEM_TYPE>(coords);
+            auto edge_length = fe::face_area<ELEM_TYPE>(this->coords->get_values(idx));
             this->length(i) = edge_length;
         }
     }

--- a/include/FEProblemInterface.h
+++ b/include/FEProblemInterface.h
@@ -379,16 +379,16 @@ protected:
         /// Time derivative (used during assembling)
         FieldValue dots;
 
-        FieldInfo(const std::string & name, Int id, Int nc, Int k, const Int & dim) :
+        FieldInfo(const std::string & name, Int id, Int nc, Int k, Int dim) :
             name(name),
             id(id),
             fe(nullptr),
             block(nullptr),
             nc(nc),
             k(k),
-            values(),
-            derivs(dim),
-            dots()
+            values(nc),
+            derivs(dim, nc),
+            dots(nc)
         {
         }
 
@@ -448,8 +448,8 @@ protected:
         /// the multiplier a for dF/dU_t
         Real u_t_shift;
 
-        AssemblyData();
-    } asmbl;
+        AssemblyData(Int dim);
+    } * asmbl;
 
     /// Functionals that must be evaluated before the weak form residual functionals
     /// associated with the PetscFormKey are evaluated

--- a/include/FieldValue.h
+++ b/include/FieldValue.h
@@ -26,26 +26,35 @@ public:
         return this->data;
     }
 
-    T
-    operator()(unsigned int idx) const
-    {
-        assert(this->data != nullptr);
-        return this->data[idx];
-    }
-
 protected:
     T * data;
 };
 
 /// Used for field values during assembling
-class FieldValue : public LateBindArray<Scalar> {};
+class FieldValue : public LateBindArray<Scalar> {
+public:
+    Scalar
+    operator()(unsigned int idx) const
+    {
+        assert(this->data != nullptr);
+        return this->data[idx];
+    }
+};
 
 /// Used for field gradient values during assembling
 class FieldGradient : public LateBindArray<Scalar> {
 public:
     explicit FieldGradient(const Int & dim) : LateBindArray<Scalar>(), dim(dim) {}
 
-    FieldGradient(const FieldGradient & other) : LateBindArray<Scalar>(other), dim(other.dim) {}
+    FieldGradient(const FieldGradient & other) = default;
+
+    Scalar
+    operator()(unsigned int idx) const
+    {
+        assert(this->data != nullptr);
+        assert(idx < this->dim);
+        return this->data[idx];
+    }
 
 protected:
     const Int & dim;

--- a/include/FieldValue.h
+++ b/include/FieldValue.h
@@ -12,7 +12,7 @@ namespace godzilla {
 template <typename T>
 class LateBindArray {
 public:
-    LateBindArray() : data(nullptr) {}
+    LateBindArray(Int size) : size(size), data(nullptr) {}
 
     void
     set(T * new_data)
@@ -26,72 +26,56 @@ public:
         return this->data;
     }
 
+    T
+    operator()(unsigned int idx) const
+    {
+        assert(this->data != nullptr);
+        assert(idx < this->size);
+        return this->data[idx];
+    }
+
 protected:
+    /// Number of elements stored in `data`
+    Int size;
+    /// The elements of the array
     T * data;
 };
 
 /// Used for field values during assembling
 class FieldValue : public LateBindArray<Scalar> {
 public:
-    Scalar
-    operator()(unsigned int idx) const
-    {
-        assert(this->data != nullptr);
-        return this->data[idx];
-    }
+    /// Constructor
+    ///
+    /// @param nc Number of field components
+    explicit FieldValue(Int nc) : LateBindArray<Scalar>(nc) {}
 };
 
 /// Used for field gradient values during assembling
 class FieldGradient : public LateBindArray<Scalar> {
 public:
-    explicit FieldGradient(const Int & dim) : LateBindArray<Scalar>(), dim(dim) {}
-
-    FieldGradient(const FieldGradient & other) = default;
-
-    Scalar
-    operator()(unsigned int idx) const
-    {
-        assert(this->data != nullptr);
-        assert(idx < this->dim);
-        return this->data[idx];
-    }
-
-protected:
-    const Int & dim;
+    /// Constructor
+    ///
+    /// @param dim Spatial dimension
+    /// @param nc Number of field components
+    explicit FieldGradient(Int dim, Int nc) : LateBindArray<Scalar>(nc * dim) {}
 };
 
 /// Used for vector values during assembling (for example normals)
 class Normal : public LateBindArray<Real> {
 public:
-    explicit Normal(const Int & dim) : LateBindArray<Real>(), dim(dim) {}
-
-    Real
-    operator()(unsigned int idx) const
-    {
-        assert(this->data != nullptr);
-        assert(idx < this->dim);
-        return this->data[idx];
-    }
-
-protected:
-    const Int & dim;
+    /// Constructor
+    ///
+    /// @param dim Spatial dimension
+    explicit Normal(Int dim) : LateBindArray<Real>(dim) {}
 };
 
 /// Used for points during assembling (for example physical coordinates)
 class Point : public LateBindArray<Real> {
 public:
-    explicit Point(const Int & dim) : LateBindArray<Real>(), dim(dim) {}
-
-    Real
-    operator()(unsigned int idx) const
-    {
-        assert(this->data != nullptr);
-        assert(idx < this->dim);
-        return this->data[idx];
-    }
-
-protected:
-    const Int & dim;
+    /// Constructor
+    ///
+    /// @param dim Spatial dimension
+    explicit Point(Int dim) : LateBindArray<Real>(dim) {}
 };
 
 } // namespace godzilla

--- a/include/FileMesh.h
+++ b/include/FileMesh.h
@@ -18,8 +18,6 @@ public:
 protected:
     /// File name with the mesh
     std::string file_name;
-    /// Create faces and edges in the mesh
-    const PetscBool interpolate;
 
 public:
     static Parameters parameters();

--- a/include/LinearProblem.h
+++ b/include/LinearProblem.h
@@ -38,7 +38,7 @@ protected:
     /// Setup solver parameters
     virtual void set_up_solver_parameters();
     /// KSP monitor
-    PetscErrorCode ksp_monitor_callback(Int it, Real rnorm);
+    void ksp_monitor_callback(Int it, Real rnorm);
     /// Method for setting matrix properties
     virtual void set_up_matrix_properties();
     /// Method for setting preconditioning

--- a/include/NonlinearProblem.h
+++ b/include/NonlinearProblem.h
@@ -44,9 +44,9 @@ protected:
     /// Set up solver parameters
     virtual void set_up_solver_parameters();
     /// SNES monitor
-    PetscErrorCode snes_monitor_callback(Int it, Real norm);
+    void snes_monitor_callback(Int it, Real norm);
     /// KSP monitor
-    PetscErrorCode ksp_monitor_callback(Int it, Real rnorm);
+    void ksp_monitor_callback(Int it, Real rnorm);
     /// Method for setting matrix properties
     virtual void set_up_matrix_properties();
     /// Method for setting preconditioning

--- a/include/Terminal.h
+++ b/include/Terminal.h
@@ -16,17 +16,24 @@ public:
     ///
     /// @param aclr Control characters representing the color
     struct Color {
-        explicit Color(const char * aclr) : str(nullptr)
+        explicit Color(const char * aclr)
         {
             if (has_colors())
-                this->str = aclr;
-            else
-                this->str = "";
+                this->str = std::string(aclr);
         }
 
-        const char * str;
+        operator const std::string &() const // NOLINT(google-explicit-constructor)
+        {
+            return this->str;
+        }
 
-        operator const char *() const { return this->str; }
+        operator const char *() const // NOLINT(google-explicit-constructor)
+        {
+            return this->str.c_str();
+        }
+
+    private:
+        std::string str;
 
     public:
         static Color black;
@@ -53,14 +60,3 @@ public:
 
 /// Operator to print the color to the terminal
 std::ostream & operator<<(std::ostream & os, const godzilla::Terminal::Color & clr);
-
-// Formatter for {fmt} library
-template <>
-struct fmt::formatter<godzilla::Terminal::Color> : formatter<std::string> {
-    template <typename FormatContext>
-    auto
-    format(const godzilla::Terminal::Color & c, FormatContext & ctx)
-    {
-        return fmt::formatter<std::string>::format(c.str, ctx);
-    }
-};

--- a/include/TransientProblemInterface.h
+++ b/include/TransientProblemInterface.h
@@ -81,8 +81,8 @@ protected:
     const Real & end_time;
     /// Number of steps
     const Int & num_steps;
-    /// Time step size
-    const Real & dt;
+    /// Initial time step size
+    const Real & dt_initial;
     /// Converged reason
     TSConvergedReason converged_reason;
     /// Simulation time

--- a/include/TransientProblemInterface.h
+++ b/include/TransientProblemInterface.h
@@ -59,7 +59,7 @@ protected:
     /// Called after the time step is done solving
     virtual PetscErrorCode post_step();
     /// TS monitor callback
-    virtual PetscErrorCode ts_monitor_callback(Int stepi, Real time, Vec x);
+    virtual void ts_monitor_callback(Int stepi, Real time, Vec x);
     /// Check if problem converged
     ///
     /// @return `true` if solve converged, otherwise `false`

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -25,10 +25,8 @@ ExodusIIMesh::create_dm()
 {
     _F_;
     TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", this->file_name);
-    PETSC_CHECK(DMPlexCreateExodusFromFile(get_comm(),
-                                           this->file_name.c_str(),
-                                           this->interpolate,
-                                           &this->dm));
+    PETSC_CHECK(
+        DMPlexCreateExodusFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &this->dm));
 
     // Ideally we would like to use DMPlexCreateExodus here and get rid of the above
     // DMPlexCreateExodusFromFile, so that we don't open the same file twice. For some reason,

--- a/src/FileMesh.cpp
+++ b/src/FileMesh.cpp
@@ -17,9 +17,7 @@ FileMesh::parameters()
     return params;
 }
 
-FileMesh::FileMesh(const Parameters & parameters) :
-    UnstructuredMesh(parameters),
-    interpolate(PETSC_TRUE)
+FileMesh::FileMesh(const Parameters & parameters) : UnstructuredMesh(parameters)
 {
     _F_;
 

--- a/src/GmshMesh.cpp
+++ b/src/GmshMesh.cpp
@@ -24,10 +24,8 @@ GmshMesh::create_dm()
     _F_;
     TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", this->file_name);
     PetscOptionsSetValue(nullptr, "-dm_plex_gmsh_use_regions", nullptr);
-    PETSC_CHECK(DMPlexCreateGmshFromFile(get_comm(),
-                                         this->file_name.c_str(),
-                                         this->interpolate,
-                                         &this->dm));
+    PETSC_CHECK(
+        DMPlexCreateGmshFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &this->dm));
 }
 
 } // namespace godzilla

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -54,7 +54,6 @@ DMTSConvertPlex(DM dm, DM * plex, PetscBool copy)
 {
     PetscBool isPlex;
 
-    PetscFunctionBegin;
     PetscCall(PetscObjectTypeCompare((PetscObject) dm, DMPLEX, &isPlex));
     if (isPlex) {
         *plex = dm;
@@ -75,7 +74,7 @@ DMTSConvertPlex(DM dm, DM * plex, PetscBool copy)
             PetscCall(PetscObjectReference((PetscObject) *plex));
         }
     }
-    PetscFunctionReturn(0);
+    return 0;
 }
 
 ///

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -29,7 +29,8 @@ __ksp_monitor_linear(KSP, Int it, Real rnorm, void * ctx)
 {
     _F_;
     auto * problem = static_cast<LinearProblem *>(ctx);
-    return problem->ksp_monitor_callback(it, rnorm);
+    problem->ksp_monitor_callback(it, rnorm);
+    return 0;
 }
 
 Parameters
@@ -142,12 +143,11 @@ LinearProblem::set_up_solver_parameters()
                                  this->lin_max_iter));
 }
 
-PetscErrorCode
+void
 LinearProblem::ksp_monitor_callback(Int it, Real rnorm)
 {
     _F_;
     lprintf(8, "{} Linear residual: {:e}", it, rnorm);
-    return 0;
 }
 
 bool

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -200,14 +200,14 @@ LinearProblem::solve()
 }
 
 PetscErrorCode
-LinearProblem::compute_rhs(Vector & b)
+LinearProblem::compute_rhs(Vector &)
 {
     _F_;
     return 0;
 }
 
 PetscErrorCode
-LinearProblem::compute_operators(Matrix & A, Matrix & B)
+LinearProblem::compute_operators(Matrix &, Matrix &)
 {
     _F_;
     return 0;

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -34,7 +34,8 @@ __ksp_monitor(KSP, Int it, Real rnorm, void * ctx)
 {
     _F_;
     auto * problem = static_cast<NonlinearProblem *>(ctx);
-    return problem->ksp_monitor_callback(it, rnorm);
+    problem->ksp_monitor_callback(it, rnorm);
+    return 0;
 }
 
 PetscErrorCode
@@ -42,7 +43,8 @@ __snes_monitor(SNES, Int it, Real norm, void * ctx)
 {
     _F_;
     auto * problem = static_cast<NonlinearProblem *>(ctx);
-    return problem->snes_monitor_callback(it, norm);
+    problem->snes_monitor_callback(it, norm);
+    return 0;
 }
 
 Parameters
@@ -236,20 +238,18 @@ NonlinearProblem::set_up_solver_parameters()
     PETSC_CHECK(KSPSetFromOptions(this->ksp));
 }
 
-PetscErrorCode
+void
 NonlinearProblem::snes_monitor_callback(Int it, Real norm)
 {
     _F_;
     lprintf(7, "{} Non-linear residual: {:e}", it, norm);
-    return 0;
 }
 
-PetscErrorCode
+void
 NonlinearProblem::ksp_monitor_callback(Int it, Real rnorm)
 {
     _F_;
     lprintf(8, "    {} Linear residual: {:e}", it, rnorm);
-    return 0;
 }
 
 bool

--- a/src/Terminal.cpp
+++ b/src/Terminal.cpp
@@ -25,6 +25,6 @@ unsigned int Terminal::num_colors = 256;
 std::ostream &
 operator<<(std::ostream & os, const godzilla::Terminal::Color & clr)
 {
-    os << clr.str;
+    os << static_cast<const char *>(clr);
     return os;
 }

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -58,7 +58,7 @@ TransientProblemInterface::TransientProblemInterface(Problem * problem, const Pa
     start_time(params.get<Real>("start_time")),
     end_time(params.get<Real>("end_time")),
     num_steps(params.get<Int>("num_steps")),
-    dt(params.get<Real>("dt")),
+    dt_initial(params.get<Real>("dt")),
     converged_reason(TS_CONVERGED_ITERATING),
     time(0.),
     step_num(0)
@@ -137,7 +137,7 @@ TransientProblemInterface::create()
         PETSC_CHECK(TSSetMaxTime(this->ts, this->end_time));
     if (this->tpi_params.is_param_valid("num_steps"))
         PETSC_CHECK(TSSetMaxSteps(this->ts, this->num_steps));
-    set_time_step(this->dt);
+    set_time_step(this->dt_initial);
     PETSC_CHECK(TSSetStepNumber(this->ts, this->step_num));
     PETSC_CHECK(TSSetExactFinalTime(this->ts, TS_EXACTFINALTIME_MATCHSTEP));
     if (this->ts_adaptor)
@@ -187,8 +187,7 @@ PetscErrorCode
 TransientProblemInterface::ts_monitor_callback(Int stepi, Real t, Vec x)
 {
     _F_;
-    Real dt;
-    PETSC_CHECK(TSGetTimeStep(this->ts, &dt));
+    Real dt = get_time_step();
     this->problem->lprintf(6, "{} Time {:f} dt = {:f}", stepi, t, dt);
     return 0;
 }

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -35,7 +35,8 @@ __transient_monitor(TS, Int stepi, Real time, Vec x, void * ctx)
 {
     _F_;
     auto * tpi = static_cast<TransientProblemInterface *>(ctx);
-    return tpi->ts_monitor_callback(stepi, time, x);
+    tpi->ts_monitor_callback(stepi, time, x);
+    return 0;
 }
 
 Parameters
@@ -183,13 +184,12 @@ TransientProblemInterface::post_step()
     return 0;
 }
 
-PetscErrorCode
+void
 TransientProblemInterface::ts_monitor_callback(Int stepi, Real t, Vec x)
 {
     _F_;
     Real dt = get_time_step();
     this->problem->lprintf(6, "{} Time {:f} dt = {:f}", stepi, t, dt);
-    return 0;
 }
 
 void

--- a/test/src/BndJacobianFunc_test.cpp
+++ b/test/src/BndJacobianFunc_test.cpp
@@ -122,9 +122,9 @@ TEST(BndJacobianFuncTest, test)
 
     Int dim;
     EXPECT_CALL(prob, get_spatial_dimension()).Times(1).WillOnce(ReturnRef(dim));
-    FieldValue val;
+    FieldValue val(1);
     EXPECT_CALL(prob, get_field_value(_)).Times(1).WillOnce(ReturnRef(val));
-    FieldGradient grad(1);
+    FieldGradient grad(1, 1);
     EXPECT_CALL(prob, get_field_gradient(_)).Times(1).WillOnce(ReturnRef(grad));
     Real time;
     EXPECT_CALL(prob, get_assembly_time()).Times(1).WillOnce(ReturnRef(time));

--- a/test/src/BndResidualFunc_test.cpp
+++ b/test/src/BndResidualFunc_test.cpp
@@ -122,11 +122,11 @@ TEST(BndResidualFuncTest, test)
 
     Int dim;
     EXPECT_CALL(prob, get_spatial_dimension()).Times(1).WillOnce(ReturnRef(dim));
-    FieldValue val;
+    FieldValue val(1);
     EXPECT_CALL(prob, get_field_value(_)).Times(1).WillOnce(ReturnRef(val));
-    FieldGradient grad(1);
+    FieldGradient grad(1, 1);
     EXPECT_CALL(prob, get_field_gradient(_)).Times(1).WillOnce(ReturnRef(grad));
-    FieldValue dot;
+    FieldValue dot(1);
     EXPECT_CALL(prob, get_field_dot(_)).Times(1).WillOnce(ReturnRef(dot));
     Real time;
     EXPECT_CALL(prob, get_assembly_time()).Times(1).WillOnce(ReturnRef(time));

--- a/test/src/FEBoundary1D_test.cpp
+++ b/test/src/FEBoundary1D_test.cpp
@@ -18,7 +18,7 @@ points_from_label(const Label & label)
     return label.get_stratum(ids[0]);
 }
 
-}; // namespace
+} // namespace
 
 namespace {
 

--- a/test/src/FEBoundary2D_test.cpp
+++ b/test/src/FEBoundary2D_test.cpp
@@ -18,7 +18,7 @@ points_from_label(const Label & label)
     return label.get_stratum(ids[0]);
 }
 
-}; // namespace
+} // namespace
 
 namespace {
 

--- a/test/src/FEBoundary3D_test.cpp
+++ b/test/src/FEBoundary3D_test.cpp
@@ -17,7 +17,7 @@ points_from_label(const Label & label)
     return label.get_stratum(ids[0]);
 }
 
-}; // namespace
+} // namespace
 
 namespace {
 

--- a/test/src/JacobianFunc_test.cpp
+++ b/test/src/JacobianFunc_test.cpp
@@ -88,9 +88,9 @@ TEST(JacobianFuncTest, test)
 
     Int dim;
     EXPECT_CALL(prob, get_spatial_dimension()).Times(1).WillOnce(ReturnRef(dim));
-    FieldValue val;
+    FieldValue val(1);
     EXPECT_CALL(prob, get_field_value(_)).Times(1).WillOnce(ReturnRef(val));
-    FieldGradient grad(1);
+    FieldGradient grad(1, 1);
     EXPECT_CALL(prob, get_field_gradient(_)).Times(1).WillOnce(ReturnRef(grad));
     Real time;
     EXPECT_CALL(prob, get_assembly_time()).Times(1).WillOnce(ReturnRef(time));

--- a/test/src/ResidualFunc_test.cpp
+++ b/test/src/ResidualFunc_test.cpp
@@ -88,11 +88,11 @@ TEST(ResidualFuncTest, test)
 
     Int dim;
     EXPECT_CALL(prob, get_spatial_dimension()).Times(1).WillOnce(ReturnRef(dim));
-    FieldValue val;
+    FieldValue val(1);
     EXPECT_CALL(prob, get_field_value(_)).Times(1).WillOnce(ReturnRef(val));
-    FieldGradient grad(1);
+    FieldGradient grad(1, 1);
     EXPECT_CALL(prob, get_field_gradient(_)).Times(1).WillOnce(ReturnRef(grad));
-    FieldValue dot;
+    FieldValue dot(1);
     EXPECT_CALL(prob, get_field_dot(_)).Times(1).WillOnce(ReturnRef(dot));
     Real time;
     EXPECT_CALL(prob, get_assembly_time()).Times(1).WillOnce(ReturnRef(time));

--- a/test/src/Terminal_test.cpp
+++ b/test/src/Terminal_test.cpp
@@ -14,7 +14,7 @@ TEST(TerminalTest, colors)
     EXPECT_EQ(Terminal::has_colors(), false);
 
     Terminal::Color blk("\33[30m");
-    EXPECT_EQ(blk.str, "");
+    EXPECT_STREQ(blk, "");
 
     // restore
     Terminal::num_colors = nc;
@@ -24,13 +24,13 @@ TEST(TerminalTest, ostream_operator)
 {
     std::ostringstream oss;
     oss << Terminal::Color::red;
-    EXPECT_EQ(oss.str(), Terminal::Color::red.str);
+    EXPECT_STREQ(oss.str().c_str(), Terminal::Color::red);
 }
 
 TEST(TerminalTest, fmt_formatter)
 {
     std::string s = fmt::format("{}", Terminal::Color::red);
-    EXPECT_EQ(s, Terminal::Color::red.str);
+    EXPECT_STREQ(s.c_str(), Terminal::Color::red);
 }
 
 TEST(TerminalTest, color_codes)

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -125,7 +125,7 @@ public:
     std::vector<Real> dts;
 
 protected:
-    virtual PetscErrorCode ts_monitor_callback(Int stepi, Real time, Vec x);
+    virtual void ts_monitor_callback(Int stepi, Real time, Vec x);
 };
 
 REGISTER_OBJECT(TestTSProblem);
@@ -135,13 +135,12 @@ TestTSProblem::TestTSProblem(const Parameters & params) : GTestImplicitFENonline
     this->dts.resize(5);
 }
 
-PetscErrorCode
+void
 TestTSProblem::ts_monitor_callback(Int stepi, Real time, Vec x)
 {
     Real dt;
     PETSC_CHECK(TSGetTimeStep(this->ts, &dt));
     this->dts[stepi] = dt;
-    return 0;
 }
 
 ///


### PR DESCRIPTION
- Fixing empty declarations
- Refactoring in Terminal::Color
- clang-tidy fixes
- Fixing shadowing
- Fixing name collison between dt and dt initial
- Fixing unused parameters
- Monitor callbacks are functions returning void
- Removing interpolate variable
