### PR TITLE
gha: workflow updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,6 @@ jobs:
           - os: ubuntu-22.04
             python-version: '3.9'
             petsc: 3.19.4
-          - os: macos-12
-            python-version: '3.9'
-            petsc: 3.19.4
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up miniconda
@@ -37,22 +34,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           auto-update-conda: false
-          channels: andrsd,conda-forge,defaults
-          channel-priority: strict
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          channels: andrsd,defaults
 
       - name: Checkout source
         uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
-          mamba install \
+          conda install \
             cmake \
             make \
-            cxx-compiler \
-            mpich \
+            mpich-mpicxx \
             petsc==${{ matrix.petsc }} \
             fmt==9.1.0 \
             yaml-cpp=0.7.0 \

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,21 +22,17 @@ jobs:
         with:
           python-version: 3.9
           auto-update-conda: false
-          channels: andrsd,conda-forge,defaults
-          channel-priority: strict
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          channels: andrsd,defaults
 
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
-          mamba install \
+          conda install \
             cmake \
             make \
-            cxx-compiler \
+            mpich-mpicxx \
             doxygen \
             sphinx \
             sphinx_rtd_theme \

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -18,21 +18,16 @@ jobs:
         with:
           python-version: 3.9
           auto-update-conda: false
-          channels: andrsd,conda-forge,defaults
-          channel-priority: strict
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          channels: andrsd,defaults
 
       - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
-          mamba install \
+          conda install \
             cmake \
             make \
-            cxx-compiler \
-            mpich \
+            mpich-mpicxx \
             fmt==9.1.0 \
             petsc==3.19.4 \
             yaml-cpp==0.7.0 \
@@ -79,22 +74,17 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           auto-update-conda: false
-          channels: andrsd,conda-forge,defaults
-          channel-priority: strict
-          miniforge-version: latest
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          channels: andrsd,defaults
 
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
-          mamba install \
+          conda install \
             cmake \
             make \
-            cxx-compiler \
-            mpich \
+            mpich-mpicxx \
             fmt==9.1.0 \
             petsc==3.19.4 \
             yaml-cpp==0.7.0 \


### PR DESCRIPTION
- not using mamba
- not using conda-forge
- dropping support for mac-osx x86
