### PR TITLE
InitialCondition::get_{vector_}value can accept coordinates as a `const Real *`

### DIFF
--- a/include/InitialCondition.h
+++ b/include/InitialCondition.h
@@ -45,6 +45,15 @@ public:
     template <Int DIM>
     Real get_value(Real time, const DenseVector<Real, DIM> & x);
 
+    /// Evaluate the initial condition
+    ///
+    /// @tparam DIM The spatial dimension
+    /// @param time The time at which to sample
+    /// @param x The coordinates
+    /// @return The value of the initial condition
+    template <Int DIM>
+    Real get_value(Real time, const Real * x);
+
     /// Evaluate the initial condition (vector-valued version)
     ///
     /// @tparam N The number of components
@@ -54,6 +63,16 @@ public:
     /// @return The value of the initial condition
     template <Int N, Int DIM>
     DenseVector<Real, N> get_vector_value(Real time, const DenseVector<Real, DIM> & x);
+
+    /// Evaluate the initial condition (vector-valued version)
+    ///
+    /// @tparam N The number of components
+    /// @tparam DIM The spatial dimension
+    /// @param time The time at which to sample
+    /// @param x The coordinates
+    /// @return The value of the initial condition
+    template <Int N, Int DIM>
+    DenseVector<Real, N> get_vector_value(Real time, const Real * x);
 
 protected:
     /// Discrete problem this object is part of
@@ -78,12 +97,30 @@ InitialCondition::get_value(Real time, const DenseVector<Real, DIM> & x)
     return val;
 }
 
+template <Int DIM>
+inline Real
+InitialCondition::get_value(Real time, const Real * x)
+{
+    Real val;
+    evaluate(DIM, time, x, 1, &val);
+    return val;
+}
+
 template <Int N, Int DIM>
 inline DenseVector<Real, N>
 InitialCondition::get_vector_value(Real time, const DenseVector<Real, DIM> & x)
 {
     DenseVector<Real, N> val;
     evaluate(DIM, time, x.data(), N, val.data());
+    return val;
+}
+
+template <Int N, Int DIM>
+inline DenseVector<Real, N>
+InitialCondition::get_vector_value(Real time, const Real * x)
+{
+    DenseVector<Real, N> val;
+    evaluate(DIM, time, x, N, val.data());
     return val;
 }
 

--- a/test/src/InitialCondition_test.cpp
+++ b/test/src/InitialCondition_test.cpp
@@ -145,8 +145,14 @@ TEST_F(InitialConditionTest, get_value)
     params.set<std::string>("_name") = "obj";
     TestInitialCondition ic(params);
 
-    DenseVector<Real, 1> x({ 1. });
-    EXPECT_EQ(ic.get_value(2., x), 22.);
+    {
+        DenseVector<Real, 1> x({ 1. });
+        EXPECT_EQ(ic.get_value(2., x), 22.);
+    }
+    {
+        Real x[1] = { 1. };
+        EXPECT_EQ(ic.get_value<1>(2., x), 22.);
+    }
 }
 
 TEST_F(InitialConditionTest, get_vector_value)
@@ -157,10 +163,18 @@ TEST_F(InitialConditionTest, get_vector_value)
     params.set<std::string>("_name") = "obj";
     TestVectorInitialCondition ic(params);
 
-    DenseVector<Real, 1> x({ 1. });
-    DenseVector<Real, 2> u = ic.get_vector_value<2>(2., x);
-    EXPECT_EQ(u(0), 12.);
-    EXPECT_EQ(u(1), 3.);
+    {
+        DenseVector<Real, 1> x({ 1. });
+        DenseVector<Real, 2> u = ic.get_vector_value<2>(2., x);
+        EXPECT_EQ(u(0), 12.);
+        EXPECT_EQ(u(1), 3.);
+    }
+    {
+        Real x[1] = { 1. };
+        DenseVector<Real, 2> u = ic.get_vector_value<2, 1>(2., x);
+        EXPECT_EQ(u(0), 12.);
+        EXPECT_EQ(u(1), 3.);
+    }
 }
 
 TEST_F(InitialConditionTest, duplicate_ic_name)


### PR DESCRIPTION
Coordinates can be obtained directly from PETSc, and they would come out as a
`const Real *`, so we should be able to use them directly in our objects.
