### PR TITLE
ExodusIIOutput can work without a problem class

### DIFF
--- a/include/ExodusIIOutput.h
+++ b/include/ExodusIIOutput.h
@@ -34,6 +34,7 @@ public:
     void set_file_name() override;
     void create() override;
     void check() override;
+    void output_mesh();
     void output_step() override;
 
 protected:

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -184,11 +184,9 @@ TEST(ExodusIIOutputTest, fe_check)
     out.check();
     app.check_integrity();
 
-    EXPECT_THAT(
-        testing::internal::GetCapturedStderr(),
-        testing::AllOf(
-            testing::HasSubstr("ExodusII output can be only used with unstructured meshes."),
-            testing::HasSubstr("ExodusII output can be only used with finite element problems.")));
+    EXPECT_THAT(testing::internal::GetCapturedStderr(),
+                testing::AllOf(testing::HasSubstr(
+                    "ExodusII output can be only used with unstructured meshes.")));
 }
 
 TEST(ExodusIIOutputTest, output)


### PR DESCRIPTION
If `_problem` parameter is `nullptr`, then `_mesh` parameter can be specified
and the output class can work with just meshes. That means no variable output
can be done, but mesh only output is possible.
