### PR TITLE
Removing DiscreteProblemInterface::get_coordinates_local

### DIFF
--- a/include/DiscreteProblemInterface.h
+++ b/include/DiscreteProblemInterface.h
@@ -216,11 +216,6 @@ public:
     /// @return The offset
     Int get_aux_field_dof(Int point, Int fid) const;
 
-    /// Gets a local vector with the coordinates associated with this problem's mesh
-    ///
-    /// @return coordinate vector
-    Vector get_coordinates_local() const;
-
     /// Get local solution vector
     ///
     /// @return Local solution vector

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -302,16 +302,6 @@ DiscreteProblemInterface::get_aux_field_dof(Int point, Int fid) const
     return offset;
 }
 
-Vector
-DiscreteProblemInterface::get_coordinates_local() const
-{
-    _F_;
-    DM dm = this->unstr_mesh->get_dm();
-    Vec coord;
-    PETSC_CHECK(DMGetCoordinatesLocal(dm, &coord));
-    return Vector(coord);
-}
-
 void
 DiscreteProblemInterface::add_boundary(DMBoundaryConditionType type,
                                        const std::string & name,

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -247,7 +247,7 @@ ExodusIIOutput::write_coords(int exo_dim)
 {
     _F_;
     int dim = (int) this->mesh->get_dimension();
-    Vector coord = this->dpi->get_coordinates_local();
+    Vector coord = this->mesh->get_coordinates_local();
     Int coord_size = coord.get_size();
     Scalar * xyz = coord.get_array();
 

--- a/src/TecplotOutput.cpp
+++ b/src/TecplotOutput.cpp
@@ -386,7 +386,7 @@ TecplotOutput::write_coordinates_ascii()
 {
     _F_;
     auto dim = this->mesh->get_dimension();
-    auto coord = this->dpi->get_coordinates_local();
+    auto coord = this->mesh->get_coordinates_local();
     auto xyz = coord.get_array_read();
     auto n_coords = coord.get_size() / dim;
     for (Int d = 0; d < dim; d++) {


### PR DESCRIPTION
This is in Mesh, so we use it via the Mesh API
