### PR TITLE
Fixes suggested by clang-tidy, pt. 3

### DIFF
--- a/examples/advect-eqn/src/AdvectionEquation.cpp
+++ b/examples/advect-eqn/src/AdvectionEquation.cpp
@@ -78,6 +78,12 @@ AdvectionEquation::compute_flux(PetscInt dim,
                                 const PetscScalar constants[],
                                 PetscScalar flux[])
 {
+    GODZILLA_UNUSED(dim);
+    GODZILLA_UNUSED(nf);
+    GODZILLA_UNUSED(x);
+    GODZILLA_UNUSED(n_consts);
+    GODZILLA_UNUSED(constants);
+
     _F_;
     PetscReal wind[] = { 0.5 };
     PetscReal wn = 0;

--- a/examples/burgers-eqn/include/BurgersEquation.h
+++ b/examples/burgers-eqn/include/BurgersEquation.h
@@ -17,10 +17,9 @@ protected:
     void set_up_fields() override;
     void set_up_weak_form() override;
 
+    PetscInt u_id;
     const PetscReal & viscosity;
 
 public:
     static Parameters parameters();
-
-    static const PetscInt u_id = 0;
 };

--- a/examples/burgers-eqn/src/BurgersEquation.cpp
+++ b/examples/burgers-eqn/src/BurgersEquation.cpp
@@ -71,7 +71,7 @@ void
 BurgersEquation::set_up_fields()
 {
     _F_;
-    set_fe(u_id, "u", 1, 1);
+    u_id = add_fe("u", 1, 1);
 }
 
 void

--- a/examples/heat-eqn/include/HeatEquationExplicit.h
+++ b/examples/heat-eqn/include/HeatEquationExplicit.h
@@ -17,12 +17,11 @@ protected:
     void set_up_fields() override;
     void set_up_weak_form() override;
 
+    PetscInt temp_id;
+    PetscInt ffn_aux_id;
     /// Polynomial order of the FE space
     PetscInt order;
 
 public:
     static Parameters parameters();
-
-    static const PetscInt temp_id = 0;
-    static const PetscInt ffn_aux_id = 0;
 };

--- a/examples/heat-eqn/include/HeatEquationProblem.h
+++ b/examples/heat-eqn/include/HeatEquationProblem.h
@@ -14,15 +14,13 @@ protected:
     void set_up_fields() override;
     void set_up_weak_form() override;
 
+    PetscInt temp_id;
+    PetscInt q_ppp_id;
+    PetscInt htc_aux_id;
+    PetscInt T_ambient_aux_id;
     /// Polynomial order of the FE space
     const PetscInt & p_order;
 
 public:
     static Parameters parameters();
-
-    static const PetscInt temp_id = 0;
-
-    static const PetscInt q_ppp_id = 0;
-    static const PetscInt htc_aux_id = 1;
-    static const PetscInt T_ambient_aux_id = 2;
 };

--- a/examples/heat-eqn/src/HeatEquationExplicit.cpp
+++ b/examples/heat-eqn/src/HeatEquationExplicit.cpp
@@ -80,8 +80,8 @@ void
 HeatEquationExplicit::set_up_fields()
 {
     _F_;
-    set_fe(temp_id, "temp", 1, this->order);
-    set_aux_fe(ffn_aux_id, "forcing_fn", 1, this->order);
+    temp_id = add_fe("temp", 1, this->order);
+    ffn_aux_id = add_aux_fe("forcing_fn", 1, this->order);
 }
 
 void

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -110,11 +110,11 @@ void
 HeatEquationProblem::set_up_fields()
 {
     _F_;
-    set_fe(temp_id, "temp", 1, this->p_order);
+    temp_id = add_fe("temp", 1, this->p_order);
 
-    set_aux_fe(q_ppp_id, "q_ppp", 1, 0);
-    set_aux_fe(htc_aux_id, "htc", 1, this->p_order);
-    set_aux_fe(T_ambient_aux_id, "T_ambient", 1, this->p_order);
+    q_ppp_id = add_aux_fe("q_ppp", 1, 0);
+    htc_aux_id = add_aux_fe("htc", 1, this->p_order);
+    T_ambient_aux_id = add_aux_fe("T_ambient", 1, this->p_order);
 }
 
 void

--- a/examples/ns-incomp/include/NSIncompressibleProblem.h
+++ b/examples/ns-incomp/include/NSIncompressibleProblem.h
@@ -19,14 +19,12 @@ protected:
     void set_up_field_null_space(DM dm) override;
     void set_up_preconditioning() override;
 
+    PetscInt velocity_id;
+    PetscInt pressure_id;
+    PetscInt ffn_aid;
     /// Reynolds number
     const PetscReal & Re;
 
 public:
     static Parameters parameters();
-
-    static const PetscInt velocity_id = 0;
-    static const PetscInt pressure_id = 1;
-
-    static const PetscInt ffn_aid = 0;
 };

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -289,12 +289,12 @@ NSIncompressibleProblem::set_up_fields()
     const char * comp_name[] = { "velocity_x", "velocity_y", "velocity_z" };
 
     PetscInt dim = this->get_dimension();
-    set_fe(velocity_id, "velocity", dim, 2);
+    velocity_id = add_fe("velocity", dim, 2);
     for (unsigned int i = 0; i < dim; i++)
         set_field_component_name(velocity_id, i, comp_name[i]);
-    set_fe(pressure_id, "pressure", 1, 1);
+    pressure_id = add_fe("pressure", 1, 1);
 
-    set_aux_fe(ffn_aid, "ffn", dim, 2);
+    ffn_aid = add_aux_fe("ffn", dim, 2);
 }
 
 void

--- a/examples/poisson/include/PoissonEquation.h
+++ b/examples/poisson/include/PoissonEquation.h
@@ -17,12 +17,10 @@ protected:
 
     /// Polynomial order of the FE space
     PetscInt p_order;
-
     /// ID for the "u" field
-    const PetscInt iu;
-
+    PetscInt iu;
     /// ID for the forcing function field
-    const PetscInt affn;
+    PetscInt affn;
 
 public:
     static Parameters parameters();

--- a/examples/poisson/src/PoissonEquation.cpp
+++ b/examples/poisson/src/PoissonEquation.cpp
@@ -20,9 +20,7 @@ PoissonEquation::parameters()
 
 PoissonEquation::PoissonEquation(const Parameters & parameters) :
     FENonlinearProblem(parameters),
-    p_order(get_param<PetscInt>("p_order")),
-    iu(0),
-    affn(0)
+    p_order(get_param<PetscInt>("p_order"))
 {
     _F_;
 }
@@ -33,8 +31,8 @@ void
 PoissonEquation::set_up_fields()
 {
     _F_;
-    set_fe(this->iu, "u", 1, this->p_order);
-    set_aux_fe(this->affn, "forcing_fn", 1, this->p_order);
+    this->iu = add_fe("u", 1, this->p_order);
+    this->affn = add_aux_fe("forcing_fn", 1, this->p_order);
 }
 
 void

--- a/include/Array1D.h
+++ b/include/Array1D.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "GodzillaConfig.h"
 #include "Types.h"
 #include "Error.h"
 #include <cassert>
@@ -174,6 +175,9 @@ public:
     void
     axpy(Real alpha, const Array1D<T> & x) const
     {
+        GODZILLA_UNUSED(alpha);
+        GODZILLA_UNUSED(x);
+
         error("AXPY not implemented");
     }
 
@@ -184,6 +188,8 @@ public:
     T
     dot(const Array1D<T> & a) const
     {
+        GODZILLA_UNUSED(a);
+
         error("Dot product not implemented");
     }
 

--- a/include/FEGeometry.h
+++ b/include/FEGeometry.h
@@ -71,6 +71,10 @@ template <ElementType ELEM_TYPE, Int DIM>
 inline DenseVector<Real, DIM>
 normal(Real volume, Real edge_len, const DenseVector<Real, DIM> & grad)
 {
+    GODZILLA_UNUSED(volume);
+    GODZILLA_UNUSED(edge_len);
+    GODZILLA_UNUSED(grad);
+
     _F_;
     error("Computation of a normal for element '{}' in {} dimensions is not implemented.",
           get_element_type_str(ELEM_TYPE),
@@ -81,6 +85,8 @@ template <>
 inline DenseVector<Real, 1>
 normal<EDGE2, 1>(Real volume, Real edge_len, const DenseVector<Real, 1> & grad)
 {
+    GODZILLA_UNUSED(edge_len);
+
     return -volume * grad;
 }
 
@@ -97,6 +103,8 @@ template <ElementType ELEM_TYPE, Int DIM, Int N_ELEM_NODES = get_num_element_nod
 inline Real
 element_length(const DenseVector<DenseVector<Real, DIM>, N_ELEM_NODES> & grad_phi)
 {
+    GODZILLA_UNUSED(grad_phi);
+
     _F_;
     error("Computation of a element length for '{}' in {} dimensions is not implemented.",
           get_element_type_str(ELEM_TYPE),
@@ -140,6 +148,8 @@ template <CoordinateType COORD_TYPE, Int DIM>
 inline Array1D<Real>
 calc_nodal_radius(Array1D<DenseVector<Real, DIM>> & coords)
 {
+    GODZILLA_UNUSED(coords);
+
     error("Radius computation is not implemented in {} dimensions.", DIM);
 }
 

--- a/include/FEMatrices.h
+++ b/include/FEMatrices.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "GodzillaConfig.h"
 #include "Types.h"
 #include "Error.h"
 #include "DenseVector.h"
@@ -78,6 +79,9 @@ template <ElementType ETYPE, Int N_ELEM_NODES = get_num_element_nodes(ETYPE)>
 inline DenseMatrixSymm<Real, N_ELEM_NODES>
 mass_rz(Real rad_e, const DenseVector<Real, N_ELEM_NODES> & rad_n)
 {
+    GODZILLA_UNUSED(rad_e);
+    GODZILLA_UNUSED(rad_n);
+
     error("Mass matrix (RZ) in not implemented for {}.", get_element_type_str(ETYPE));
 }
 
@@ -162,6 +166,8 @@ template <ElementType ETYPE, Int N_ELEM_NODES = get_num_element_nodes(ETYPE)>
 inline DenseMatrixSymm<Real, N_ELEM_NODES>
 mass_lumped_rz(const DenseVector<Real, N_ELEM_NODES> & rad_n)
 {
+    GODZILLA_UNUSED(rad_n);
+
     error("Mass matrix (RZ) in not implemented for {}.", get_element_type_str(ETYPE));
 }
 
@@ -283,6 +289,8 @@ template <ElementType ELEM_TYPE, Int N_BND_NODES>
 inline DenseMatrix<Real, N_BND_NODES>
 bnd_rz(const DenseVector<Real, N_BND_NODES> & radii)
 {
+    GODZILLA_UNUSED(radii);
+
     error("Not implemented.");
 }
 
@@ -290,6 +298,8 @@ template <>
 inline DenseMatrix<Real, 1>
 bnd_rz<EDGE2, 1>(const DenseVector<Real, 1> & radius)
 {
+    GODZILLA_UNUSED(radius);
+
     DenseMatrix<Real, 1> bi;
     bi(0, 0) = 1.;
     return bi;

--- a/include/FEShapeFns.h
+++ b/include/FEShapeFns.h
@@ -22,6 +22,9 @@ template <ElementType ELEM_TYPE, int DIM, Int N_ELEM_NODES = get_num_element_nod
 inline DenseVector<DenseVector<Real, DIM>, N_ELEM_NODES>
 grad_shape(const DenseVector<DenseVector<Real, DIM>, N_ELEM_NODES> & coords, Real volume)
 {
+    GODZILLA_UNUSED(coords);
+    GODZILLA_UNUSED(volume);
+
     error("Calculation of shape function gradients is not implemented for element '{}' yet.",
           get_element_type_str(ELEM_TYPE));
 }
@@ -31,6 +34,8 @@ template <>
 inline DenseVector<DenseVector<Real, 1>, 2>
 grad_shape<EDGE2, 1>(const DenseVector<DenseVector<Real, 1>, 2> & coords, Real volume)
 {
+    GODZILLA_UNUSED(coords);
+
     _F_;
     Real c = 1 / volume;
     DenseVector<DenseVector<Real, 1>, 2> grads;

--- a/include/FEVolumes.h
+++ b/include/FEVolumes.h
@@ -13,6 +13,8 @@ template <ElementType ELEM_TYPE, Int DIM, Int N_ELEM_NODES = get_num_element_nod
 Real
 volume(const DenseVector<DenseVector<Real, DIM>, N_ELEM_NODES> & coords)
 {
+    GODZILLA_UNUSED(coords);
+
     _F_;
     error("Volume calculation for {} in {} dimensions is not implemented.",
           get_element_type_str(ELEM_TYPE),
@@ -126,6 +128,8 @@ template <ElementType ELEM_TYPE, Int DIM, Int N_ELEM_NODES = get_num_element_nod
 Real
 face_area(const DenseVector<DenseVector<Real, DIM>, N_ELEM_NODES> & coords)
 {
+    GODZILLA_UNUSED(coords);
+
     _F_;
     error("Face area calculation for {} in {} dimensions is not implemented.",
           get_element_type_str(ELEM_TYPE),
@@ -136,6 +140,8 @@ template <>
 inline Real
 face_area<EDGE2, 1>(const DenseVector<DenseVector<Real, 1>, 1> & coords)
 {
+    GODZILLA_UNUSED(coords);
+
     return 1.;
 }
 

--- a/include/GodzillaConfig.h.in
+++ b/include/GodzillaConfig.h.in
@@ -7,3 +7,7 @@
 #cmakedefine GODZILLA_WITH_PERF_LOG
 
 #define GODZILLA_UNIT_TESTS_ROOT "@GODZILLA_UNIT_TESTS_ROOT@"
+
+#define GODZILLA_UNUSED_STRINGIFY(param_string_literal) #param_string_literal
+#define GODZILLA_UNUSED_VAR(param) _Pragma(GODZILLA_UNUSED_STRINGIFY(unused(#param)))
+#define GODZILLA_UNUSED(x) (void)(x)

--- a/include/mpi/Communicator.h
+++ b/include/mpi/Communicator.h
@@ -2,6 +2,7 @@
 
 #include <mpi.h>
 #include <vector>
+#include "GodzillaConfig.h"
 #include "Datatype.h"
 #include "Status.h"
 #include "Request.h"
@@ -229,6 +230,8 @@ template <typename T>
 Request
 Communicator::isend(int dest, int tag, const T * values, int n) const
 {
+    GODZILLA_UNUSED(n);
+
     assert(values != nullptr);
     MPI_Request request;
     MPI_CHECK(MPI_Isend(const_cast<T *>(values),

--- a/include/mpi/Communicator.h
+++ b/include/mpi/Communicator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <mpi.h>
+#include "mpi.h"
 #include <vector>
 #include "GodzillaConfig.h"
 #include "Datatype.h"

--- a/test/src/CallStack_test.cpp
+++ b/test/src/CallStack_test.cpp
@@ -7,7 +7,7 @@ void
 segfault()
 {
     volatile int * x = nullptr;
-    int a = *x;
+    int a = *x; // NOLINT
 }
 
 TEST(CallStackTest, abort)


### PR DESCRIPTION
- Skip linting
- Marking unused arguments
- Examples: use member variables for field ids
