### PR TITLE
FEBoundary refactoring

### DIFF
--- a/include/FEVolumes.h
+++ b/include/FEVolumes.h
@@ -4,6 +4,7 @@
 #include "Types.h"
 #include "Array1D.h"
 #include "DenseVector.h"
+#include "DenseMatrix.h"
 
 namespace godzilla {
 
@@ -124,9 +125,9 @@ calc_volumes(const Array1D<DenseVector<Real, DIM>> & coords,
 
 //
 
-template <ElementType ELEM_TYPE, Int DIM, Int N_ELEM_NODES = get_num_element_nodes(ELEM_TYPE)>
+template <ElementType ELEM_TYPE, Int DIM, Int N_FACE_NODES>
 Real
-face_area(const DenseVector<DenseVector<Real, DIM>, N_ELEM_NODES> & coords)
+face_area(const DenseMatrix<Real, N_FACE_NODES, DIM> & coords)
 {
     GODZILLA_UNUSED(coords);
 
@@ -138,7 +139,7 @@ face_area(const DenseVector<DenseVector<Real, DIM>, N_ELEM_NODES> & coords)
 
 template <>
 inline Real
-face_area<EDGE2, 1>(const DenseVector<DenseVector<Real, 1>, 1> & coords)
+face_area<EDGE2, 1>(const DenseMatrix<Real, 1, 1> & coords)
 {
     GODZILLA_UNUSED(coords);
 
@@ -147,11 +148,11 @@ face_area<EDGE2, 1>(const DenseVector<DenseVector<Real, 1>, 1> & coords)
 
 template <>
 inline Real
-face_area<TRI3, 2>(const DenseVector<DenseVector<Real, 2>, 2> & coords)
+face_area<TRI3, 2>(const DenseMatrix<Real, 2, 2> & coords)
 {
     DenseVector<Real, 2> v;
-    v(0) = coords(0)(0) - coords(1)(0);
-    v(1) = coords(0)(1) - coords(1)(1);
+    v(0) = coords(0, 0) - coords(1, 0);
+    v(1) = coords(0, 1) - coords(1, 1);
     return v.magnitude();
 }
 

--- a/include/UnstructuredMesh.h
+++ b/include/UnstructuredMesh.h
@@ -338,7 +338,7 @@ public:
     /// Compute a map of cells common to a vertex
     ///
     /// @return A mapping [vertex index -> list of cell indices]
-    std::map<Int, std::vector<Int>> common_cells_by_vertex() const;
+    const std::map<Int, std::vector<Int>> & common_cells_by_vertex();
 
 protected:
     /// Method that builds DM for the mesh
@@ -367,6 +367,11 @@ protected:
 
     /// Face set IDs
     std::map<std::string, Int> face_set_ids;
+
+    /// Cells common to a vertex
+    std::map<Int, std::vector<Int>> common_cells_by_vtx;
+    /// Flag indicating if `common_cells_by_vtx` was computed
+    bool common_cells_by_vtx_computed;
 
 public:
     static Parameters parameters();

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <typeinfo>
 #include <petsclog.h>
+#include "fmt/printf.h"
 
 namespace godzilla {
 namespace utils {
@@ -76,6 +77,26 @@ map_values(const std::map<T, U> & m)
 /// @param time Time in seconds
 /// @return Formatted string with human readable time
 std::string human_time(PetscLogDouble time);
+
+/// Get index of an value in a std::vector
+///
+/// @tparam T Type
+/// @param array Array of values
+/// @param value The value we are looking for
+/// @return Index in the array
+///
+/// NOTE:
+/// 1. This function will find only the first value, so make sure that `array` does not have
+///    duplicates unless you are really looking for just the first one.
+template <typename T>
+std::size_t
+index_of(const std::vector<T> & array, T value)
+{
+    for (std::size_t i = 0; i < array.size(); i++)
+        if (array[i] == value)
+            return i;
+    throw std::runtime_error(fmt::format("Did not find {} in array", value));
+}
 
 } // namespace utils
 } // namespace godzilla

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -53,7 +53,8 @@ UnstructuredMesh::parameters()
 
 UnstructuredMesh::UnstructuredMesh(const Parameters & parameters) :
     Mesh(parameters),
-    partition_overlap(0)
+    partition_overlap(0),
+    common_cells_by_vtx_computed(false)
 {
     _F_;
     this->partitioner.create(comm());
@@ -527,17 +528,18 @@ UnstructuredMesh::cell_end() const
     return Iterator(idx);
 }
 
-std::map<Int, std::vector<Int>>
-UnstructuredMesh::common_cells_by_vertex() const
+const std::map<Int, std::vector<Int>> &
+UnstructuredMesh::common_cells_by_vertex()
 {
     _F_;
-    std::map<Int, std::vector<Int>> map;
-    for (auto & cell : get_cell_range()) {
-        auto connect = get_connectivity(cell);
-        for (auto & vtx : connect)
-            map[vtx].push_back(cell);
+    if (!this->common_cells_by_vtx_computed) {
+        for (auto & cell : get_cell_range()) {
+            auto connect = get_connectivity(cell);
+            for (auto & vtx : connect)
+                this->common_cells_by_vtx[vtx].push_back(cell);
+        }
     }
-    return map;
+    return this->common_cells_by_vtx;
 }
 
 void

--- a/test/src/FEBoundary1D_test.cpp
+++ b/test/src/FEBoundary1D_test.cpp
@@ -69,10 +69,9 @@ public:
 class TestBoundary1D : public fe::BoundaryInfo<EDGE2, 1, 2> {
 public:
     TestBoundary1D(UnstructuredMesh * mesh,
-                   const Array1D<Real> * fe_volume,
                    const Array1D<DenseMatrix<Real, 2, 1>> * grad_phi,
                    const IndexSet & facets) :
-        fe::BoundaryInfo<EDGE2, 1, 2>(mesh, fe_volume, grad_phi, facets)
+        fe::BoundaryInfo<EDGE2, 1, 2>(mesh, grad_phi, facets)
     {
     }
 
@@ -117,7 +116,7 @@ TEST(FEBoundaryTest, nodal_normals_1d)
 
     {
         IndexSet bnd_facets = points_from_label(mesh.get_label("left"));
-        TestBoundary1D bnd(&mesh, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary1D bnd(&mesh, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), -1);
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(0)(0), -1);
@@ -127,7 +126,7 @@ TEST(FEBoundaryTest, nodal_normals_1d)
 
     {
         IndexSet bnd_facets = points_from_label(mesh.get_label("right"));
-        TestBoundary1D bnd(&mesh, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary1D bnd(&mesh, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 1);
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(0)(0), 1);

--- a/test/src/FEBoundary1D_test.cpp
+++ b/test/src/FEBoundary1D_test.cpp
@@ -69,11 +69,10 @@ public:
 class TestBoundary1D : public fe::BoundaryInfo<EDGE2, 1, 2> {
 public:
     TestBoundary1D(UnstructuredMesh * mesh,
-                   const Array1D<DenseVector<Real, 1>> * coords,
                    const Array1D<Real> * fe_volume,
                    const Array1D<DenseMatrix<Real, 2, 1>> * grad_phi,
                    const IndexSet & facets) :
-        fe::BoundaryInfo<EDGE2, 1, 2>(mesh, coords, fe_volume, grad_phi, facets)
+        fe::BoundaryInfo<EDGE2, 1, 2>(mesh, fe_volume, grad_phi, facets)
     {
     }
 
@@ -118,19 +117,21 @@ TEST(FEBoundaryTest, nodal_normals_1d)
 
     {
         IndexSet bnd_facets = points_from_label(mesh.get_label("left"));
-        TestBoundary1D bnd(&mesh, &coords, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary1D bnd(&mesh, &fe_volume, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), -1);
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(0)(0), -1);
+        EXPECT_DOUBLE_EQ(bnd.length(0), 1.);
         bnd.destroy();
     }
 
     {
         IndexSet bnd_facets = points_from_label(mesh.get_label("right"));
-        TestBoundary1D bnd(&mesh, &coords, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary1D bnd(&mesh, &fe_volume, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 1);
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(0)(0), 1);
+        EXPECT_DOUBLE_EQ(bnd.length(0), 1.);
         bnd.destroy();
     }
 }

--- a/test/src/FEBoundary1D_test.cpp
+++ b/test/src/FEBoundary1D_test.cpp
@@ -37,7 +37,7 @@ protected:
         build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
 
         // create "side sets"
-        DMLabel face_sets = create_label("Face Sets");
+        auto face_sets = create_label("Face Sets");
 
         create_side_set(face_sets, 1, { 2 }, "left");
         create_side_set(face_sets, 2, { 4 }, "right");
@@ -51,13 +51,13 @@ protected:
     }
 
     void
-    create_side_set(const DMLabel & face_sets,
+    create_side_set(Label & face_sets,
                     Int id,
                     const std::vector<Int> & faces,
                     const char * name)
     {
         for (auto & f : faces) {
-            PETSC_CHECK(DMLabelSetValue(face_sets, f, id));
+            face_sets.set_value(f, id);
             PETSC_CHECK(DMSetLabelValue(dm(), name, f, id));
         }
     }

--- a/test/src/FEBoundary1D_test.cpp
+++ b/test/src/FEBoundary1D_test.cpp
@@ -68,14 +68,12 @@ public:
 
 class TestBoundary1D : public fe::BoundaryInfo<EDGE2, 1, 2> {
 public:
-    TestBoundary1D(const UnstructuredMesh * mesh,
+    TestBoundary1D(UnstructuredMesh * mesh,
                    const Array1D<DenseVector<Real, 1>> * coords,
-                   const Array1D<DenseVector<Int, 2>> * connect,
-                   const Array1D<std::vector<Int>> * nelcom,
                    const Array1D<Real> * fe_volume,
                    const Array1D<DenseMatrix<Real, 2, 1>> * grad_phi,
                    const IndexSet & facets) :
-        fe::BoundaryInfo<EDGE2, 1, 2>(mesh, coords, connect, nelcom, fe_volume, grad_phi, facets)
+        fe::BoundaryInfo<EDGE2, 1, 2>(mesh, coords, fe_volume, grad_phi, facets)
     {
     }
 
@@ -118,15 +116,9 @@ TEST(FEBoundaryTest, nodal_normals_1d)
     auto fe_volume = fe::calc_volumes<EDGE2, 1>(coords, connect);
     auto grad_phi = fe::calc_grad_shape<EDGE2, 1>(coords, connect, fe_volume);
 
-    auto n_nodes = mesh.get_num_vertices();
-
-    Array1D<std::vector<Int>> nelcom;
-    nelcom.create(n_nodes);
-    fe::common_elements_by_node(connect, nelcom);
-
     {
         IndexSet bnd_facets = points_from_label(mesh.get_label("left"));
-        TestBoundary1D bnd(&mesh, &coords, &connect, &nelcom, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary1D bnd(&mesh, &coords, &fe_volume, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), -1);
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(0)(0), -1);
@@ -135,7 +127,7 @@ TEST(FEBoundaryTest, nodal_normals_1d)
 
     {
         IndexSet bnd_facets = points_from_label(mesh.get_label("right"));
-        TestBoundary1D bnd(&mesh, &coords, &connect, &nelcom, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary1D bnd(&mesh, &coords, &fe_volume, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 1);
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(0)(0), 1);

--- a/test/src/FEBoundary2D_test.cpp
+++ b/test/src/FEBoundary2D_test.cpp
@@ -70,14 +70,12 @@ public:
 
 class TestBoundary2D : public fe::BoundaryInfo<TRI3, 2, 3> {
 public:
-    TestBoundary2D(const UnstructuredMesh * mesh,
+    TestBoundary2D(UnstructuredMesh * mesh,
                    const Array1D<DenseVector<Real, 2>> * coords,
-                   const Array1D<DenseVector<Int, 3>> * connect,
-                   const Array1D<std::vector<Int>> * nelcom,
                    const Array1D<Real> * fe_volume,
                    const Array1D<DenseMatrix<Real, 3, 2>> * grad_phi,
                    const IndexSet & facets) :
-        fe::BoundaryInfo<TRI3, 2, 3>(mesh, coords, connect, nelcom, fe_volume, grad_phi, facets)
+        fe::BoundaryInfo<TRI3, 2, 3>(mesh, coords, fe_volume, grad_phi, facets)
     {
     }
 
@@ -120,16 +118,10 @@ TEST(FEBoundaryTest, nodal_normals_2d)
     auto fe_volume = fe::calc_volumes<TRI3, 2>(coords, connect);
     auto grad_phi = fe::calc_grad_shape<TRI3, 2>(coords, connect, fe_volume);
 
-    auto n_nodes = mesh.get_num_vertices();
-
-    Array1D<std::vector<Int>> nelcom;
-    nelcom.create(n_nodes);
-    fe::common_elements_by_node(connect, nelcom);
-
     {
         auto label = mesh.get_label("left");
         IndexSet bnd_facets = points_from_label(label);
-        TestBoundary2D bnd(&mesh, &coords, &connect, &nelcom, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary2D bnd(&mesh, &coords, &fe_volume, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), -1);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(1), 0);
@@ -145,7 +137,7 @@ TEST(FEBoundaryTest, nodal_normals_2d)
     {
         auto label = mesh.get_label("bottom");
         IndexSet bnd_facets = points_from_label(label);
-        TestBoundary2D bnd(&mesh, &coords, &connect, &nelcom, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary2D bnd(&mesh, &coords, &fe_volume, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 0);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(1), -1);
@@ -161,7 +153,7 @@ TEST(FEBoundaryTest, nodal_normals_2d)
     {
         auto label = mesh.get_label("top_right");
         IndexSet bnd_facets = points_from_label(label);
-        TestBoundary2D bnd(&mesh, &coords, &connect, &nelcom, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary2D bnd(&mesh, &coords, &fe_volume, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 1);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(1), 0);

--- a/test/src/FEBoundary2D_test.cpp
+++ b/test/src/FEBoundary2D_test.cpp
@@ -37,7 +37,7 @@ protected:
         build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
 
         // create "side sets"
-        DMLabel face_sets = create_label("Face Sets");
+        auto face_sets = create_label("Face Sets");
 
         create_side_set(face_sets, 1, { 8 }, "left");
         create_side_set(face_sets, 2, { 6 }, "bottom");
@@ -53,13 +53,13 @@ protected:
     }
 
     void
-    create_side_set(const DMLabel & face_sets,
+    create_side_set(Label & face_sets,
                     Int id,
                     const std::vector<Int> & faces,
                     const char * name)
     {
         for (auto & f : faces) {
-            PETSC_CHECK(DMLabelSetValue(face_sets, f, id));
+            face_sets.set_value(f, id);
             PETSC_CHECK(DMSetLabelValue(dm(), name, f, id));
         }
     }

--- a/test/src/FEBoundary2D_test.cpp
+++ b/test/src/FEBoundary2D_test.cpp
@@ -71,11 +71,10 @@ public:
 class TestBoundary2D : public fe::BoundaryInfo<TRI3, 2, 3> {
 public:
     TestBoundary2D(UnstructuredMesh * mesh,
-                   const Array1D<DenseVector<Real, 2>> * coords,
                    const Array1D<Real> * fe_volume,
                    const Array1D<DenseMatrix<Real, 3, 2>> * grad_phi,
                    const IndexSet & facets) :
-        fe::BoundaryInfo<TRI3, 2, 3>(mesh, coords, fe_volume, grad_phi, facets)
+        fe::BoundaryInfo<TRI3, 2, 3>(mesh, fe_volume, grad_phi, facets)
     {
     }
 
@@ -121,7 +120,7 @@ TEST(FEBoundaryTest, nodal_normals_2d)
     {
         auto label = mesh.get_label("left");
         IndexSet bnd_facets = points_from_label(label);
-        TestBoundary2D bnd(&mesh, &coords, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary2D bnd(&mesh, &fe_volume, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), -1);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(1), 0);
@@ -131,13 +130,16 @@ TEST(FEBoundaryTest, nodal_normals_2d)
 
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(1)(0), -1);
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(1)(1), 0);
+
+        EXPECT_DOUBLE_EQ(bnd.length(0), 1.);
+
         bnd.destroy();
     }
 
     {
         auto label = mesh.get_label("bottom");
         IndexSet bnd_facets = points_from_label(label);
-        TestBoundary2D bnd(&mesh, &coords, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary2D bnd(&mesh, &fe_volume, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 0);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(1), -1);
@@ -147,13 +149,16 @@ TEST(FEBoundaryTest, nodal_normals_2d)
 
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(1)(0), 0);
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(1)(1), -1);
+
+        EXPECT_DOUBLE_EQ(bnd.length(0), 1.);
+
         bnd.destroy();
     }
 
     {
         auto label = mesh.get_label("top_right");
         IndexSet bnd_facets = points_from_label(label);
-        TestBoundary2D bnd(&mesh, &coords, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary2D bnd(&mesh, &fe_volume, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 1);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(1), 0);
@@ -169,6 +174,10 @@ TEST(FEBoundaryTest, nodal_normals_2d)
 
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(2)(0), 1. / std::sqrt(2));
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(2)(1), 1. / std::sqrt(2));
+
+        EXPECT_DOUBLE_EQ(bnd.length(0), 1.);
+        EXPECT_DOUBLE_EQ(bnd.length(1), 1.);
+
         bnd.destroy();
     }
 }

--- a/test/src/FEBoundary2D_test.cpp
+++ b/test/src/FEBoundary2D_test.cpp
@@ -71,10 +71,9 @@ public:
 class TestBoundary2D : public fe::BoundaryInfo<TRI3, 2, 3> {
 public:
     TestBoundary2D(UnstructuredMesh * mesh,
-                   const Array1D<Real> * fe_volume,
                    const Array1D<DenseMatrix<Real, 3, 2>> * grad_phi,
                    const IndexSet & facets) :
-        fe::BoundaryInfo<TRI3, 2, 3>(mesh, fe_volume, grad_phi, facets)
+        fe::BoundaryInfo<TRI3, 2, 3>(mesh, grad_phi, facets)
     {
     }
 
@@ -120,7 +119,7 @@ TEST(FEBoundaryTest, nodal_normals_2d)
     {
         auto label = mesh.get_label("left");
         IndexSet bnd_facets = points_from_label(label);
-        TestBoundary2D bnd(&mesh, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary2D bnd(&mesh, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), -1);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(1), 0);
@@ -139,7 +138,7 @@ TEST(FEBoundaryTest, nodal_normals_2d)
     {
         auto label = mesh.get_label("bottom");
         IndexSet bnd_facets = points_from_label(label);
-        TestBoundary2D bnd(&mesh, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary2D bnd(&mesh, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 0);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(1), -1);
@@ -158,7 +157,7 @@ TEST(FEBoundaryTest, nodal_normals_2d)
     {
         auto label = mesh.get_label("top_right");
         IndexSet bnd_facets = points_from_label(label);
-        TestBoundary2D bnd(&mesh, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary2D bnd(&mesh, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 1);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(1), 0);

--- a/test/src/FEBoundary3D_test.cpp
+++ b/test/src/FEBoundary3D_test.cpp
@@ -36,7 +36,7 @@ protected:
         build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
 
         // create "side sets"
-        DMLabel face_sets = create_label("Face Sets");
+        auto face_sets = create_label("Face Sets");
 
         create_side_set(face_sets, 1, { 5 }, "front");
         create_side_set(face_sets, 2, { 6 }, "bottom");
@@ -54,13 +54,13 @@ protected:
     }
 
     void
-    create_side_set(const DMLabel & face_sets,
+    create_side_set(Label & face_sets,
                     Int id,
                     const std::vector<Int> & faces,
                     const char * name)
     {
         for (auto & f : faces) {
-            PETSC_CHECK(DMLabelSetValue(face_sets, f, id));
+            face_sets.set_value(f, id);
             PETSC_CHECK(DMSetLabelValue(dm(), name, f, id));
         }
     }

--- a/test/src/FEBoundary3D_test.cpp
+++ b/test/src/FEBoundary3D_test.cpp
@@ -72,11 +72,10 @@ public:
 class TestBoundary3D : public fe::BoundaryInfo<TET4, 3, 4> {
 public:
     TestBoundary3D(UnstructuredMesh * mesh,
-                   const Array1D<DenseVector<Real, 3>> * coords,
                    const Array1D<Real> * fe_volume,
                    const Array1D<DenseMatrix<Real, 4, 3>> * grad_phi,
                    const IndexSet & facets) :
-        fe::BoundaryInfo<TET4, 3, 4>(mesh, coords, fe_volume, grad_phi, facets)
+        fe::BoundaryInfo<TET4, 3, 4>(mesh, fe_volume, grad_phi, facets)
     {
     }
 

--- a/test/src/FEBoundary3D_test.cpp
+++ b/test/src/FEBoundary3D_test.cpp
@@ -71,14 +71,12 @@ public:
 
 class TestBoundary3D : public fe::BoundaryInfo<TET4, 3, 4> {
 public:
-    TestBoundary3D(const UnstructuredMesh * mesh,
+    TestBoundary3D(UnstructuredMesh * mesh,
                    const Array1D<DenseVector<Real, 3>> * coords,
-                   const Array1D<DenseVector<Int, 4>> * connect,
-                   const Array1D<std::vector<Int>> * nelcom,
                    const Array1D<Real> * fe_volume,
                    const Array1D<DenseMatrix<Real, 4, 3>> * grad_phi,
                    const IndexSet & facets) :
-        fe::BoundaryInfo<TET4, 3, 4>(mesh, coords, connect, nelcom, fe_volume, grad_phi, facets)
+        fe::BoundaryInfo<TET4, 3, 4>(mesh, coords, fe_volume, grad_phi, facets)
     {
     }
 
@@ -118,20 +116,13 @@ TEST(FEBoundaryTest, nodal_normals_3d)
     mesh.create();
 
     auto coords = fe::coordinates<3>(mesh);
-    auto connect = fe::connectivity<3, 4>(mesh);
     auto fe_volume = fe::calc_volumes<TET4, 3>(coords, connect);
     auto grad_phi = fe::calc_grad_shape<TET4, 3>(coords, connect, fe_volume);
-
-    auto n_nodes = mesh.get_num_vertices();
-
-    Array1D<std::vector<Int>> nelcom;
-    nelcom.create(n_nodes);
-    fe::common_elements_by_node(connect, nelcom);
 
     {
         auto label = mesh.get_label("left");
         IndexSet bnd_facets = points_from_label(label);
-        TestBoundary3D bnd(&mesh, &coords, &connect, &nelcom, &fe_volume, &grad_phi, bnd_facets);
+        TestBoundary3D bnd(&mesh, &coords, &fe_volume, &grad_phi, bnd_facets);
          bnd.create();
          bnd.destroy();
     }

--- a/test/src/FEVolumes_test.cpp
+++ b/test/src/FEVolumes_test.cpp
@@ -74,27 +74,27 @@ TEST(FEVolumesTest, calc_volumes)
 
 TEST(FEVolumesTest, face_area_edge2)
 {
-    DenseVector<DenseVector<Real, 1>, 1> coords;
-    coords(0) = DenseVector<Real, 1>({ 0. });
+    DenseMatrix<Real, 1, 1> coords;
+    coords(0, 0) = 0.;
     auto A = fe::face_area<EDGE2>(coords);
     EXPECT_DOUBLE_EQ(A, 1.);
 }
 
 TEST(FEVolumesTest, face_area_tri3)
 {
-    DenseVector<DenseVector<Real, 2>, 2> coords;
-    coords(0) = DenseVector<Real, 2>({ 0., 0. });
-    coords(1) = DenseVector<Real, 2>({ 1., 1. });
+    DenseMatrix<Real, 2, 2> coords;
+    coords.set_row(0, { 0., 0. });
+    coords.set_row(1, { 1., 1. });
     auto A = fe::face_area<TRI3>(coords);
     EXPECT_DOUBLE_EQ(A, std::sqrt(2));
 }
 
 TEST(FEVolumesTest, face_area_tet4)
 {
-    DenseVector<DenseVector<Real, 3>, 3> coords;
-    coords(0) = DenseVector<Real, 3>({ 0., 0., 0. });
-    coords(1) = DenseVector<Real, 3>({ 1., 0., 0. });
-    coords(2) = DenseVector<Real, 3>({ 0., 1., 0. });
+    DenseMatrix<Real, 3, 3> coords;
+    coords.set_row(0, { 0., 0., 0. });
+    coords.set_row(1, { 1., 0., 0. });
+    coords.set_row(2, { 0., 1., 0. });
     EXPECT_DEATH(fe::face_area<TET4>(coords),
                  "Face area calculation for TET4 in 3 dimensions is not implemented.");
 }

--- a/test/src/Utils_test.cpp
+++ b/test/src/Utils_test.cpp
@@ -56,3 +56,13 @@ TEST(UtilsTest, human_time)
     EXPECT_EQ(utils::human_time(3725), "1h 2m 5s");
     EXPECT_EQ(utils::human_time(3725.2), "1h 2m 5.200s");
 }
+
+TEST(UtilsTest, index_of)
+{
+    std::vector<int> vals = { 2, 5, 8 };
+    EXPECT_EQ(utils::index_of(vals, 2), 0);
+    EXPECT_EQ(utils::index_of(vals, 5), 1);
+    EXPECT_EQ(utils::index_of(vals, 8), 2);
+
+    EXPECT_THROW({ utils::index_of(vals, 1); }, std::runtime_error);
+}


### PR DESCRIPTION
- Adding utils::index_of()
- UnstructuredMesh::common_cells_by_vertex return a reference to the map
- `FEBoundary` is using `UnstructuredMesh::common_cells_by_vertex`
- Use Label instead of DMLabel
- `FEBoundary::calc_face_length` is using PETSc
- FEBoundary uses volume computed via PETSc API
