### PR TITLE
Making member variables private

### DIFF
--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -346,7 +346,7 @@ NSIncompressibleProblem::set_up_preconditioning()
     PetscInt n_fields;
     char ** field_names;
     IS * is;
-    PETSC_CHECK(DMCreateFieldIS(dm(), &n_fields, &field_names, &is));
+    PETSC_CHECK(DMCreateFieldIS(get_dm(), &n_fields, &field_names, &is));
 
     // attach null space to the pressure field
     MatNullSpace nsp;

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -350,7 +350,7 @@ NSIncompressibleProblem::set_up_preconditioning()
 
     // attach null space to the pressure field
     MatNullSpace nsp;
-    PETSC_CHECK(MatNullSpaceCreate(comm(), PETSC_TRUE, 0, nullptr, &nsp));
+    PETSC_CHECK(MatNullSpaceCreate(get_comm(), PETSC_TRUE, 0, nullptr, &nsp));
     PETSC_CHECK(PetscObjectCompose((PetscObject) is[1], "nullspace", (PetscObject) nsp));
     PETSC_CHECK(MatNullSpaceDestroy(&nsp));
 

--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -48,7 +48,9 @@ public:
     /// Get pointer to the `Problem` class in this application
     ///
     /// @return Get problem this application is representing
-    virtual Problem * get_problem() const;
+    Problem * get_problem() const;
+
+    void set_problem(Problem * problem);
 
     /// Parse command line arguments
     ///
@@ -114,10 +116,6 @@ protected:
     /// @param input_file Input file to set
     void set_input_file(InputFile * input_file);
 
-    /// Create method can be used to additional object allocation, etc. needed before the
-    /// application runs
-    virtual void create();
-
     /// Create command line options
     ///
     virtual void create_command_line_options();
@@ -125,18 +123,18 @@ protected:
     /// Build application objects from an input file
     ///
     /// @param file_name The input file name
-    virtual void build_from_yml(const std::string & file_name);
+    void build_from_yml(const std::string & file_name);
 
     /// Check integrity of the application
-    virtual void check_integrity();
+    void check_integrity();
 
     /// Run the input file
     ///
     /// @param input_file_name Input file name
-    virtual void run_input_file(const std::string & input_file_name);
+    void run_input_file(const std::string & input_file_name);
 
     /// Run the problem build via `build_from_yml`
-    virtual void run_problem();
+    void run_problem();
 
 private:
     /// Application name
@@ -162,6 +160,9 @@ private:
 
     /// YML file with application objects
     InputFile * yml;
+
+    /// Pointer to `Problem`
+    Problem * problem;
 
     /// Factory for building objects
     Factory factory;

--- a/include/godzilla/AuxiliaryField.h
+++ b/include/godzilla/AuxiliaryField.h
@@ -60,6 +60,7 @@ protected:
     /// @return Problem this auxiliary field of part of
     Problem * get_problem() const;
 
+private:
     /// Unstructured mesh this field is defined on
     UnstructuredMesh * mesh;
 

--- a/include/godzilla/BasicTSAdapt.h
+++ b/include/godzilla/BasicTSAdapt.h
@@ -11,7 +11,7 @@ public:
     explicit BasicTSAdapt(const Parameters & params);
 
 protected:
-    void set_type() override;
+    void set_type_impl() override;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/BoundaryCondition.h
+++ b/include/godzilla/BoundaryCondition.h
@@ -35,6 +35,7 @@ protected:
     /// Get problem this auxiliary field is part of
     Problem * get_problem() const;
 
+private:
     /// Discrete problem this object is part of
     DiscreteProblemInterface * dpi;
 

--- a/include/godzilla/BoxMesh.h
+++ b/include/godzilla/BoxMesh.h
@@ -12,6 +12,8 @@ public:
     /// Constructor for building the object via Factory
     explicit BoxMesh(const Parameters & parameters);
 
+    void create() override;
+
     /// Get lower limit in x-direction
     NO_DISCARD Real get_x_min() const;
 
@@ -40,7 +42,7 @@ public:
     NO_DISCARD Int get_nz() const;
 
 protected:
-    void create_dm() override;
+    DM create_dm() override;
 
     /// Minimum in the x direction
     const Real & xmin;

--- a/include/godzilla/BoxMesh.h
+++ b/include/godzilla/BoxMesh.h
@@ -44,6 +44,7 @@ public:
 protected:
     DM create_dm() override;
 
+private:
     /// Minimum in the x direction
     const Real & xmin;
 

--- a/include/godzilla/CSVOutput.h
+++ b/include/godzilla/CSVOutput.h
@@ -17,12 +17,22 @@ public:
     NO_DISCARD std::string get_file_ext() const override;
     void output_step() override;
 
+    /// Get post-processor names
+    ///
+    /// @return Post-processor names
+    const std::vector<std::string> &
+    get_pps_names() const
+    {
+        return pps_names;
+    }
+
 protected:
     void open_file();
     void write_header();
     void write_values(Real time);
     void close_file();
 
+private:
     /// Output file
     std::FILE * f;
 

--- a/include/godzilla/CallStack.h
+++ b/include/godzilla/CallStack.h
@@ -51,7 +51,7 @@ public:
         const char * func;
     };
 
-protected:
+private:
     /// The object storing call stack objects
     std::array<Obj *, MAX_SIZE> stack;
     /// Actual size of the stack

--- a/include/godzilla/ConstantAuxiliaryField.h
+++ b/include/godzilla/ConstantAuxiliaryField.h
@@ -17,8 +17,11 @@ public:
     NO_DISCARD PetscFunc * get_func() const override;
     void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override;
 
-protected:
+private:
+    /// Values (per component)
     const std::vector<Real> & values;
+
+    /// Number of compoennts
     unsigned int num_comps;
 
 public:

--- a/include/godzilla/ConstantAuxiliaryField.h
+++ b/include/godzilla/ConstantAuxiliaryField.h
@@ -18,11 +18,8 @@ public:
     void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override;
 
 private:
-    /// Values (per component)
+    /// Values (one per component)
     const std::vector<Real> & values;
-
-    /// Number of compoennts
-    unsigned int num_comps;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/ConstantInitialCondition.h
+++ b/include/godzilla/ConstantInitialCondition.h
@@ -19,7 +19,7 @@ public:
 
     void evaluate(Int dim, Real time, const Real x[], Int Nc, Scalar u[]) override;
 
-protected:
+private:
     /// Constant values -- one for each component
     const std::vector<Real> & values;
 

--- a/include/godzilla/DependencyGraph.h
+++ b/include/godzilla/DependencyGraph.h
@@ -136,7 +136,7 @@ public:
         return sorted_vector;
     }
 
-protected:
+private:
     /// adjacency
     std::map<T, std::set<T>> adj;
 };

--- a/include/godzilla/DirichletBC.h
+++ b/include/godzilla/DirichletBC.h
@@ -8,7 +8,7 @@ namespace godzilla {
 /// Dirichlet boundary condition
 ///
 /// Can be used only on single-field problems
-class DirichletBC : public EssentialBC, public FunctionInterface {
+class DirichletBC : public EssentialBC, protected FunctionInterface {
 public:
     explicit DirichletBC(const Parameters & params);
 

--- a/include/godzilla/DirichletBC.h
+++ b/include/godzilla/DirichletBC.h
@@ -18,7 +18,7 @@ public:
     void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override;
     void evaluate_t(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override;
 
-protected:
+private:
     std::vector<Int> components;
 
 public:

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -379,7 +379,7 @@ DiscreteProblemInterface::set_closure(const Vector & v,
                                       const DenseVector<Real, N> & vec,
                                       InsertMode mode) const
 {
-    auto dm = this->unstr_mesh->dm();
+    auto dm = this->unstr_mesh->get_dm();
     PETSC_CHECK(DMPlexVecSetClosure(dm, this->section, v, point, vec.data(), mode));
 }
 
@@ -390,7 +390,7 @@ DiscreteProblemInterface::set_closure(const Matrix & A,
                                       const DenseMatrix<Real, N> & mat,
                                       InsertMode mode) const
 {
-    auto dm = this->unstr_mesh->dm();
+    auto dm = this->unstr_mesh->get_dm();
     Section global_section = this->problem->get_global_section();
     PETSC_CHECK(DMPlexMatSetClosure(dm, this->section, global_section, A, point, mat.data(), mode));
 }
@@ -402,7 +402,7 @@ DiscreteProblemInterface::set_closure(const Matrix & A,
                                       const DenseMatrixSymm<Real, N> & mat,
                                       InsertMode mode) const
 {
-    auto dm = this->unstr_mesh->dm();
+    auto dm = this->unstr_mesh->get_dm();
     Section global_section = this->problem->get_global_section();
     DenseMatrix<Real, N> m = mat;
     PETSC_CHECK(DMPlexMatSetClosure(dm, this->section, global_section, A, point, m.data(), mode));
@@ -412,7 +412,7 @@ template <Int N>
 DenseVector<Real, N>
 DiscreteProblemInterface::get_closure(const Vector & v, Int point) const
 {
-    auto dm = this->unstr_mesh->dm();
+    auto dm = this->unstr_mesh->get_dm();
     Int sz = N;
     DenseVector<Real, N> vec;
     Real * data = vec.data();
@@ -445,7 +445,7 @@ template <typename T>
 T
 DiscreteProblemInterface::get_point_local_field_ref(Int point, Int field, Scalar * array) const
 {
-    auto dm = this->unstr_mesh->dm();
+    auto dm = this->unstr_mesh->get_dm();
     T var;
     PETSC_CHECK(DMPlexPointLocalFieldRef(dm, point, field, array, &var));
     return var;

--- a/include/godzilla/EssentialBC.h
+++ b/include/godzilla/EssentialBC.h
@@ -52,7 +52,7 @@ public:
 
     void set_up() override;
 
-protected:
+private:
     /// Field ID this boundary condition is attached to
     Int fid;
 

--- a/include/godzilla/ExodusIIMesh.h
+++ b/include/godzilla/ExodusIIMesh.h
@@ -10,8 +10,10 @@ class ExodusIIMesh : public FileMesh {
 public:
     explicit ExodusIIMesh(const Parameters & parameters);
 
+    void create() override;
+
 protected:
-    void create_dm() override;
+    DM create_dm() override;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/ExodusIIOutput.h
+++ b/include/godzilla/ExodusIIOutput.h
@@ -59,6 +59,7 @@ protected:
                                   Int n_elems_in_block,
                                   const Int * cells);
 
+private:
     /// Variable names to be stored
     const std::vector<std::string> & variable_names;
     /// FE problem interface (convenience pointer)

--- a/include/godzilla/ExodusIIOutput.h
+++ b/include/godzilla/ExodusIIOutput.h
@@ -31,7 +31,6 @@ public:
     ~ExodusIIOutput() override;
 
     NO_DISCARD std::string get_file_ext() const override;
-    void set_file_name() override;
     void create() override;
     void check() override;
     void output_mesh();

--- a/include/godzilla/ExplicitFELinearProblem.h
+++ b/include/godzilla/ExplicitFELinearProblem.h
@@ -20,6 +20,18 @@ public:
     void solve() override;
     const Vector & get_solution_vector_local() override;
 
+    const Matrix &
+    get_mass_matrix() const
+    {
+        return this->M;
+    }
+
+    const Vector &
+    get_lumped_mass_matrix() const
+    {
+        return this->M_lumped_inv;
+    }
+
     virtual PetscErrorCode compute_rhs(Real time, const Vector & X, Vector & F);
 
 protected:
@@ -37,6 +49,7 @@ protected:
     virtual PetscErrorCode compute_rhs_local(Real time, const Vector & x, Vector & F);
     void post_step() override;
 
+private:
     /// Time stepping scheme
     const std::string & scheme;
 

--- a/include/godzilla/ExplicitFVLinearProblem.h
+++ b/include/godzilla/ExplicitFVLinearProblem.h
@@ -24,6 +24,18 @@ public:
 
     virtual PetscErrorCode compute_rhs(Real time, const Vector & x, Vector & F);
 
+    const Matrix &
+    get_mass_matrix() const
+    {
+        return this->M;
+    }
+
+    const Vector &
+    get_lumped_mass_matrix() const
+    {
+        return this->M_lumped_inv;
+    }
+
 protected:
     void init() override;
     void allocate_objects() override;
@@ -37,6 +49,7 @@ protected:
     virtual PetscErrorCode compute_rhs_local(Real time, const Vector & x, Vector & F);
     void post_step() override;
 
+private:
     /// Time stepping scheme
     const std::string & scheme;
 

--- a/include/godzilla/FEBoundary.h
+++ b/include/godzilla/FEBoundary.h
@@ -182,7 +182,7 @@ BoundaryInfo<TRI3, 2, 3>::correct_nodal_normals()
     for (Int i = 0; i < this->vertices.get_local_size(); i++) {
         Int vertex = this->vertices(i);
         auto support = this->mesh->get_support(vertex);
-        IndexSet support_is = IndexSet::create_general(this->mesh->comm(), support);
+        IndexSet support_is = IndexSet::create_general(this->mesh->get_comm(), support);
         auto common_edges = IndexSet::intersect(this->facets, support_is);
         if (common_edges.get_size() == 1) {
             common_edges.get_indices();

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -25,6 +25,8 @@ class ValueFunctional;
 ///
 /// Any problem using PetscFE should inherit from this for unified API
 class FEProblemInterface : public DiscreteProblemInterface, public DependencyEvaluator {
+    struct FieldInfo;
+
 public:
     FEProblemInterface(Problem * problem, const Parameters & params);
     ~FEProblemInterface() override;
@@ -242,7 +244,7 @@ public:
                                                   Scalar elem_mat[]);
 
 protected:
-    struct FieldInfo;
+    const std::map<Int, FieldInfo> & get_fields() const;
 
     void create() override;
     void init() override;
@@ -344,6 +346,7 @@ protected:
 
     Int get_next_id(const std::vector<Int> & ids) const;
 
+private:
     /// Quadrature order
     Int qorder;
 

--- a/include/godzilla/FVProblemInterface.h
+++ b/include/godzilla/FVProblemInterface.h
@@ -100,6 +100,7 @@ protected:
 
     Int get_next_id(const std::vector<Int> & ids) const;
 
+private:
     /// Field information
     struct FieldInfo {
         /// The name of the field

--- a/include/godzilla/Factory.h
+++ b/include/godzilla/Factory.h
@@ -84,7 +84,7 @@ public:
     /// Destroy all object build by this factory
     void destroy();
 
-protected:
+private:
     /// All objects built by this factory
     std::list<Object *> objects;
     /// All Parameters objects built by this factory

--- a/include/godzilla/FieldValue.h
+++ b/include/godzilla/FieldValue.h
@@ -34,7 +34,7 @@ public:
         return this->data[idx];
     }
 
-protected:
+private:
     /// Number of elements stored in `data`
     Int size;
     /// The elements of the array

--- a/include/godzilla/FileMesh.h
+++ b/include/godzilla/FileMesh.h
@@ -15,7 +15,7 @@ public:
     /// @return Name of the file
     NO_DISCARD const std::string & get_file_name() const;
 
-protected:
+private:
     /// File name with the mesh
     std::string file_name;
 

--- a/include/godzilla/FileOutput.h
+++ b/include/godzilla/FileOutput.h
@@ -17,27 +17,26 @@ public:
     /// Get the file name with the output file produced by this outputter
     ///
     /// @return The file name with the output
-    NO_DISCARD virtual const std::string & get_file_name() const;
+    std::string get_file_name() const;
 
-    /// Set the file name for single output
-    virtual void set_file_name();
+    /// Set file base
+    ///
+    /// @param file_base File base to set
+    void set_file_base(const std::string & file_base);
 
-    /// Set the file name for a sequence of outputs
+    /// Set the file base for a sequence of outputs
     ///
     /// @param stepi Step number
-    virtual void set_sequence_file_name(unsigned int stepi);
+    void set_sequence_file_base(unsigned int stepi);
 
     /// Get file extension
     ///
     /// @return File extension
     NO_DISCARD virtual std::string get_file_ext() const = 0;
 
-protected:
+private:
     /// The file base of the output file
     std::string file_base;
-
-    /// The file name of the output file
-    std::string file_name;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/FunctionAuxiliaryField.h
+++ b/include/godzilla/FunctionAuxiliaryField.h
@@ -8,7 +8,7 @@ namespace godzilla {
 
 /// Auxiliary field set by a function
 ///
-class FunctionAuxiliaryField : public AuxiliaryField, public FunctionInterface {
+class FunctionAuxiliaryField : public AuxiliaryField, protected FunctionInterface {
 public:
     explicit FunctionAuxiliaryField(const Parameters & params);
 

--- a/include/godzilla/FunctionEvaluator.h
+++ b/include/godzilla/FunctionEvaluator.h
@@ -44,7 +44,7 @@ public:
 
     bool evaluate(Int dim, Real time, const Real x[], Int nc, Real u[]);
 
-protected:
+private:
     /// Underlying muParser object
     mu::Parser parser;
 };

--- a/include/godzilla/FunctionInitialCondition.h
+++ b/include/godzilla/FunctionInitialCondition.h
@@ -7,7 +7,7 @@ namespace godzilla {
 
 /// Initial condition given by a function expression
 ///
-class FunctionInitialCondition : public InitialCondition, public FunctionInterface {
+class FunctionInitialCondition : public InitialCondition, protected FunctionInterface {
 public:
     explicit FunctionInitialCondition(const Parameters & params);
 

--- a/include/godzilla/FunctionInterface.h
+++ b/include/godzilla/FunctionInterface.h
@@ -17,6 +17,16 @@ public:
     /// Build the evaluator
     void create();
 
+    /// Get number of components
+    ///
+    /// @return The number of components
+    unsigned int get_num_components() const;
+
+    /// Check if time dependent expression was specified
+    ///
+    /// @return `true` if time dependent expression is specified, `false` otherwise
+    bool has_time_expression() const;
+
     /// Evaluate parsed function
     ///
     /// @return 'true' if evaluation was successful, `false` otherwise
@@ -37,7 +47,7 @@ public:
     /// @param u The result of evaluation (one per component)
     bool evaluate_func_t(Int dim, Real time, const Real x[], Int nc, Real u[]);
 
-protected:
+private:
     /// Application
     const App * fi_app;
     /// Function expressions

--- a/include/godzilla/GmshMesh.h
+++ b/include/godzilla/GmshMesh.h
@@ -11,7 +11,7 @@ public:
     explicit GmshMesh(const Parameters & parameters);
 
 protected:
-    void create_dm() override;
+    DM create_dm() override;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/ImplicitFENonlinearProblem.h
+++ b/include/godzilla/ImplicitFENonlinearProblem.h
@@ -35,6 +35,7 @@ protected:
     void set_up_monitors() override;
     void post_step() override;
 
+private:
     /// Time stepping scheme
     const std::string & scheme;
 

--- a/include/godzilla/InitialCondition.h
+++ b/include/godzilla/InitialCondition.h
@@ -36,7 +36,7 @@ public:
     /// @param u  The output field values
     virtual void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) = 0;
 
-protected:
+private:
     /// Discrete problem this object is part of
     DiscreteProblemInterface * dpi;
 

--- a/include/godzilla/InputFile.h
+++ b/include/godzilla/InputFile.h
@@ -36,10 +36,13 @@ public:
     ///
     /// @return `true` if successful, otherwise `false`
     virtual bool parse(const std::string & file_name);
-    /// create
-    virtual void create();
-    /// check
+
+    /// Create objects
+    virtual void create_objects();
+
+    /// Check objects
     virtual void check();
+
     /// build the simulation objects
     virtual void build() = 0;
 
@@ -125,7 +128,7 @@ protected:
                       std::set<std::string> & unused_param_names);
 
     /// Application object
-    godzilla::App * _app;
+    App * _app;
     /// Name of this input file
     std::string file_name;
     /// Root node of the YML file
@@ -135,7 +138,7 @@ protected:
     /// Problem object
     Problem * problem;
     /// List of all objects built from the input file
-    std::vector<Object *> objects;
+    std::vector<Object *> objs;
     /// Names of object with correct parameters
     std::set<std::string> valid_param_object_names;
     /// Names of used top-level blocks

--- a/include/godzilla/InputFile.h
+++ b/include/godzilla/InputFile.h
@@ -30,7 +30,7 @@ public:
     /// Get application
     ///
     /// @return Application this input file belongs to
-    App * app() const;
+    App * get_app() const;
 
     /// Parse the YML file
     ///
@@ -46,8 +46,11 @@ public:
     /// build the simulation objects
     virtual void build() = 0;
 
-    virtual Mesh * get_mesh();
-    virtual Problem * get_problem();
+    /// Get the mesh specified in the input file
+    Mesh * get_mesh() const;
+
+    /// Get the problem specified in the input file
+    Problem * get_problem() const;
 
 protected:
     /// Representation of a block in the YAML input file
@@ -128,7 +131,7 @@ protected:
                       std::set<std::string> & unused_param_names);
 
     /// Application object
-    App * _app;
+    App * app;
     /// Name of this input file
     std::string file_name;
     /// Root node of the YML file

--- a/include/godzilla/L2Diff.h
+++ b/include/godzilla/L2Diff.h
@@ -24,7 +24,7 @@ public:
     /// @param u  The output field values
     void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]);
 
-protected:
+private:
     /// Computed L_2 error
     Real l2_diff;
 

--- a/include/godzilla/L2FieldDiff.h
+++ b/include/godzilla/L2FieldDiff.h
@@ -19,7 +19,7 @@ public:
     void compute() override;
     Real get_value() override;
 
-protected:
+private:
     /// FE problem
     const FEProblemInterface * fepi;
 

--- a/include/godzilla/LineMesh.h
+++ b/include/godzilla/LineMesh.h
@@ -30,6 +30,7 @@ public:
 protected:
     DM create_dm() override;
 
+private:
     /// Minimum in the x direction
     const Real & xmin;
     /// Maximum in the x direction

--- a/include/godzilla/LineMesh.h
+++ b/include/godzilla/LineMesh.h
@@ -10,6 +10,8 @@ class LineMesh : public UnstructuredMesh {
 public:
     explicit LineMesh(const Parameters & parameters);
 
+    void create() override;
+
     /// Get the lower bound in x-direction
     ///
     /// @return Lower bound in x-direction
@@ -26,7 +28,7 @@ public:
     NO_DISCARD Int get_nx() const;
 
 protected:
-    void create_dm() override;
+    DM create_dm() override;
 
     /// Minimum in the x direction
     const Real & xmin;

--- a/include/godzilla/LinearInterpolation.h
+++ b/include/godzilla/LinearInterpolation.h
@@ -33,7 +33,7 @@ public:
     /// @return Interpolated value
     Real sample(Real x);
 
-protected:
+private:
     /// Independent values
     std::vector<Real> x;
     /// Dependent values

--- a/include/godzilla/LinearProblem.h
+++ b/include/godzilla/LinearProblem.h
@@ -46,6 +46,7 @@ protected:
     /// Solve the problem
     virtual void solve();
 
+private:
     /// KSP object
     KSP ksp;
     /// The solution vector

--- a/include/godzilla/Logger.h
+++ b/include/godzilla/Logger.h
@@ -90,6 +90,7 @@ protected:
         return str;
     }
 
+private:
     /// List of logged errors/warnings
     std::vector<Entry> entries;
     /// Number of errors

--- a/include/godzilla/LoggingInterface.h
+++ b/include/godzilla/LoggingInterface.h
@@ -30,7 +30,7 @@ public:
         this->logger->warning(this->prefix, format, std::forward<T>(args)...);
     }
 
-protected:
+private:
     /// Logger object
     Logger * logger;
 

--- a/include/godzilla/LoggingInterface.h
+++ b/include/godzilla/LoggingInterface.h
@@ -4,7 +4,7 @@
 
 namespace godzilla {
 
-/// Logging interface to give objects capability to log problems like errors and warnings
+/// Logging interface to give objects capability to logger problems like errors and warnings
 ///
 class LoggingInterface {
 public:

--- a/include/godzilla/Mesh.h
+++ b/include/godzilla/Mesh.h
@@ -21,9 +21,7 @@ public:
     /// Get the underlying DM object
     ///
     /// @return Underlying PETSc DM
-    [[deprecated("Use dm() instead")]] DM get_dm() const;
-
-    DM dm() const;
+    DM get_dm() const;
 
     /// Get the mesh spatial dimension
     ///
@@ -82,7 +80,7 @@ public:
 
 protected:
     /// DM object
-    DM _dm;
+    DM dm;
     /// Spatial dimension of the mesh
     Int dim;
 

--- a/include/godzilla/Mesh.h
+++ b/include/godzilla/Mesh.h
@@ -79,10 +79,12 @@ public:
     void set_up();
 
 protected:
+    /// Set the DM
+    void set_dm(DM dm);
+
+private:
     /// DM object
     DM dm;
-    /// Spatial dimension of the mesh
-    Int dim;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/NaturalBC.h
+++ b/include/godzilla/NaturalBC.h
@@ -51,6 +51,7 @@ protected:
                             BndJacobianFunc * g2,
                             BndJacobianFunc * g3);
 
+private:
     /// Field ID this boundary condition is attached to
     Int fid;
 

--- a/include/godzilla/NaturalRiemannBC.h
+++ b/include/godzilla/NaturalRiemannBC.h
@@ -34,7 +34,7 @@ public:
     virtual void
     evaluate(Real time, const Real * c, const Real * n, const Scalar * xI, Scalar * xG) = 0;
 
-protected:
+private:
     /// Field ID this boundary condition is attached to
     Int fid;
 

--- a/include/godzilla/Object.h
+++ b/include/godzilla/Object.h
@@ -46,10 +46,7 @@ public:
     App * get_app() const;
 
     /// Get the MPI comm this object works on
-    [[deprecated("Use comm() instead")]] const mpi::Communicator & get_comm() const;
-
-    /// Get the MPI comm this object works on
-    const mpi::Communicator & comm() const;
+    const mpi::Communicator & get_comm() const;
 
     /// Get processor ID (aka MPI rank) this object is running at
     int get_processor_id() const;

--- a/include/godzilla/Output.h
+++ b/include/godzilla/Output.h
@@ -20,7 +20,12 @@ public:
     /// Set execute mask
     ///
     /// @param mask Bit mask for execution
-    virtual void set_exec_mask(unsigned int mask);
+    void set_exec_mask(unsigned int mask);
+
+    /// Get execution mask
+    ///
+    /// @return execution mask
+    unsigned int get_exec_mask() const;
 
     /// Should output happen at a specified occasion
     ///
@@ -32,9 +37,15 @@ public:
     virtual void output_step() = 0;
 
 protected:
+    /// Get problem
+    ///
+    /// @return Problem this output is part of
+    Problem * get_problem() const;
+
     /// Set up the execution mask
     void set_up_exec();
 
+private:
     /// Problem to get data from
     Problem * problem;
 

--- a/include/godzilla/ParsedFunction.h
+++ b/include/godzilla/ParsedFunction.h
@@ -33,7 +33,7 @@ public:
     /// Get the pointer to the context that will be passed into PETSc API
     virtual void * get_context();
 
-protected:
+private:
     /// Text representation of the function to evaluate (one per component)
     const std::vector<std::string> & function;
     /// User defined constants

--- a/include/godzilla/PerfLog.h
+++ b/include/godzilla/PerfLog.h
@@ -83,7 +83,7 @@ public:
         /// @return ID of this stage
         NO_DISCARD PetscLogStage get_id() const;
 
-    protected:
+    private:
         /// Event ID
         PetscLogStage id;
     };
@@ -107,7 +107,7 @@ public:
         /// @return Number of times this event was called
         NO_DISCARD int get_num_calls() const;
 
-    protected:
+    private:
         /// Event information collected by PETSc
         PetscEventPerfInfo info;
     };
@@ -156,7 +156,7 @@ public:
         /// Log number of FLOPS
         void log_flops(PetscLogDouble n);
 
-    protected:
+    private:
         /// Event ID
         PetscLogEvent id;
     };

--- a/include/godzilla/PiecewiseConstant.h
+++ b/include/godzilla/PiecewiseConstant.h
@@ -26,6 +26,7 @@ protected:
     Real eval_right_cont(Real x);
     Real eval_left_cont(Real x);
 
+private:
     enum Continuity { LEFT, RIGHT } continuity;
     /// Independent values
     const std::vector<Real> & x;

--- a/include/godzilla/PiecewiseLinear.h
+++ b/include/godzilla/PiecewiseLinear.h
@@ -20,7 +20,7 @@ public:
     /// Evaluate this function at point 'x'
     Real evaluate(Real x);
 
-protected:
+private:
     /// Linear interpolation object used for function evaluation
     LinearInterpolation linpol;
 

--- a/include/godzilla/Postprocessor.h
+++ b/include/godzilla/Postprocessor.h
@@ -25,7 +25,12 @@ public:
     /// @return The value computed by the postprocessor
     virtual Real get_value() = 0;
 
-protected:
+    /// Get problem this post-processor is part of
+    ///
+    /// @return Problem this postprocessor is part of
+    Problem * get_problem() const;
+
+private:
     /// Problem this object is part of
     Problem * problem;
 

--- a/include/godzilla/PrintInterface.h
+++ b/include/godzilla/PrintInterface.h
@@ -37,7 +37,7 @@ public:
             return TimedEvent(pi, level, event_name, text);
         }
 
-    protected:
+    private:
         const PrintInterface * pi;
         unsigned int level;
         PerfLog::Event * event;

--- a/include/godzilla/PrintInterface.h
+++ b/include/godzilla/PrintInterface.h
@@ -51,6 +51,13 @@ public:
                    const unsigned int & verbosity_level,
                    std::string prefix);
 
+    template <typename... T>
+    [[deprecated("Use lprint() instead")]]  void
+    lprintf(unsigned int level, fmt::format_string<T...> format, T... args) const
+    {
+        lprint(level, format, std::forward<T>(args)...);
+    }
+
     /// Print a message on a terminal
     ///
     /// @param level Verbosity level. If application verbose level is higher than this number, the
@@ -59,7 +66,7 @@ public:
     /// @param ... Arguments specifying data to print
     template <typename... T>
     void
-    lprintf(unsigned int level, fmt::format_string<T...> format, T... args) const
+    lprint(unsigned int level, fmt::format_string<T...> format, T... args) const
     {
         if (level <= this->verbosity_level && this->proc_id == 0) {
             fmt::print(stdout, "{}: ", this->prefix);
@@ -84,6 +91,6 @@ private:
         auto __timed_event_obj =                \
             PrintInterface::TimedEvent::create(this, level, event_name, __VA_ARGS__)
 #else
-    #define TIMED_EVENT(level, event_name, ...) lprintf(level, __VA_ARGS__)
+    #define TIMED_EVENT(level, event_name, ...) lprint(level, __VA_ARGS__)
 #endif
 } // namespace godzilla

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -29,8 +29,7 @@ public:
     /// Run the problem
     virtual void run() = 0;
     /// Provide DM for this problem
-    [[deprecated("Use dm() instead.")]] virtual DM get_dm() const;
-    DM dm() const;
+    DM get_dm() const;
     /// Return solution vector
     virtual const Vector & get_solution_vector() const = 0;
     /// Get mesh this problem is using

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -127,12 +127,15 @@ public:
     /// Set the `Section` encoding the global data layout for the `DM`.
     void set_global_section(const Section & section) const;
 
+    void set_default_output_on(unsigned int mask);
+
 protected:
     /// Called before solving starts
     virtual void on_initial();
     /// Called after solve has successfully finished
     virtual void on_final();
 
+private:
     /// Mesh
     Mesh * mesh;
 

--- a/include/godzilla/RectangleMesh.h
+++ b/include/godzilla/RectangleMesh.h
@@ -10,6 +10,7 @@ class RectangleMesh : public UnstructuredMesh {
 public:
     explicit RectangleMesh(const Parameters & parameters);
 
+    void create() override;
     ///
     NO_DISCARD Real get_x_min() const;
     NO_DISCARD Real get_x_max() const;
@@ -22,7 +23,7 @@ public:
     NO_DISCARD Int get_ny() const;
 
 protected:
-    void create_dm() override;
+    DM create_dm() override;
 
     /// Minimum in the x direction
     const Real & xmin;

--- a/include/godzilla/RectangleMesh.h
+++ b/include/godzilla/RectangleMesh.h
@@ -25,6 +25,7 @@ public:
 protected:
     DM create_dm() override;
 
+private:
     /// Minimum in the x direction
     const Real & xmin;
     /// Maximum in the x direction

--- a/include/godzilla/TecplotOutput.h
+++ b/include/godzilla/TecplotOutput.h
@@ -20,7 +20,6 @@ public:
     ~TecplotOutput() override;
 
     NO_DISCARD std::string get_file_ext() const override;
-    void set_file_name() override;
     void create() override;
     void check() override;
     void output_step() override;

--- a/include/godzilla/TecplotOutput.h
+++ b/include/godzilla/TecplotOutput.h
@@ -46,6 +46,7 @@ protected:
 
     void write_line(const std::string & line);
 
+private:
     enum Format { BINARY, ASCII } format;
 
     /// FE problem interface (convenience pointer)

--- a/include/godzilla/TimeSteppingAdaptor.h
+++ b/include/godzilla/TimeSteppingAdaptor.h
@@ -33,9 +33,20 @@ public:
     NO_DISCARD Real get_dt_max() const;
 
 protected:
-    /// Set the type of time stepping adaptivity
-    virtual void set_type() = 0;
+    /// Set time adaptor type
+    ///
+    /// @param type Type of time adaptor
+    void set_type(const char * type);
 
+    /// Set the type of time stepping adaptivity
+    virtual void set_type_impl() = 0;
+
+    /// Get problem this time adaptor is part of
+    ///
+    /// @return Problem this time adaptor is part of
+    Problem * get_problem() const;
+
+private:
     /// Problem this adaptor is part of
     Problem * problem;
 

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -66,6 +66,10 @@ public:
     TSConvergedReason get_converged_reason() const;
 
 protected:
+    /// Get time
+    Real get_time() const;
+    /// Get step number
+    Int get_step_number() const;
     /// Initialize
     virtual void init();
     /// Create
@@ -89,12 +93,15 @@ protected:
     /// Solve
     virtual void solve(Vector & x);
 
+protected:
+    /// PETSc TS object
+    TS ts;
+
+private:
     /// Problem this interface is part of
     Problem * problem;
     /// Parameters
     const Parameters & tpi_params;
-    /// PETSc TS object
-    TS ts;
     /// Time-stepping adaptor
     TimeSteppingAdaptor * ts_adaptor;
     /// Simulation start time

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -155,12 +155,12 @@ public:
     ///
     /// NOTES:
     /// - only process 0 takes in the input
-    void build_from_cell_list(Int dim,
-                              Int n_corners,
-                              const std::vector<Int> & cells,
-                              Int space_dim,
-                              const std::vector<Real> & vertices,
-                              bool interpolate);
+    DM build_from_cell_list(Int dim,
+                            Int n_corners,
+                            const std::vector<Int> & cells,
+                            Int space_dim,
+                            const std::vector<Real> & vertices,
+                            bool interpolate);
 
     /// Get the `Label` recording the depth of each point
     ///
@@ -342,7 +342,7 @@ public:
 
 protected:
     /// Method that builds DM for the mesh
-    virtual void create_dm() = 0;
+    virtual DM create_dm() = 0;
 
     void create_cell_set(Int id, const std::string & name);
 

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -255,6 +255,11 @@ public:
     /// @param type Type of the partitioner
     virtual void set_partitioner_type(const std::string & type);
 
+    /// Get partition overlap
+    ///
+    /// @return Partition overlap
+    Int get_partition_overlap();
+
     /// Set partitioner type
     ///
     /// @param type Type of the partitioner
@@ -350,6 +355,7 @@ protected:
 
     void create_face_set(Int id, const std::string & name);
 
+private:
     /// Mesh partitioner
     Partitioner partitioner;
 

--- a/include/godzilla/VTKOutput.h
+++ b/include/godzilla/VTKOutput.h
@@ -25,7 +25,7 @@ public:
     void check() override;
     void output_step() override;
 
-protected:
+private:
     /// Viewer for the output
     PetscViewer viewer;
 

--- a/include/godzilla/ValueFunctional.h
+++ b/include/godzilla/ValueFunctional.h
@@ -30,6 +30,7 @@ protected:
         return this->evalr->declare_value<T>(val_name);
     }
 
+private:
     /// Dependency evaluator
     DependencyEvaluator * evalr;
     /// Values this object provides (i.e what was announced via `declare_value`)

--- a/include/godzilla/WeakForm.h
+++ b/include/godzilla/WeakForm.h
@@ -82,7 +82,7 @@ public:
     /// @return Field ID used in `PetscFormKey`
     NO_DISCARD Int get_jac_key(Int f, Int g) const;
 
-protected:
+private:
     /// Number of fields
     Int n_fields;
 

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -235,7 +235,7 @@ void
 App::check_integrity()
 {
     _F_;
-    lprintf(9, "Checking integrity");
+    lprint(9, "Checking integrity");
     this->yml->check();
     if (this->log->get_num_entries() > 0) {
         this->log->print();
@@ -247,7 +247,7 @@ void
 App::run_problem()
 {
     _F_;
-    lprintf(9, "Running");
+    lprint(9, "Running");
     Problem * p = this->yml->get_problem();
     assert(p != nullptr);
     p->run();

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -12,17 +12,17 @@
 namespace godzilla {
 
 App::App(const mpi::Communicator & comm,
-         const std::string & app_name,
+         const std::string & name,
          int argc,
          const char * const * argv) :
-    PrintInterface(comm, this->_verbosity_level, app_name),
-    _name(app_name),
-    _comm(comm),
-    log(new Logger()),
+    PrintInterface(comm, this->verbosity_level, name),
+    name(name),
+    mpi_comm(comm),
+    logger(new Logger()),
     argc(argc),
     argv(argv),
-    cmdln_opts(app_name),
-    _verbosity_level(1),
+    cmdln_opts(name),
+    verbosity_level(1),
     yml(nullptr)
 {
     _F_;
@@ -32,22 +32,15 @@ App::~App()
 {
     _F_;
     delete this->yml;
-    delete this->log;
-    this->_factory.destroy();
+    delete this->logger;
+    this->factory.destroy();
 }
 
 const std::string &
 App::get_name() const
 {
     _F_;
-    return this->_name;
-}
-
-const std::string &
-App::name() const
-{
-    _F_;
-    return this->_name;
+    return this->name;
 }
 
 const std::string &
@@ -58,25 +51,17 @@ App::get_version() const
     return ver;
 }
 
-const std::string &
-App::version() const
-{
-    _F_;
-    static const std::string ver(GODZILLA_VERSION);
-    return ver;
-}
-
 Logger *
 App::get_logger() const
 {
     _F_;
-    return this->log;
+    return this->logger;
 }
 
 Factory &
-App::factory()
+App::get_factory()
 {
-    return this->_factory;
+    return this->factory;
 }
 
 Problem *
@@ -129,14 +114,7 @@ const unsigned int &
 App::get_verbosity_level() const
 {
     _F_;
-    return verbosity_level();
-}
-
-const unsigned int &
-App::verbosity_level() const
-{
-    _F_;
-    return this->_verbosity_level;
+    return this->verbosity_level;
 }
 
 const std::string &
@@ -151,44 +129,43 @@ const mpi::Communicator &
 App::get_comm() const
 {
     _F_;
-    return comm();
+    return this->mpi_comm;
 }
 
-const mpi::Communicator &
-App::comm() const
+cxxopts::Options &
+App::get_command_line_opts()
+{
+    return this->cmdln_opts;
+}
+
+void
+App::set_input_file(InputFile * input_file)
 {
     _F_;
-    return this->_comm;
+    this->yml = input_file;
 }
 
 Parameters *
 App::get_parameters(const std::string & class_name)
 {
-    return this->_factory.get_parameters(class_name);
-}
-
-InputFile *
-App::allocate_input_file()
-{
-    _F_;
-    return new GYMLFile(this);
+    return this->factory.get_parameters(class_name);
 }
 
 void
-App::process_command_line(cxxopts::ParseResult & result)
+App::process_command_line(const cxxopts::ParseResult & result)
 {
     _F_;
     if (result.count("help")) {
         fmt::print("{}", this->cmdln_opts.help());
     }
     else if (result.count("version"))
-        fmt::print("{}, version {}\n", name(), version());
+        fmt::print("{}, version {}\n", get_name(), get_version());
     else {
         if (result.count("no-colors"))
             Terminal::num_colors = 1;
 
         if (result.count("verbose"))
-            this->_verbosity_level = result["verbose"].as<unsigned int>();
+            this->verbosity_level = result["verbose"].as<unsigned int>();
 
         if (result.count("input-file")) {
             auto input_file_name = result["input-file"].as<std::string>();
@@ -211,9 +188,9 @@ App::run_input_file(const std::string & input_file_name)
 {
     _F_;
     if (utils::path_exists(input_file_name)) {
-        this->yml = allocate_input_file();
+        set_input_file(new GYMLFile(this));
         build_from_yml(input_file_name);
-        if (this->log->get_num_errors() == 0)
+        if (this->logger->get_num_errors() == 0)
             create();
         check_integrity();
         run_problem();
@@ -237,8 +214,8 @@ App::check_integrity()
     _F_;
     lprint(9, "Checking integrity");
     this->yml->check();
-    if (this->log->get_num_entries() > 0) {
-        this->log->print();
+    if (this->logger->get_num_entries() > 0) {
+        this->logger->print();
         godzilla::internal::terminate();
     }
 }

--- a/src/BasicTSAdapt.cpp
+++ b/src/BasicTSAdapt.cpp
@@ -16,10 +16,10 @@ BasicTSAdapt::parameters()
 BasicTSAdapt::BasicTSAdapt(const Parameters & params) : TimeSteppingAdaptor(params) {}
 
 void
-BasicTSAdapt::set_type()
+BasicTSAdapt::set_type_impl()
 {
     _F_;
-    PETSC_CHECK(TSAdaptSetType(this->ts_adapt, TSADAPTBASIC));
+    set_type(TSADAPTBASIC);
 }
 
 } // namespace godzilla

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -132,7 +132,7 @@ BoxMesh::create_dm()
                                     upper.data(),
                                     periodicity.data(),
                                     this->interpolate,
-                                    &this->_dm));
+                                    &this->dm));
 
     remove_label("marker");
     // create user-friendly names for sides

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -124,7 +124,7 @@ BoxMesh::create_dm()
         this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED
     };
 
-    PETSC_CHECK(DMPlexCreateBoxMesh(comm(),
+    PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
                                     3,
                                     this->simplex,
                                     faces.data(),

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -112,27 +112,10 @@ BoxMesh::get_nz() const
 }
 
 void
-BoxMesh::create_dm()
+BoxMesh::create()
 {
     _F_;
-    std::array<Real, 3> lower = { this->xmin, this->ymin, this->zmin };
-    std::array<Real, 3> upper = { this->xmax, this->ymax, this->zmax };
-    std::array<Int, 3> faces = { this->nx, this->ny, this->nz };
-    std::array<DMBoundaryType, 3> periodicity = {
-        this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED,
-        this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED,
-        this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED
-    };
-
-    PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
-                                    3,
-                                    this->simplex,
-                                    faces.data(),
-                                    lower.data(),
-                                    upper.data(),
-                                    periodicity.data(),
-                                    this->interpolate,
-                                    &this->dm));
+    UnstructuredMesh::create();
 
     remove_label("marker");
     // create user-friendly names for sides
@@ -146,6 +129,32 @@ BoxMesh::create_dm()
     create_face_set_labels(face_set_names);
     for (auto it : face_set_names)
         set_face_set_name(it.first, it.second);
+}
+
+DM
+BoxMesh::create_dm()
+{
+    _F_;
+    std::array<Real, 3> lower = { this->xmin, this->ymin, this->zmin };
+    std::array<Real, 3> upper = { this->xmax, this->ymax, this->zmax };
+    std::array<Int, 3> faces = { this->nx, this->ny, this->nz };
+    std::array<DMBoundaryType, 3> periodicity = {
+        this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED,
+        this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED,
+        this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED
+    };
+
+    DM dm;
+    PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
+                                    3,
+                                    this->simplex,
+                                    faces.data(),
+                                    lower.data(),
+                                    upper.data(),
+                                    periodicity.data(),
+                                    this->interpolate,
+                                    &dm));
+    return dm;
 }
 
 } // namespace godzilla

--- a/src/CSVOutput.cpp
+++ b/src/CSVOutput.cpp
@@ -36,7 +36,7 @@ CSVOutput::create()
 
     set_file_name();
 
-    this->pps_names = this->problem->get_postprocessor_names();
+    this->pps_names = get_problem()->get_postprocessor_names();
 
     if (!this->pps_names.empty())
         open_file();
@@ -62,7 +62,7 @@ CSVOutput::output_step()
         write_header();
         this->has_header = true;
     }
-    write_values(this->problem->get_time());
+    write_values(get_problem()->get_time());
 }
 
 void
@@ -90,7 +90,7 @@ CSVOutput::write_values(Real time)
     _F_;
     fmt::print(this->f, "{:g}", time);
     for (auto & name : this->pps_names) {
-        auto * pps = this->problem->get_postprocessor(name);
+        auto * pps = get_problem()->get_postprocessor(name);
         Real val = pps->get_value();
         fmt::print(this->f, ",{:g}", val);
     }

--- a/src/CSVOutput.cpp
+++ b/src/CSVOutput.cpp
@@ -34,8 +34,6 @@ CSVOutput::create()
     _F_;
     FileOutput::create();
 
-    set_file_name();
-
     this->pps_names = get_problem()->get_postprocessor_names();
 
     if (!this->pps_names.empty())
@@ -56,7 +54,7 @@ CSVOutput::output_step()
     if (this->pps_names.empty())
         return;
 
-    lprint(9, "Output to file: {}", this->file_name);
+    lprint(9, "Output to file: {}", get_file_name());
 
     if (!this->has_header) {
         write_header();
@@ -69,9 +67,9 @@ void
 CSVOutput::open_file()
 {
     _F_;
-    this->f = fopen(this->file_name.c_str(), "w");
+    this->f = fopen(get_file_name().c_str(), "w");
     if (this->f == nullptr)
-        log_error("Unable to open '{}' for writing: {}.", this->file_name, strerror(errno));
+        log_error("Unable to open '{}' for writing: {}.", get_file_name(), strerror(errno));
 }
 
 void

--- a/src/CSVOutput.cpp
+++ b/src/CSVOutput.cpp
@@ -56,7 +56,7 @@ CSVOutput::output_step()
     if (this->pps_names.empty())
         return;
 
-    lprintf(9, "Output to file: {}", this->file_name);
+    lprint(9, "Output to file: {}", this->file_name);
 
     if (!this->has_header) {
         write_header();

--- a/src/ConstantAuxiliaryField.cpp
+++ b/src/ConstantAuxiliaryField.cpp
@@ -30,8 +30,7 @@ ConstantAuxiliaryField::ConstantAuxiliaryField(const Parameters & params) :
     values(params.get<std::vector<Real>>("value"))
 {
     _F_;
-    this->num_comps = this->values.size();
-    assert(this->num_comps >= 1);
+    assert(this->values.size() >= 1);
 }
 
 void
@@ -45,7 +44,7 @@ Int
 ConstantAuxiliaryField::get_num_components() const
 {
     _F_;
-    return this->num_comps;
+    return this->values.size();
 }
 
 PetscFunc *

--- a/src/DirichletBC.cpp
+++ b/src/DirichletBC.cpp
@@ -18,10 +18,10 @@ DirichletBC::parameters()
 DirichletBC::DirichletBC(const Parameters & params) :
     EssentialBC(params),
     FunctionInterface(params),
-    components(this->num_comps, 0)
+    components(get_num_components(), 0)
 {
     _F_;
-    for (Int i = 0; i < this->num_comps; i++)
+    for (Int i = 0; i < get_num_components(); i++)
         this->components[i] = i;
 }
 
@@ -44,7 +44,7 @@ PetscFunc *
 DirichletBC::get_function_t()
 {
     _F_;
-    if (!this->expression_t.empty())
+    if (has_time_expression())
         return EssentialBC::get_function_t();
     else
         return nullptr;

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -267,8 +267,7 @@ DiscreteProblemInterface::set_initial_guess_from_ics()
         ic_ctxs[fid] = ic->get_context();
     }
 
-    auto dm = this->unstr_mesh->dm();
-    PETSC_CHECK(DMProjectFunction(dm,
+    PETSC_CHECK(DMProjectFunction(this->unstr_mesh->get_dm(),
                                   this->problem->get_time(),
                                   ic_funcs,
                                   ic_ctxs,

--- a/src/EssentialBC.cpp
+++ b/src/EssentialBC.cpp
@@ -55,17 +55,18 @@ void
 EssentialBC::create()
 {
     _F_;
-    assert(this->dpi != nullptr);
+    auto dpi = get_discrete_problem_interface();
+    assert(dpi != nullptr);
 
-    std::vector<std::string> field_names = this->dpi->get_field_names();
+    std::vector<std::string> field_names = dpi->get_field_names();
     if (field_names.size() == 1) {
-        this->fid = this->dpi->get_field_id(field_names[0]);
+        this->fid = dpi->get_field_id(field_names[0]);
     }
     else if (field_names.size() > 1) {
         const auto & field_name = get_param<std::string>("field");
         if (field_name.length() > 0) {
-            if (this->dpi->has_field_by_name(field_name))
-                this->fid = this->dpi->get_field_id(field_name);
+            if (dpi->has_field_by_name(field_name))
+                this->fid = dpi->get_field_id(field_name);
             else
                 log_error("Field '{}' does not exists. Typo?", field_name);
         }
@@ -107,14 +108,15 @@ void
 EssentialBC::set_up()
 {
     _F_;
+    auto dpi = get_discrete_problem_interface();
     for (auto & bnd : get_boundary())
-        this->dpi->add_boundary_essential(get_name(),
-                                          bnd,
-                                          get_field_id(),
-                                          get_components(),
-                                          get_function(),
-                                          get_function_t(),
-                                          this);
+        dpi->add_boundary_essential(get_name(),
+                                    bnd,
+                                    get_field_id(),
+                                    get_components(),
+                                    get_function(),
+                                    get_function_t(),
+                                    this);
 }
 
 } // namespace godzilla

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -26,7 +26,7 @@ ExodusIIMesh::create_dm()
     _F_;
     TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", this->file_name);
     PETSC_CHECK(
-        DMPlexCreateExodusFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &this->_dm));
+        DMPlexCreateExodusFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &this->dm));
 
     // Ideally we would like to use DMPlexCreateExodus here and get rid of the above
     // DMPlexCreateExodusFromFile, so that we don't open the same file twice. For some reason,

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -30,7 +30,7 @@ ExodusIIMesh::create()
     // DMPlexCreateExodusFromFile, so that we don't open the same file twice. For some reason,
     // that just doesn't work even though this is just exactly what DMPlexCreateExodusFromFile
     // is doing :confused:
-    exodusIIcpp::File f(this->file_name, exodusIIcpp::FileAccess::READ);
+    exodusIIcpp::File f(get_file_name(), exodusIIcpp::FileAccess::READ);
     if (f.is_opened()) {
         auto blk_names = f.read_block_names();
         for (auto & it : blk_names) {
@@ -54,9 +54,9 @@ DM
 ExodusIIMesh::create_dm()
 {
     _F_;
-    TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", this->file_name);
+    TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", get_file_name());
     DM dm;
-    PETSC_CHECK(DMPlexCreateExodusFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &dm));
+    PETSC_CHECK(DMPlexCreateExodusFromFile(get_comm(), get_file_name().c_str(), PETSC_TRUE, &dm));
     return dm;
 }
 

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -26,7 +26,7 @@ ExodusIIMesh::create_dm()
     _F_;
     TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", this->file_name);
     PETSC_CHECK(
-        DMPlexCreateExodusFromFile(comm(), this->file_name.c_str(), PETSC_TRUE, &this->_dm));
+        DMPlexCreateExodusFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &this->_dm));
 
     // Ideally we would like to use DMPlexCreateExodus here and get rid of the above
     // DMPlexCreateExodusFromFile, so that we don't open the same file twice. For some reason,

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -21,12 +21,10 @@ ExodusIIMesh::ExodusIIMesh(const Parameters & parameters) : FileMesh(parameters)
 }
 
 void
-ExodusIIMesh::create_dm()
+ExodusIIMesh::create()
 {
     _F_;
-    TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", this->file_name);
-    PETSC_CHECK(
-        DMPlexCreateExodusFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &this->dm));
+    UnstructuredMesh::create();
 
     // Ideally we would like to use DMPlexCreateExodus here and get rid of the above
     // DMPlexCreateExodusFromFile, so that we don't open the same file twice. For some reason,
@@ -50,6 +48,16 @@ ExodusIIMesh::create_dm()
 
         f.close();
     }
+}
+
+DM
+ExodusIIMesh::create_dm()
+{
+    _F_;
+    TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", this->file_name);
+    DM dm;
+    PETSC_CHECK(DMPlexCreateExodusFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &dm));
+    return dm;
 }
 
 } // namespace godzilla

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -383,7 +383,7 @@ ExodusIIOutput::write_face_sets()
     if (!this->mesh->has_label("Face Sets"))
         return;
 
-    auto dm = this->mesh->dm();
+    auto dm = this->mesh->get_dm();
     std::vector<std::string> fs_names;
 
     auto face_sets_label = this->mesh->get_label("Face Sets");
@@ -704,7 +704,7 @@ ExodusIIOutput::write_block_connectivity(int blk_id,
                                          const Int * cells)
 {
     _F_;
-    auto dm = this->mesh->dm();
+    auto dm = this->mesh->get_dm();
     Int n_all_elems = this->mesh->get_num_all_cells();
     const char * elem_type = get_elem_type(polytope_type);
     int n_nodes_per_elem = UnstructuredMesh::get_num_cell_nodes(polytope_type);

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -131,17 +131,6 @@ ExodusIIOutput::get_file_ext() const
 }
 
 void
-ExodusIIOutput::set_file_name()
-{
-    _F_;
-    if (get_comm().size() == 1)
-        this->file_name = fmt::format("{}.{}", this->file_base, this->get_file_ext());
-    else
-        this->file_name =
-            fmt::format("{}.{}.{}", this->file_base, get_processor_id(), this->get_file_ext());
-}
-
-void
 ExodusIIOutput::create()
 {
     _F_;
@@ -192,8 +181,7 @@ ExodusIIOutput::output_mesh()
 {
     _F_;
     // We only have fixed meshes, so no need to deal with a sequence of files
-    set_file_name();
-    TIMED_EVENT(9, "ExodusIIOutput", "Output to file: {}", this->file_name);
+    TIMED_EVENT(9, "ExodusIIOutput", "Output to file: {}", get_file_name());
 
     if (this->exo == nullptr)
         open_file();
@@ -209,8 +197,7 @@ ExodusIIOutput::output_step()
 {
     _F_;
     // We only have fixed meshes, so no need to deal with a sequence of files
-    set_file_name();
-    TIMED_EVENT(9, "ExodusIIOutput", "Output to file: {}", this->file_name);
+    TIMED_EVENT(9, "ExodusIIOutput", "Output to file: {}", get_file_name());
 
     if (this->exo == nullptr)
         open_file();
@@ -229,7 +216,7 @@ void
 ExodusIIOutput::open_file()
 {
     _F_;
-    this->exo = new exodusIIcpp::File(this->file_name, exodusIIcpp::FileAccess::WRITE);
+    this->exo = new exodusIIcpp::File(get_file_name(), exodusIIcpp::FileAccess::WRITE);
     if (!this->exo->is_opened())
         error("Could not open file '{}' for writing.", get_file_name());
 }

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -134,7 +134,7 @@ void
 ExodusIIOutput::set_file_name()
 {
     _F_;
-    if (comm().size() == 1)
+    if (get_comm().size() == 1)
         this->file_name = fmt::format("{}.{}", this->file_base, this->get_file_ext());
     else
         this->file_name =
@@ -686,10 +686,11 @@ void
 ExodusIIOutput::write_info()
 {
     _F_;
+    auto app = get_app();
     std::time_t now = std::time(nullptr);
     std::string datetime = fmt::format("{:%d %b %Y, %H:%M:%S}", fmt::localtime(now));
     std::string created_by =
-        fmt::format("Created by {} {}, on {}", get_app()->name(), get_app()->version(), datetime);
+        fmt::format("Created by {} {}, on {}", app->get_name(), app->get_version(), datetime);
 
     std::vector<std::string> info;
     info.push_back(created_by);

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -106,8 +106,8 @@ ExodusIIOutput::parameters()
 ExodusIIOutput::ExodusIIOutput(const Parameters & params) :
     FileOutput(params),
     variable_names(get_param<std::vector<std::string>>("variables")),
-    dpi(dynamic_cast<DiscreteProblemInterface *>(this->problem)),
-    mesh(this->problem ? dynamic_cast<UnstructuredMesh *>(this->problem->get_mesh())
+    dpi(dynamic_cast<DiscreteProblemInterface *>(get_problem())),
+    mesh(get_problem() ? dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh())
                        : get_param<UnstructuredMesh *>("_mesh")),
     exo(nullptr),
     step_num(1),
@@ -150,7 +150,7 @@ ExodusIIOutput::create()
     if (this->dpi) {
         auto flds = this->dpi->get_field_names();
         auto aux_flds = this->dpi->get_aux_field_names();
-        auto & pps = this->problem->get_postprocessor_names();
+        auto & pps = get_problem()->get_postprocessor_names();
 
         if (this->variable_names.empty()) {
             this->field_var_names = flds;
@@ -525,7 +525,7 @@ void
 ExodusIIOutput::write_variables()
 {
     _F_;
-    Real time = this->problem->get_time();
+    Real time = get_problem()->get_time();
     this->exo->write_time(this->step_num, time);
 
     write_field_variables();
@@ -675,7 +675,7 @@ ExodusIIOutput::write_global_variables()
 
     int exo_var_id = 1;
     for (auto & name : this->global_var_names) {
-        Postprocessor * pp = this->problem->get_postprocessor(name);
+        Postprocessor * pp = get_problem()->get_postprocessor(name);
         Real val = pp->get_value();
         this->exo->write_global_var(this->step_num, exo_var_id, val);
         exo_var_id++;

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -61,7 +61,7 @@ ExplicitFELinearProblem::ExplicitFELinearProblem(const Parameters & params) :
     scheme(get_param<std::string>("scheme"))
 {
     _F_;
-    this->default_output_on = Output::ON_INITIAL | Output::ON_TIMESTEP;
+    set_default_output_on(Output::ON_INITIAL | Output::ON_TIMESTEP);
 }
 
 ExplicitFELinearProblem::~ExplicitFELinearProblem()

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -77,14 +77,14 @@ Real
 ExplicitFELinearProblem::get_time() const
 {
     _F_;
-    return this->time;
+    return TransientProblemInterface::get_time();
 }
 
 Int
 ExplicitFELinearProblem::get_step_num() const
 {
     _F_;
-    return this->step_num;
+    return TransientProblemInterface::get_step_number();
 }
 
 void

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -100,7 +100,7 @@ ExplicitFELinearProblem::init()
     for (Int i = 0; i < get_num_fields(); i++)
         add_jacobian_block(i, i, new G0Identity(this), nullptr, nullptr, nullptr);
 
-    for (auto & f : this->fields) {
+    for (auto & f : get_fields()) {
         Int fid = f.second.id;
         PETSC_CHECK(PetscDSSetImplicit(this->ds, fid, PETSC_FALSE));
     }

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -137,7 +137,7 @@ void
 ExplicitFELinearProblem::solve()
 {
     _F_;
-    lprintf(9, "Solving");
+    lprint(9, "Solving");
     TransientProblemInterface::solve(this->x);
 }
 

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -104,7 +104,7 @@ void
 ExplicitFVLinearProblem::solve()
 {
     _F_;
-    lprintf(9, "Solving");
+    lprint(9, "Solving");
     TransientProblemInterface::solve(this->x);
 }
 

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -113,7 +113,7 @@ ExplicitFVLinearProblem::get_solution_vector_local()
 {
     _F_;
     auto & loc_sln = this->sln;
-    PETSC_CHECK(DMGlobalToLocal(dm(), get_solution_vector(), INSERT_VALUES, loc_sln));
+    PETSC_CHECK(DMGlobalToLocal(get_dm(), get_solution_vector(), INSERT_VALUES, loc_sln));
     compute_boundary_local(get_time(), loc_sln);
     return loc_sln;
 }
@@ -131,7 +131,7 @@ void
 ExplicitFVLinearProblem::set_up_callbacks()
 {
     _F_;
-    PETSC_CHECK(DMTSSetRHSFunction(dm(), __efvlp_compute_rhs, this));
+    PETSC_CHECK(DMTSSetRHSFunction(get_dm(), __efvlp_compute_rhs, this));
 }
 
 void
@@ -180,7 +180,7 @@ ExplicitFVLinearProblem::create_mass_matrix()
 {
     _F_;
     Mat m;
-    PETSC_CHECK(DMCreateMassMatrix(dm(), dm(), &m));
+    PETSC_CHECK(DMCreateMassMatrix(get_dm(), get_dm(), &m));
     this->M = Matrix(m);
     PETSC_CHECK(KSPSetOperators(this->ksp, this->M, this->M));
 }
@@ -190,7 +190,7 @@ ExplicitFVLinearProblem::create_mass_matrix_lumped()
 {
     _F_;
     Vec v;
-    PETSC_CHECK(DMCreateMassMatrixLumped(dm(), &v));
+    PETSC_CHECK(DMCreateMassMatrixLumped(get_dm(), &v));
     this->M_lumped_inv = Vector(v);
     this->M_lumped_inv.reciprocal();
 }
@@ -203,11 +203,11 @@ ExplicitFVLinearProblem::compute_rhs(Real time, const Vector & x, Vector & F)
     Vector loc_F = get_local_vector();
     loc_x.zero();
     compute_boundary_local(time, loc_x);
-    PETSC_CHECK(DMGlobalToLocal(dm(), x, INSERT_VALUES, loc_x));
+    PETSC_CHECK(DMGlobalToLocal(get_dm(), x, INSERT_VALUES, loc_x));
     loc_F.zero();
     compute_rhs_local(time, loc_x, loc_F);
     F.zero();
-    PETSC_CHECK(DMLocalToGlobal(dm(), loc_F, ADD_VALUES, F));
+    PETSC_CHECK(DMLocalToGlobal(get_dm(), loc_F, ADD_VALUES, F));
     if ((Vec) this->M_lumped_inv == nullptr)
         PETSC_CHECK(KSPSolve(this->ksp, F, F));
     else
@@ -221,14 +221,14 @@ PetscErrorCode
 ExplicitFVLinearProblem::compute_boundary_local(Real time, Vector & x)
 {
     _F_;
-    return DMPlexTSComputeBoundary(dm(), time, x, nullptr, this);
+    return DMPlexTSComputeBoundary(get_dm(), time, x, nullptr, this);
 }
 
 PetscErrorCode
 ExplicitFVLinearProblem::compute_rhs_local(Real time, const Vector & x, Vector & F)
 {
     _F_;
-    return DMPlexTSComputeRHSFunctionFVM(dm(), time, x, F, this);
+    return DMPlexTSComputeRHSFunctionFVM(get_dm(), time, x, F, this);
 }
 
 void

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -36,7 +36,7 @@ ExplicitFVLinearProblem::ExplicitFVLinearProblem(const Parameters & params) :
     scheme(get_param<std::string>("scheme"))
 {
     _F_;
-    this->default_output_on = Output::ON_INITIAL | Output::ON_TIMESTEP;
+    set_default_output_on(Output::ON_INITIAL | Output::ON_TIMESTEP);
 }
 
 ExplicitFVLinearProblem::~ExplicitFVLinearProblem()

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -51,14 +51,14 @@ Real
 ExplicitFVLinearProblem::get_time() const
 {
     _F_;
-    return this->time;
+    return TransientProblemInterface::get_time();
 }
 
 Int
 ExplicitFVLinearProblem::get_step_num() const
 {
     _F_;
-    return this->step_num;
+    return TransientProblemInterface::get_step_number();
 }
 
 void

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -134,7 +134,7 @@ FENonlinearProblem::compute_residual(const Vector & x, Vector & f)
     // this is based on DMSNESComputeResidual()
     IndexSet all_cells = this->unstr_mesh->get_all_cells();
 
-    for (auto & res_key : this->wf->get_residual_keys()) {
+    for (auto & res_key : get_weak_form()->get_residual_keys()) {
         IndexSet cells;
         if (res_key.label == nullptr) {
             all_cells.inc_ref();
@@ -621,13 +621,14 @@ FENonlinearProblem::compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp)
     // based on DMPlexSNESComputeJacobianFEM and DMSNESComputeJacobianAction
     IndexSet all_cells = this->unstr_mesh->get_all_cells();
 
-    auto has_jac = this->wf->has_jacobian();
-    auto has_precond = this->wf->has_jacobian_preconditioner();
+    auto wf = get_weak_form();
+    auto has_jac = wf->has_jacobian();
+    auto has_precond = wf->has_jacobian_preconditioner();
     if (has_jac && has_precond)
         J.zero();
     Jp.zero();
 
-    for (auto & jac_key : this->wf->get_jacobian_keys()) {
+    for (auto & jac_key : wf->get_jacobian_keys()) {
         IndexSet cells;
         if (!jac_key.label) {
             all_cells.inc_ref();
@@ -683,8 +684,9 @@ FENonlinearProblem::compute_jacobian_internal(DM dm,
     PetscCall(PetscDSGetNumFields(prob, &n_fields));
     Int tot_dim;
     PetscCall(PetscDSGetTotalDimension(prob, &tot_dim));
-    auto has_jac = this->wf->has_jacobian();
-    auto has_prec = this->wf->has_jacobian_preconditioner();
+    auto wf = get_weak_form();
+    auto has_jac = wf->has_jacobian();
+    auto has_prec = wf->has_jacobian_preconditioner();
     // user passed in the same matrix, avoid double contributions and only assemble the Jacobian
     if (has_jac && J == Jp)
         has_prec = PETSC_FALSE;

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -81,9 +81,10 @@ void
 FENonlinearProblem::set_up_callbacks()
 {
     _F_;
-    PETSC_CHECK(DMSNESSetBoundaryLocal(dm(), __fep_compute_boundary, this));
-    PETSC_CHECK(DMSNESSetFunctionLocal(dm(), __fep_compute_residual, this));
-    PETSC_CHECK(DMSNESSetJacobianLocal(dm(), __fep_compute_jacobian, this));
+    auto dm = get_dm();
+    PETSC_CHECK(DMSNESSetBoundaryLocal(dm, __fep_compute_boundary, this));
+    PETSC_CHECK(DMSNESSetFunctionLocal(dm, __fep_compute_residual, this));
+    PETSC_CHECK(DMSNESSetJacobianLocal(dm, __fep_compute_jacobian, this));
     PETSC_CHECK(SNESSetJacobian(this->snes, this->J, this->J, nullptr, nullptr));
 }
 
@@ -107,7 +108,7 @@ const Vector &
 FENonlinearProblem::get_solution_vector_local()
 {
     _F_;
-    PETSC_CHECK(DMGlobalToLocal(dm(), get_solution_vector(), INSERT_VALUES, this->sln));
+    PETSC_CHECK(DMGlobalToLocal(get_dm(), get_solution_vector(), INSERT_VALUES, this->sln));
     compute_boundary(this->sln);
     return this->sln;
 }
@@ -116,8 +117,13 @@ PetscErrorCode
 FENonlinearProblem::compute_boundary(Vector & x)
 {
     _F_;
-    PETSC_CHECK(
-        DMPlexInsertBoundaryValues(dm(), PETSC_TRUE, x, PETSC_MIN_REAL, nullptr, nullptr, nullptr));
+    PETSC_CHECK(DMPlexInsertBoundaryValues(get_dm(),
+                                           PETSC_TRUE,
+                                           x,
+                                           PETSC_MIN_REAL,
+                                           nullptr,
+                                           nullptr,
+                                           nullptr));
     return 0;
 }
 
@@ -140,7 +146,7 @@ FENonlinearProblem::compute_residual(const Vector & x, Vector & f)
             cells = IndexSet::intersect_caching(all_cells, points);
             points.destroy();
         }
-        compute_residual_internal(dm(), res_key, cells, PETSC_MIN_REAL, x, Vector(), 0.0, f);
+        compute_residual_internal(get_dm(), res_key, cells, PETSC_MIN_REAL, x, Vector(), 0.0, f);
         cells.destroy();
     }
 
@@ -633,7 +639,7 @@ FENonlinearProblem::compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp)
             cells = IndexSet::intersect_caching(all_cells, points);
             points.destroy();
         }
-        compute_jacobian_internal(dm(), jac_key, cells, 0.0, 0.0, x, Vector(), J, Jp);
+        compute_jacobian_internal(get_dm(), jac_key, cells, 0.0, 0.0, x, Vector(), J, Jp);
         cells.destroy();
     }
 

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -77,6 +77,13 @@ FEProblemInterface::~FEProblemInterface()
     delete this->asmbl;
 }
 
+const std::map<Int, FEProblemInterface::FieldInfo> &
+FEProblemInterface::get_fields() const
+{
+    _F_;
+    return this->fields;
+}
+
 void
 FEProblemInterface::create()
 {

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -421,7 +421,7 @@ void
 FEProblemInterface::create_fe(FieldInfo & fi)
 {
     _F_;
-    auto comm = this->unstr_mesh->comm();
+    auto comm = this->unstr_mesh->get_comm();
     Int dim = this->problem->get_dimension();
     PetscBool is_simplex = this->unstr_mesh->is_simplex() ? PETSC_TRUE : PETSC_FALSE;
     PETSC_CHECK(internal::create_lagrange_petscfe(comm,

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -93,7 +93,7 @@ FEProblemInterface::init()
     _F_;
     DiscreteProblemInterface::init();
 
-    auto dm = this->unstr_mesh->dm();
+    auto dm = this->unstr_mesh->get_dm();
     DM cdm = dm;
     while (cdm) {
         set_up_auxiliary_dm(cdm);
@@ -444,7 +444,7 @@ FEProblemInterface::set_up_ds()
 
     set_up_quadrature();
 
-    auto dm = this->unstr_mesh->dm();
+    auto dm = this->unstr_mesh->get_dm();
     for (auto & it : this->fields) {
         FieldInfo & fi = it.second;
         PETSC_CHECK(DMSetField(dm, fi.id, fi.block, (PetscObject) fi.fe));

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -50,7 +50,7 @@ FVProblemInterface::init()
                                           &this->aux_fe.at(fi.id)));
     }
 
-    auto dm = this->unstr_mesh->dm();
+    auto dm = this->unstr_mesh->get_dm();
     DM cdm = dm;
     while (cdm) {
         set_up_auxiliary_dm(cdm);
@@ -378,7 +378,7 @@ FVProblemInterface::set_up_ds()
         c += fi.nc;
     }
 
-    auto dm = this->unstr_mesh->dm();
+    auto dm = this->unstr_mesh->get_dm();
     PETSC_CHECK(DMAddField(dm, nullptr, (PetscObject) this->fvm));
     PETSC_CHECK(DMCreateDS(dm));
     PETSC_CHECK(DMGetDS(dm, &this->ds));

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -36,7 +36,7 @@ FVProblemInterface::init()
     _F_;
     DiscreteProblemInterface::init();
 
-    auto comm = this->unstr_mesh->comm();
+    auto comm = this->unstr_mesh->get_comm();
     Int dim = this->problem->get_dimension();
     PetscBool is_simplex = this->unstr_mesh->is_simplex() ? PETSC_TRUE : PETSC_FALSE;
     for (auto & it : this->aux_fields) {
@@ -352,7 +352,7 @@ void
 FVProblemInterface::set_up_ds()
 {
     _F_;
-    auto comm = this->unstr_mesh->comm();
+    auto comm = this->unstr_mesh->get_comm();
 
     PETSC_CHECK(PetscFVCreate(comm, &this->fvm));
     PETSC_CHECK(PetscFVSetType(this->fvm, PETSCFVUPWIND));

--- a/src/FileOutput.cpp
+++ b/src/FileOutput.cpp
@@ -33,25 +33,28 @@ FileOutput::create()
     }
 }
 
-const std::string &
+std::string
 FileOutput::get_file_name() const
 {
     _F_;
-    return this->file_name;
+    if (get_comm().size() == 1)
+        return fmt::format("{}.{}", this->file_base, this->get_file_ext());
+    else
+        return fmt::format("{}.{}.{}", this->file_base, get_processor_id(), this->get_file_ext());
 }
 
 void
-FileOutput::set_file_name()
+FileOutput::set_file_base(const std::string & file_base)
 {
     _F_;
-    this->file_name = fmt::format("{}.{}", this->file_base, this->get_file_ext());
+    this->file_base = file_base;
 }
 
 void
-FileOutput::set_sequence_file_name(unsigned int stepi)
+FileOutput::set_sequence_file_base(unsigned int stepi)
 {
     _F_;
-    this->file_name = fmt::format("{}.{}.{}", this->file_base, stepi, this->get_file_ext());
+    this->file_base = fmt::format("{}.{}", this->file_base, stepi);
 }
 
 } // namespace godzilla

--- a/src/FunctionAuxiliaryField.cpp
+++ b/src/FunctionAuxiliaryField.cpp
@@ -42,7 +42,7 @@ Int
 FunctionAuxiliaryField::get_num_components() const
 {
     _F_;
-    return this->num_comps;
+    return FunctionInterface::get_num_components();
 }
 
 PetscFunc *

--- a/src/FunctionInitialCondition.cpp
+++ b/src/FunctionInitialCondition.cpp
@@ -32,7 +32,7 @@ Int
 FunctionInitialCondition::get_num_components() const
 {
     _F_;
-    return this->num_comps;
+    return FunctionInterface::get_num_components();
 }
 
 void

--- a/src/FunctionInterface.cpp
+++ b/src/FunctionInterface.cpp
@@ -53,6 +53,18 @@ FunctionInterface::create()
     }
 }
 
+unsigned int
+FunctionInterface::get_num_components() const
+{
+    return this->num_comps;
+}
+
+bool
+FunctionInterface::has_time_expression() const
+{
+    return !this->expression_t.empty();
+}
+
 bool
 FunctionInterface::evaluate_func(Int dim, Real time, const Real x[], Int nc, Real u[])
 {

--- a/src/GYMLFile.cpp
+++ b/src/GYMLFile.cpp
@@ -27,7 +27,7 @@ void
 GYMLFile::build()
 {
     _F_;
-    lprintf(9, "Allocating objects");
+    lprint(9, "Allocating objects");
     build_mesh();
     build_problem();
     build_problem_adapt();
@@ -47,7 +47,7 @@ GYMLFile::build_functions()
     if (!this->root["functions"])
         return;
 
-    lprintf(9, "- functions");
+    lprint(9, "- functions");
     auto funcs_block = get_block(this->root, "functions");
     for (const auto & it : funcs_block.values()) {
         Block blk = get_block(funcs_block, it.first.as<std::string>());
@@ -103,7 +103,7 @@ GYMLFile::build_partitioner()
     if (!this->root["partitioner"])
         return;
 
-    lprintf(9, "- partitioner");
+    lprint(9, "- partitioner");
     auto part_node = get_block(this->root, "partitioner");
     auto name = part_node["name"];
     if (name)
@@ -121,7 +121,7 @@ GYMLFile::build_auxiliary_fields()
     if (!this->root["auxs"])
         return;
 
-    lprintf(9, "- auxiliary fields");
+    lprint(9, "- auxiliary fields");
     auto auxs_node = get_block(this->root, "auxs");
     auto * fepi = dynamic_cast<FEProblemInterface *>(this->problem);
     auto * fvpi = dynamic_cast<FVProblemInterface *>(this->problem);
@@ -148,7 +148,7 @@ GYMLFile::build_initial_conditions()
     if (!this->root["ics"])
         return;
 
-    lprintf(9, "- initial conditions");
+    lprint(9, "- initial conditions");
     auto ics_node = get_block(this->root, "ics");
     auto * dpi = dynamic_cast<DiscreteProblemInterface *>(this->problem);
     if (dpi == nullptr)
@@ -173,7 +173,7 @@ GYMLFile::build_boundary_conditions()
     if (!this->root["bcs"])
         return;
 
-    lprintf(9, "- boundary conditions");
+    lprint(9, "- boundary conditions");
     auto bcs_node = get_block(this->root, "bcs");
     auto * dpi = dynamic_cast<DiscreteProblemInterface *>(this->problem);
     if (dpi == nullptr)
@@ -198,7 +198,7 @@ GYMLFile::build_postprocessors()
     if (!this->root["pps"])
         return;
 
-    lprintf(9, "- post-processors");
+    lprint(9, "- post-processors");
     auto pps_node = get_block(this->root, "pps");
     for (const auto & it : pps_node.values()) {
         Block blk = get_block(pps_node, it.first.as<std::string>());

--- a/src/GmshMesh.cpp
+++ b/src/GmshMesh.cpp
@@ -22,10 +22,10 @@ DM
 GmshMesh::create_dm()
 {
     _F_;
-    TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", this->file_name);
+    TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", get_file_name());
     PetscOptionsSetValue(nullptr, "-dm_plex_gmsh_use_regions", nullptr);
     DM dm;
-    PETSC_CHECK(DMPlexCreateGmshFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &dm));
+    PETSC_CHECK(DMPlexCreateGmshFromFile(get_comm(), get_file_name().c_str(), PETSC_TRUE, &dm));
     return dm;
 }
 

--- a/src/GmshMesh.cpp
+++ b/src/GmshMesh.cpp
@@ -25,7 +25,7 @@ GmshMesh::create_dm()
     TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", this->file_name);
     PetscOptionsSetValue(nullptr, "-dm_plex_gmsh_use_regions", nullptr);
     PETSC_CHECK(
-        DMPlexCreateGmshFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &this->_dm));
+        DMPlexCreateGmshFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &this->dm));
 }
 
 } // namespace godzilla

--- a/src/GmshMesh.cpp
+++ b/src/GmshMesh.cpp
@@ -18,14 +18,15 @@ GmshMesh::GmshMesh(const Parameters & parameters) : FileMesh(parameters)
     _F_;
 }
 
-void
+DM
 GmshMesh::create_dm()
 {
     _F_;
     TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", this->file_name);
     PetscOptionsSetValue(nullptr, "-dm_plex_gmsh_use_regions", nullptr);
-    PETSC_CHECK(
-        DMPlexCreateGmshFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &this->dm));
+    DM dm;
+    PETSC_CHECK(DMPlexCreateGmshFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &dm));
+    return dm;
 }
 
 } // namespace godzilla

--- a/src/GmshMesh.cpp
+++ b/src/GmshMesh.cpp
@@ -24,7 +24,8 @@ GmshMesh::create_dm()
     _F_;
     TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", this->file_name);
     PetscOptionsSetValue(nullptr, "-dm_plex_gmsh_use_regions", nullptr);
-    PETSC_CHECK(DMPlexCreateGmshFromFile(comm(), this->file_name.c_str(), PETSC_TRUE, &this->_dm));
+    PETSC_CHECK(
+        DMPlexCreateGmshFromFile(get_comm(), this->file_name.c_str(), PETSC_TRUE, &this->_dm));
 }
 
 } // namespace godzilla

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -167,9 +167,10 @@ void
 ImplicitFENonlinearProblem::set_up_callbacks()
 {
     _F_;
-    PETSC_CHECK(DMTSSetBoundaryLocal(dm(), _tsfep_compute_boundary, this));
-    PETSC_CHECK(DMTSSetIFunctionLocal(dm(), __tsfep_compute_ifunction, this));
-    PETSC_CHECK(DMTSSetIJacobianLocal(dm(), __tsfep_compute_ijacobian, this));
+    auto dm = get_dm();
+    PETSC_CHECK(DMTSSetBoundaryLocal(dm, _tsfep_compute_boundary, this));
+    PETSC_CHECK(DMTSSetIFunctionLocal(dm, __tsfep_compute_ifunction, this));
+    PETSC_CHECK(DMTSSetIJacobianLocal(dm, __tsfep_compute_ijacobian, this));
 }
 
 void
@@ -196,7 +197,7 @@ ImplicitFENonlinearProblem::get_solution_vector_local()
 {
     _F_;
     auto & loc_sln = this->sln;
-    PETSC_CHECK(DMGlobalToLocal(dm(), get_solution_vector(), INSERT_VALUES, loc_sln));
+    PETSC_CHECK(DMGlobalToLocal(get_dm(), get_solution_vector(), INSERT_VALUES, loc_sln));
     compute_boundary(get_time(), loc_sln, Vector());
     return loc_sln;
 }
@@ -223,7 +224,7 @@ ImplicitFENonlinearProblem::compute_ifunction(Real time,
             cells = IndexSet::intersect_caching(all_cells, points);
             points.destroy();
         }
-        compute_residual_internal(dm(), res_key, cells, time, X, X_t, time, F);
+        compute_residual_internal(get_dm(), res_key, cells, time, X, X_t, time, F);
         cells.destroy();
     }
 
@@ -257,7 +258,7 @@ ImplicitFENonlinearProblem::compute_ijacobian(Real time,
             cells = IndexSet::intersect_caching(all_cells, points);
             points.destroy();
         }
-        compute_jacobian_internal(dm(), jac_key, cells, time, x_t_shift, X, X_t, J, Jp);
+        compute_jacobian_internal(get_dm(), jac_key, cells, time, x_t_shift, X, X_t, J, Jp);
         cells.destroy();
     }
 
@@ -268,7 +269,7 @@ PetscErrorCode
 ImplicitFENonlinearProblem::compute_boundary(Real time, const Vector & X, const Vector & X_t)
 {
     _F_;
-    return DMPlexTSComputeBoundary(dm(), time, X, X_t, this);
+    return DMPlexTSComputeBoundary(get_dm(), time, X, X_t, this);
 }
 
 void

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -212,7 +212,7 @@ ImplicitFENonlinearProblem::compute_ifunction(Real time,
     _F_;
     IndexSet all_cells = this->unstr_mesh->get_all_cells();
 
-    for (auto & res_key : this->wf->get_residual_keys()) {
+    for (auto & res_key : get_weak_form()->get_residual_keys()) {
         IndexSet cells;
         if (res_key.label == nullptr) {
             all_cells.inc_ref();
@@ -246,7 +246,7 @@ ImplicitFENonlinearProblem::compute_ijacobian(Real time,
 
     Jp.zero();
 
-    for (auto & jac_key : this->wf->get_jacobian_keys()) {
+    for (auto & jac_key : get_weak_form()->get_jacobian_keys()) {
         IndexSet cells;
         if (!jac_key.label) {
             all_cells.inc_ref();

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -159,7 +159,7 @@ void
 ImplicitFENonlinearProblem::solve()
 {
     _F_;
-    lprintf(9, "Solving");
+    lprint(9, "Solving");
     TransientProblemInterface::solve(this->x);
 }
 

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -108,14 +108,14 @@ Real
 ImplicitFENonlinearProblem::get_time() const
 {
     _F_;
-    return this->time;
+    return TransientProblemInterface::get_time();
 }
 
 Int
 ImplicitFENonlinearProblem::get_step_num() const
 {
     _F_;
-    return this->step_num;
+    return TransientProblemInterface::get_step_number();
 }
 
 void

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -94,7 +94,7 @@ ImplicitFENonlinearProblem::ImplicitFENonlinearProblem(const Parameters & params
     scheme(get_param<std::string>("scheme"))
 {
     _F_;
-    this->default_output_on = Output::ON_INITIAL | Output::ON_TIMESTEP;
+    set_default_output_on(Output::ON_INITIAL | Output::ON_TIMESTEP);
 }
 
 ImplicitFENonlinearProblem::~ImplicitFENonlinearProblem()

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -45,7 +45,7 @@ InputFile::Block::name() const
 InputFile::InputFile(App * app) :
     PrintInterface(app),
     LoggingInterface(app->get_logger()),
-    _app(app),
+    app(app),
     mesh(nullptr),
     problem(nullptr)
 {
@@ -60,9 +60,9 @@ InputFile::get_file_name() const
 }
 
 App *
-InputFile::app() const
+InputFile::get_app() const
 {
-    return this->_app;
+    return this->app;
 }
 
 bool
@@ -82,14 +82,14 @@ InputFile::parse(const std::string & file_name)
 }
 
 Mesh *
-InputFile::get_mesh()
+InputFile::get_mesh() const
 {
     _F_;
     return this->mesh;
 }
 
 Problem *
-InputFile::get_problem()
+InputFile::get_problem() const
 {
     _F_;
     return this->problem;
@@ -143,7 +143,7 @@ InputFile::build_mesh()
     auto node = get_block(this->root, "mesh");
     Parameters * params = build_params(node);
     const auto & class_name = params->get<std::string>("_type");
-    this->mesh = app()->build_object<Mesh>(class_name, "mesh", params);
+    this->mesh = this->app->build_object<Mesh>(class_name, "mesh", params);
     add_object(this->mesh);
 }
 
@@ -156,7 +156,7 @@ InputFile::build_problem()
     Parameters * params = build_params(node);
     const auto & class_name = params->get<std::string>("_type");
     params->set<Mesh *>("_mesh") = this->mesh;
-    this->problem = app()->build_object<Problem>(class_name, "problem", params);
+    this->problem = this->app->build_object<Problem>(class_name, "problem", params);
     add_object(this->problem);
 }
 
@@ -174,7 +174,7 @@ InputFile::build_outputs()
         Parameters * params = build_params(blk);
         const auto & class_name = params->get<std::string>("_type");
         params->set<Problem *>("_problem") = this->problem;
-        auto output = app()->build_object<Output>(class_name, blk.name(), params);
+        auto output = this->app->build_object<Output>(class_name, blk.name(), params);
         assert(this->problem != nullptr);
         this->problem->add_output(output);
     }
@@ -209,14 +209,14 @@ InputFile::build_params(const Block & block)
     if (!type)
         error("{}: No 'type' specified.", block.name());
     const std::string & class_name = type.as<std::string>();
-    if (!app()->get_factory().is_registered(class_name))
+    if (!this->app->get_factory().is_registered(class_name))
         error("{}: Type '{}' is not a registered object.", block.name(), class_name);
     unused_param_names.erase("type");
 
-    Parameters * params = app()->get_parameters(class_name);
+    Parameters * params = this->app->get_parameters(class_name);
     params->set<std::string>("_type") = class_name;
     params->set<std::string>("_name") = block.name();
-    params->set<App *>("_app") = app();
+    params->set<App *>("_app") = this->app;
 
     for (auto & kv : *params) {
         const std::string & param_name = kv.first;

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -96,11 +96,11 @@ InputFile::get_problem()
 }
 
 void
-InputFile::create()
+InputFile::create_objects()
 {
     _F_;
     lprint(9, "Creating objects");
-    for (auto & obj : this->objects)
+    for (auto & obj : this->objs)
         obj->create();
 }
 
@@ -108,7 +108,7 @@ void
 InputFile::check()
 {
     _F_;
-    for (auto & obj : this->objects)
+    for (auto & obj : this->objs)
         obj->check();
     check_unused_blocks();
 }
@@ -131,7 +131,7 @@ InputFile::add_object(Object * obj)
     if (obj != nullptr) {
         // only add objects with valid parameters
         if (this->valid_param_object_names.count(obj->get_name()) == 1)
-            this->objects.push_back(obj);
+            this->objs.push_back(obj);
     }
 }
 

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -209,7 +209,7 @@ InputFile::build_params(const Block & block)
     if (!type)
         error("{}: No 'type' specified.", block.name());
     const std::string & class_name = type.as<std::string>();
-    if (!app()->factory().is_registered(class_name))
+    if (!app()->get_factory().is_registered(class_name))
         error("{}: Type '{}' is not a registered object.", block.name(), class_name);
     unused_param_names.erase("type");
 

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -69,7 +69,7 @@ bool
 InputFile::parse(const std::string & file_name)
 {
     _F_;
-    lprintf(9, "Parsing input file '{}'", file_name);
+    lprint(9, "Parsing input file '{}'", file_name);
     try {
         this->root = { YAML::Node(), YAML::LoadFile(file_name) };
         this->file_name = file_name;
@@ -99,7 +99,7 @@ void
 InputFile::create()
 {
     _F_;
-    lprintf(9, "Creating objects");
+    lprint(9, "Creating objects");
     for (auto & obj : this->objects)
         obj->create();
 }
@@ -139,7 +139,7 @@ void
 InputFile::build_mesh()
 {
     _F_;
-    lprintf(9, "- mesh");
+    lprint(9, "- mesh");
     auto node = get_block(this->root, "mesh");
     Parameters * params = build_params(node);
     const auto & class_name = params->get<std::string>("_type");
@@ -151,7 +151,7 @@ void
 InputFile::build_problem()
 {
     _F_;
-    lprintf(9, "- problem");
+    lprint(9, "- problem");
     auto node = get_block(this->root, "problem");
     Parameters * params = build_params(node);
     const auto & class_name = params->get<std::string>("_type");
@@ -167,7 +167,7 @@ InputFile::build_outputs()
     if (!this->root["output"])
         return;
 
-    lprintf(9, "- outputs");
+    lprint(9, "- outputs");
     auto output_block = get_block(this->root, "output");
     for (const auto & it : output_block.values()) {
         Block blk = get_block(output_block, it.first.as<std::string>());

--- a/src/L2Diff.cpp
+++ b/src/L2Diff.cpp
@@ -42,13 +42,14 @@ void
 L2Diff::compute()
 {
     _F_;
+    auto problem = get_problem();
     std::vector<PetscFunc *> funcs(1, l2_diff_eval);
     std::vector<void *> ctxs(1, this);
-    PETSC_CHECK(DMComputeL2Diff(this->problem->get_dm(),
-                                this->problem->get_time(),
+    PETSC_CHECK(DMComputeL2Diff(problem->get_dm(),
+                                problem->get_time(),
                                 funcs.data(),
                                 ctxs.data(),
-                                this->problem->get_solution_vector(),
+                                problem->get_solution_vector(),
                                 &this->l2_diff));
 }
 

--- a/src/L2Diff.cpp
+++ b/src/L2Diff.cpp
@@ -44,7 +44,7 @@ L2Diff::compute()
     _F_;
     std::vector<PetscFunc *> funcs(1, l2_diff_eval);
     std::vector<void *> ctxs(1, this);
-    PETSC_CHECK(DMComputeL2Diff(this->problem->dm(),
+    PETSC_CHECK(DMComputeL2Diff(this->problem->get_dm(),
                                 this->problem->get_time(),
                                 funcs.data(),
                                 ctxs.data(),

--- a/src/L2FieldDiff.cpp
+++ b/src/L2FieldDiff.cpp
@@ -84,7 +84,7 @@ L2FieldDiff::compute()
         ctxs[fid] = pfn->get_context();
     }
 
-    PETSC_CHECK(DMComputeL2FieldDiff(this->problem->dm(),
+    PETSC_CHECK(DMComputeL2FieldDiff(this->problem->get_dm(),
                                      this->problem->get_time(),
                                      pfns.data(),
                                      ctxs.data(),

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -61,7 +61,7 @@ LineMesh::create_dm()
     std::array<Int, 1> faces = { this->nx };
     std::array<DMBoundaryType, 1> periodicity = { DM_BOUNDARY_GHOSTED };
 
-    PETSC_CHECK(DMPlexCreateBoxMesh(comm(),
+    PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
                                     1,
                                     PETSC_TRUE,
                                     faces.data(),

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -53,23 +53,10 @@ LineMesh::get_nx() const
 }
 
 void
-LineMesh::create_dm()
+LineMesh::create()
 {
     _F_;
-    std::array<Real, 1> lower = { this->xmin };
-    std::array<Real, 1> upper = { this->xmax };
-    std::array<Int, 1> faces = { this->nx };
-    std::array<DMBoundaryType, 1> periodicity = { DM_BOUNDARY_GHOSTED };
-
-    PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
-                                    1,
-                                    PETSC_TRUE,
-                                    faces.data(),
-                                    lower.data(),
-                                    upper.data(),
-                                    periodicity.data(),
-                                    this->interpolate,
-                                    &this->dm));
+    UnstructuredMesh::create();
 
     remove_label("marker");
     // create user-friendly names for sides
@@ -79,6 +66,28 @@ LineMesh::create_dm()
     create_face_set_labels(face_set_names);
     for (auto it : face_set_names)
         set_face_set_name(it.first, it.second);
+}
+
+DM
+LineMesh::create_dm()
+{
+    _F_;
+    std::array<Real, 1> lower = { this->xmin };
+    std::array<Real, 1> upper = { this->xmax };
+    std::array<Int, 1> faces = { this->nx };
+    std::array<DMBoundaryType, 1> periodicity = { DM_BOUNDARY_GHOSTED };
+
+    DM dm;
+    PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
+                                    1,
+                                    PETSC_TRUE,
+                                    faces.data(),
+                                    lower.data(),
+                                    upper.data(),
+                                    periodicity.data(),
+                                    this->interpolate,
+                                    &dm));
+    return dm;
 }
 
 } // namespace godzilla

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -69,7 +69,7 @@ LineMesh::create_dm()
                                     upper.data(),
                                     periodicity.data(),
                                     this->interpolate,
-                                    &this->_dm));
+                                    &this->dm));
 
     remove_label("marker");
     // create user-friendly names for sides

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -146,7 +146,7 @@ void
 LinearProblem::ksp_monitor_callback(Int it, Real rnorm)
 {
     _F_;
-    lprintf(8, "{} Linear residual: {:e}", it, rnorm);
+    lprint(8, "{} Linear residual: {:e}", it, rnorm);
 }
 
 bool

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -100,7 +100,7 @@ void
 LinearProblem::init()
 {
     _F_;
-    PETSC_CHECK(KSPCreate(comm(), &this->ksp));
+    PETSC_CHECK(KSPCreate(get_comm(), &this->ksp));
     PETSC_CHECK(KSPSetDM(this->ksp, dm()));
     PETSC_CHECK(DMSetApplicationContext(dm(), this));
 }

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -58,7 +58,7 @@ LinearProblem::LinearProblem(const Parameters & parameters) :
     lin_max_iter(get_param<Int>("lin_max_iter"))
 {
     _F_;
-    this->default_output_on = Output::ON_FINAL;
+    set_default_output_on(Output::ON_FINAL);
 }
 
 LinearProblem::~LinearProblem()

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -101,8 +101,8 @@ LinearProblem::init()
 {
     _F_;
     PETSC_CHECK(KSPCreate(get_comm(), &this->ksp));
-    PETSC_CHECK(KSPSetDM(this->ksp, dm()));
-    PETSC_CHECK(DMSetApplicationContext(dm(), this));
+    PETSC_CHECK(KSPSetDM(this->ksp, get_dm()));
+    PETSC_CHECK(DMSetApplicationContext(get_dm(), this));
 }
 
 void

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -14,7 +14,7 @@ Mesh::parameters()
 Mesh::Mesh(const Parameters & parameters) :
     Object(parameters),
     PrintInterface(this),
-    _dm(nullptr),
+    dm(nullptr),
     dim(-1)
 {
 }
@@ -22,22 +22,15 @@ Mesh::Mesh(const Parameters & parameters) :
 Mesh::~Mesh()
 {
     _F_;
-    if (this->_dm)
-        PETSC_CHECK(DMDestroy(&this->_dm));
+    if (this->dm)
+        PETSC_CHECK(DMDestroy(&this->dm));
 }
 
 DM
 Mesh::get_dm() const
 {
     _F_;
-    return dm();
-}
-
-DM
-Mesh::dm() const
-{
-    _F_;
-    return this->_dm;
+    return this->dm;
 }
 
 Int
@@ -52,7 +45,7 @@ Mesh::has_label(const std::string & name) const
 {
     _F_;
     PetscBool exists = PETSC_FALSE;
-    PETSC_CHECK(DMHasLabel(this->_dm, name.c_str(), &exists));
+    PETSC_CHECK(DMHasLabel(this->dm, name.c_str(), &exists));
     return exists == PETSC_TRUE;
 }
 
@@ -61,7 +54,7 @@ Mesh::get_label(const std::string & name) const
 {
     _F_;
     DMLabel label;
-    PETSC_CHECK(DMGetLabel(this->_dm, name.c_str(), &label));
+    PETSC_CHECK(DMGetLabel(this->dm, name.c_str(), &label));
     return Label(label);
 }
 
@@ -70,8 +63,8 @@ Mesh::create_label(const std::string & name) const
 {
     _F_;
     DMLabel label;
-    PETSC_CHECK(DMCreateLabel(this->_dm, name.c_str()));
-    PETSC_CHECK(DMGetLabel(this->_dm, name.c_str(), &label));
+    PETSC_CHECK(DMCreateLabel(this->dm, name.c_str()));
+    PETSC_CHECK(DMGetLabel(this->dm, name.c_str(), &label));
     return Label(label);
 }
 
@@ -79,7 +72,7 @@ void
 Mesh::remove_label(const std::string & name)
 {
     _F_;
-    PETSC_CHECK(DMRemoveLabel(this->_dm, name.c_str(), nullptr));
+    PETSC_CHECK(DMRemoveLabel(this->dm, name.c_str(), nullptr));
 }
 
 DM
@@ -87,7 +80,7 @@ Mesh::get_coordinate_dm() const
 {
     _F_;
     DM cdm;
-    PETSC_CHECK(DMGetCoordinateDM(this->_dm, &cdm));
+    PETSC_CHECK(DMGetCoordinateDM(this->dm, &cdm));
     return cdm;
 }
 
@@ -96,7 +89,7 @@ Mesh::get_coordinates() const
 {
     _F_;
     Vec vec;
-    PETSC_CHECK(DMGetCoordinates(this->_dm, &vec));
+    PETSC_CHECK(DMGetCoordinates(this->dm, &vec));
     return { vec };
 }
 
@@ -105,7 +98,7 @@ Mesh::get_coordinates_local() const
 {
     _F_;
     Vec vec;
-    PETSC_CHECK(DMGetCoordinatesLocal(this->_dm, &vec));
+    PETSC_CHECK(DMGetCoordinatesLocal(this->dm, &vec));
     return { vec };
 }
 
@@ -114,7 +107,7 @@ Mesh::get_coordinate_section() const
 {
     _F_;
     PetscSection section;
-    PETSC_CHECK(DMGetCoordinateSection(this->_dm, &section));
+    PETSC_CHECK(DMGetCoordinateSection(this->dm, &section));
     return { section };
 }
 
@@ -122,7 +115,7 @@ void
 Mesh::set_up()
 {
     _F_;
-    PETSC_CHECK(DMSetUp(this->_dm));
+    PETSC_CHECK(DMSetUp(this->dm));
 }
 
 } // namespace godzilla

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -11,13 +11,7 @@ Mesh::parameters()
     return params;
 }
 
-Mesh::Mesh(const Parameters & parameters) :
-    Object(parameters),
-    PrintInterface(this),
-    dm(nullptr),
-    dim(-1)
-{
-}
+Mesh::Mesh(const Parameters & parameters) : Object(parameters), PrintInterface(this), dm(nullptr) {}
 
 Mesh::~Mesh()
 {
@@ -37,7 +31,9 @@ Int
 Mesh::get_dimension() const
 {
     _F_;
-    return this->dim;
+    Int dim;
+    PETSC_CHECK(DMGetDimension(this->dm, &dim));
+    return dim;
 }
 
 bool
@@ -116,6 +112,15 @@ Mesh::set_up()
 {
     _F_;
     PETSC_CHECK(DMSetUp(this->dm));
+}
+
+void
+Mesh::set_dm(DM dm)
+{
+    _F_;
+    if (this->dm)
+        PETSC_CHECK(DMDestroy(&this->dm));
+    this->dm = dm;
 }
 
 } // namespace godzilla

--- a/src/MeshPartitioningOutput.cpp
+++ b/src/MeshPartitioningOutput.cpp
@@ -19,7 +19,7 @@ MeshPartitioningOutput::parameters()
 MeshPartitioningOutput::MeshPartitioningOutput(const Parameters & params) : FileOutput(params)
 {
     _F_;
-    this->file_base = "part";
+    set_file_base("part");
 }
 
 void
@@ -43,8 +43,6 @@ void
 MeshPartitioningOutput::output_step()
 {
     _F_;
-    set_file_name();
-
     PetscViewer viewer;
     PETSC_CHECK(PetscViewerHDF5Open(get_comm(), get_file_name().c_str(), FILE_MODE_WRITE, &viewer));
 

--- a/src/MeshPartitioningOutput.cpp
+++ b/src/MeshPartitioningOutput.cpp
@@ -27,7 +27,7 @@ MeshPartitioningOutput::check()
 {
     _F_;
     FileOutput::check();
-    auto dm = this->problem->dm();
+    auto dm = this->problem->get_dm();
     if (dm == nullptr)
         log_error("Mesh partitioning output works only with problems that provide DM.");
 }
@@ -49,7 +49,7 @@ MeshPartitioningOutput::output_step()
     PETSC_CHECK(PetscViewerHDF5Open(get_comm(), get_file_name().c_str(), FILE_MODE_WRITE, &viewer));
 
     DM dmp;
-    PETSC_CHECK(DMClone(this->problem->dm(), &dmp));
+    PETSC_CHECK(DMClone(this->problem->get_dm(), &dmp));
 
     Int dim;
     PETSC_CHECK(DMGetDimension(dmp, &dim));

--- a/src/MeshPartitioningOutput.cpp
+++ b/src/MeshPartitioningOutput.cpp
@@ -27,7 +27,7 @@ MeshPartitioningOutput::check()
 {
     _F_;
     FileOutput::check();
-    auto dm = this->problem->get_dm();
+    auto dm = get_problem()->get_dm();
     if (dm == nullptr)
         log_error("Mesh partitioning output works only with problems that provide DM.");
 }
@@ -49,7 +49,7 @@ MeshPartitioningOutput::output_step()
     PETSC_CHECK(PetscViewerHDF5Open(get_comm(), get_file_name().c_str(), FILE_MODE_WRITE, &viewer));
 
     DM dmp;
-    PETSC_CHECK(DMClone(this->problem->get_dm(), &dmp));
+    PETSC_CHECK(DMClone(get_problem()->get_dm(), &dmp));
 
     Int dim;
     PETSC_CHECK(DMGetDimension(dmp, &dim));

--- a/src/MeshPartitioningOutput.cpp
+++ b/src/MeshPartitioningOutput.cpp
@@ -46,7 +46,7 @@ MeshPartitioningOutput::output_step()
     set_file_name();
 
     PetscViewer viewer;
-    PETSC_CHECK(PetscViewerHDF5Open(comm(), get_file_name().c_str(), FILE_MODE_WRITE, &viewer));
+    PETSC_CHECK(PetscViewerHDF5Open(get_comm(), get_file_name().c_str(), FILE_MODE_WRITE, &viewer));
 
     DM dmp;
     PETSC_CHECK(DMClone(this->problem->dm(), &dmp));

--- a/src/NaturalBC.cpp
+++ b/src/NaturalBC.cpp
@@ -19,7 +19,7 @@ NaturalBC::parameters()
 NaturalBC::NaturalBC(const Parameters & params) :
     BoundaryCondition(params),
     fid(-1),
-    fepi(dynamic_cast<FEProblemInterface *>(this->dpi))
+    fepi(dynamic_cast<FEProblemInterface *>(get_discrete_problem_interface()))
 {
     _F_;
 }
@@ -28,17 +28,18 @@ void
 NaturalBC::create()
 {
     _F_;
-    assert(this->dpi != nullptr);
+    auto dpi = get_discrete_problem_interface();
+    assert(dpi != nullptr);
 
-    std::vector<std::string> field_names = this->dpi->get_field_names();
+    std::vector<std::string> field_names = dpi->get_field_names();
     if (field_names.size() == 1) {
-        this->fid = this->dpi->get_field_id(field_names[0]);
+        this->fid = dpi->get_field_id(field_names[0]);
     }
     else if (field_names.size() > 1) {
         const auto & field_name = get_param<std::string>("field");
         if (field_name.length() > 0) {
-            if (this->dpi->has_field_by_name(field_name))
-                this->fid = this->dpi->get_field_id(field_name);
+            if (dpi->has_field_by_name(field_name))
+                this->fid = dpi->get_field_id(field_name);
             else
                 log_error("Field '{}' does not exists. Typo?", field_name);
         }
@@ -59,8 +60,9 @@ void
 NaturalBC::set_up()
 {
     _F_;
+    auto dpi = get_discrete_problem_interface();
     for (auto & bnd : get_boundary())
-        this->dpi->add_boundary_natural(get_name(), bnd, get_field_id(), get_components(), this);
+        dpi->add_boundary_natural(get_name(), bnd, get_field_id(), get_components(), this);
 }
 
 void

--- a/src/NaturalRiemannBC.cpp
+++ b/src/NaturalRiemannBC.cpp
@@ -39,11 +39,12 @@ void
 NaturalRiemannBC::create()
 {
     _F_;
-    assert(this->dpi != nullptr);
+    auto dpi = get_discrete_problem_interface();
+    assert(dpi != nullptr);
 
-    std::vector<std::string> field_names = this->dpi->get_field_names();
+    std::vector<std::string> field_names = dpi->get_field_names();
     if (field_names.size() == 1) {
-        this->fid = this->dpi->get_field_id(field_names[0]);
+        this->fid = dpi->get_field_id(field_names[0]);
     }
 }
 
@@ -58,14 +59,15 @@ void
 NaturalRiemannBC::set_up()
 {
     _F_;
+    auto dpi = get_discrete_problem_interface();
     for (auto & bnd : get_boundary())
-        this->dpi->add_boundary_natural_riemann(get_name(),
-                                                bnd,
-                                                get_field_id(),
-                                                get_components(),
-                                                natural_riemann_boundary_condition_function,
-                                                nullptr,
-                                                this);
+        dpi->add_boundary_natural_riemann(get_name(),
+                                          bnd,
+                                          get_field_id(),
+                                          get_components(),
+                                          natural_riemann_boundary_condition_function,
+                                          nullptr,
+                                          this);
 }
 
 } // namespace godzilla

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -250,14 +250,14 @@ void
 NonlinearProblem::snes_monitor_callback(Int it, Real norm)
 {
     _F_;
-    lprintf(7, "{} Non-linear residual: {:e}", it, norm);
+    lprint(7, "{} Non-linear residual: {:e}", it, norm);
 }
 
 void
 NonlinearProblem::ksp_monitor_callback(Int it, Real rnorm)
 {
     _F_;
-    lprintf(8, "    {} Linear residual: {:e}", it, rnorm);
+    lprint(8, "    {} Linear residual: {:e}", it, rnorm);
 }
 
 bool
@@ -298,7 +298,7 @@ void
 NonlinearProblem::solve()
 {
     _F_;
-    lprintf(9, "Solving");
+    lprint(9, "Solving");
     PETSC_CHECK(SNESSolve(this->snes, nullptr, this->x));
     PETSC_CHECK(SNESGetConvergedReason(this->snes, &this->converged_reason));
 }

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -147,8 +147,8 @@ NonlinearProblem::init()
 {
     _F_;
     PETSC_CHECK(SNESCreate(get_comm(), &this->snes));
-    PETSC_CHECK(SNESSetDM(this->snes, dm()));
-    PETSC_CHECK(DMSetApplicationContext(dm(), this));
+    PETSC_CHECK(SNESSetDM(this->snes, get_dm()));
+    PETSC_CHECK(DMSetApplicationContext(get_dm(), this));
     PETSC_CHECK(SNESGetKSP(this->snes, &this->ksp));
 }
 

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -146,7 +146,7 @@ void
 NonlinearProblem::init()
 {
     _F_;
-    PETSC_CHECK(SNESCreate(comm(), &this->snes));
+    PETSC_CHECK(SNESCreate(get_comm(), &this->snes));
     PETSC_CHECK(SNESSetDM(this->snes, dm()));
     PETSC_CHECK(DMSetApplicationContext(dm(), this));
     PETSC_CHECK(SNESGetKSP(this->snes, &this->ksp));

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -92,7 +92,7 @@ NonlinearProblem::NonlinearProblem(const Parameters & parameters) :
     lin_max_iter(get_param<Int>("lin_max_iter"))
 {
     _F_;
-    this->default_output_on = Output::ON_FINAL;
+    set_default_output_on(Output::ON_FINAL);
     line_search_type = utils::to_lower(line_search_type);
 }
 

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -69,21 +69,14 @@ const mpi::Communicator &
 Object::get_comm() const
 {
     _F_;
-    return this->_app->comm();
-}
-
-const mpi::Communicator &
-Object::comm() const
-{
-    _F_;
-    return this->_app->comm();
+    return this->_app->get_comm();
 }
 
 int
 Object::get_processor_id() const
 {
     _F_;
-    return this->_app->comm().rank();
+    return this->_app->get_comm().rank();
 }
 
 void

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -52,6 +52,20 @@ Output::set_exec_mask(unsigned int mask)
     this->on_mask = mask;
 }
 
+Problem *
+Output::get_problem() const
+{
+    _F_;
+    return this->problem;
+}
+
+unsigned int
+Output::get_exec_mask() const
+{
+    _F_;
+    return this->on_mask;
+}
+
 void
 Output::set_up_exec()
 {

--- a/src/Postprocessor.cpp
+++ b/src/Postprocessor.cpp
@@ -18,4 +18,11 @@ Postprocessor::Postprocessor(const Parameters & params) :
 {
 }
 
+Problem *
+Postprocessor::get_problem() const
+{
+    _F_;
+    return this->problem;
+}
+
 } // namespace godzilla

--- a/src/PrintInterface.cpp
+++ b/src/PrintInterface.cpp
@@ -13,7 +13,7 @@ PrintInterface::TimedEvent::TimedEvent(const PrintInterface * pi,
     pi(pi),
     level(level)
 {
-    std::string evt_name = fmt::format("{}::{}", this->pi->pi_app->name(), event_name);
+    std::string evt_name = fmt::format("{}::{}", this->pi->pi_app->get_name(), event_name);
     if (!PerfLog::is_event_registered(evt_name))
         PerfLog::register_event(evt_name);
     this->event = new PerfLog::Event(evt_name);
@@ -37,7 +37,7 @@ PrintInterface::TimedEvent::~TimedEvent()
 PrintInterface::PrintInterface(const Object * obj) :
     pi_app(obj->get_app()),
     proc_id(obj->get_processor_id()),
-    verbosity_level(obj->get_app()->verbosity_level()),
+    verbosity_level(obj->get_app()->get_verbosity_level()),
     prefix(obj->get_name())
 {
     _F_;
@@ -45,9 +45,9 @@ PrintInterface::PrintInterface(const Object * obj) :
 
 PrintInterface::PrintInterface(const App * app) :
     pi_app(app),
-    proc_id(app->comm().rank()),
-    verbosity_level(app->verbosity_level()),
-    prefix(app->name())
+    proc_id(app->get_comm().rank()),
+    verbosity_level(app->get_verbosity_level()),
+    prefix(app->get_name())
 {
     _F_;
 }

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -257,4 +257,10 @@ Problem::set_global_section(const Section & section) const
     PETSC_CHECK(DMSetGlobalSection(get_dm(), section));
 }
 
+void
+Problem::set_default_output_on(unsigned int mask)
+{
+    this->default_output_on = mask;
+}
+
 } // namespace godzilla

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -28,14 +28,7 @@ DM
 Problem::get_dm() const
 {
     _F_;
-    return dm();
-}
-
-DM
-Problem::dm() const
-{
-    _F_;
-    return this->mesh->dm();
+    return this->mesh->get_dm();
 }
 
 void
@@ -178,7 +171,7 @@ Problem::create_local_vector() const
 {
     _F_;
     Vec v;
-    PETSC_CHECK(DMCreateLocalVector(dm(), &v));
+    PETSC_CHECK(DMCreateLocalVector(get_dm(), &v));
     return { v };
 }
 
@@ -187,7 +180,7 @@ Problem::get_local_vector() const
 {
     _F_;
     Vec v;
-    PETSC_CHECK(DMGetLocalVector(dm(), &v));
+    PETSC_CHECK(DMGetLocalVector(get_dm(), &v));
     return { v };
 }
 
@@ -196,7 +189,7 @@ Problem::restore_local_vector(const Vector & vec) const
 {
     _F_;
     Vec v = vec;
-    PETSC_CHECK(DMRestoreLocalVector(dm(), &v));
+    PETSC_CHECK(DMRestoreLocalVector(get_dm(), &v));
 }
 
 Vector
@@ -204,7 +197,7 @@ Problem::create_global_vector() const
 {
     _F_;
     Vec v;
-    PETSC_CHECK(DMCreateGlobalVector(dm(), &v));
+    PETSC_CHECK(DMCreateGlobalVector(get_dm(), &v));
     return { v };
 }
 
@@ -213,7 +206,7 @@ Problem::get_global_vector() const
 {
     _F_;
     Vec v;
-    PETSC_CHECK(DMGetGlobalVector(dm(), &v));
+    PETSC_CHECK(DMGetGlobalVector(get_dm(), &v));
     return { v };
 }
 
@@ -222,7 +215,7 @@ Problem::restore_global_vector(const Vector & vec) const
 {
     _F_;
     Vec v = vec;
-    PETSC_CHECK(DMRestoreGlobalVector(dm(), &v));
+    PETSC_CHECK(DMRestoreGlobalVector(get_dm(), &v));
 }
 
 Matrix
@@ -230,7 +223,7 @@ Problem::create_matrix() const
 {
     _F_;
     Mat m;
-    PETSC_CHECK(DMCreateMatrix(dm(), &m));
+    PETSC_CHECK(DMCreateMatrix(get_dm(), &m));
     return { m };
 }
 
@@ -238,7 +231,7 @@ Section
 Problem::get_local_section() const
 {
     PetscSection section = nullptr;
-    PETSC_CHECK(DMGetLocalSection(dm(), &section));
+    PETSC_CHECK(DMGetLocalSection(get_dm(), &section));
     return { section };
 }
 
@@ -246,14 +239,14 @@ void
 Problem::set_local_section(const Section & section) const
 {
     _F_;
-    PETSC_CHECK(DMSetLocalSection(dm(), section));
+    PETSC_CHECK(DMSetLocalSection(get_dm(), section));
 }
 
 Section
 Problem::get_global_section() const
 {
     PetscSection section = nullptr;
-    PETSC_CHECK(DMGetGlobalSection(dm(), &section));
+    PETSC_CHECK(DMGetGlobalSection(get_dm(), &section));
     return { section };
 }
 
@@ -261,7 +254,7 @@ void
 Problem::set_global_section(const Section & section) const
 {
     _F_;
-    PETSC_CHECK(DMSetGlobalSection(dm(), section));
+    PETSC_CHECK(DMSetGlobalSection(get_dm(), section));
 }
 
 } // namespace godzilla

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -102,7 +102,7 @@ RectangleMesh::create_dm()
                                     upper.data(),
                                     periodicity.data(),
                                     this->interpolate,
-                                    &this->_dm));
+                                    &this->dm));
 
     remove_label("marker");
     // create user-friendly names for sides

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -94,7 +94,7 @@ RectangleMesh::create_dm()
         this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED
     };
 
-    PETSC_CHECK(DMPlexCreateBoxMesh(comm(),
+    PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
                                     2,
                                     this->simplex,
                                     faces.data(),

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -83,26 +83,10 @@ RectangleMesh::get_ny() const
 }
 
 void
-RectangleMesh::create_dm()
+RectangleMesh::create()
 {
     _F_;
-    std::array<Real, 2> lower = { this->xmin, this->ymin };
-    std::array<Real, 2> upper = { this->xmax, this->ymax };
-    std::array<Int, 2> faces = { this->nx, this->ny };
-    std::array<DMBoundaryType, 2> periodicity = {
-        this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED,
-        this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED
-    };
-
-    PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
-                                    2,
-                                    this->simplex,
-                                    faces.data(),
-                                    lower.data(),
-                                    upper.data(),
-                                    periodicity.data(),
-                                    this->interpolate,
-                                    &this->dm));
+    UnstructuredMesh::create();
 
     remove_label("marker");
     // create user-friendly names for sides
@@ -114,6 +98,31 @@ RectangleMesh::create_dm()
     create_face_set_labels(face_set_names);
     for (auto it : face_set_names)
         set_face_set_name(it.first, it.second);
+}
+
+DM
+RectangleMesh::create_dm()
+{
+    _F_;
+    std::array<Real, 2> lower = { this->xmin, this->ymin };
+    std::array<Real, 2> upper = { this->xmax, this->ymax };
+    std::array<Int, 2> faces = { this->nx, this->ny };
+    std::array<DMBoundaryType, 2> periodicity = {
+        this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED,
+        this->simplex ? DM_BOUNDARY_NONE : DM_BOUNDARY_GHOSTED
+    };
+
+    DM dm;
+    PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
+                                    2,
+                                    this->simplex,
+                                    faces.data(),
+                                    lower.data(),
+                                    upper.data(),
+                                    periodicity.data(),
+                                    this->interpolate,
+                                    &dm));
+    return dm;
 }
 
 } // namespace godzilla

--- a/src/TecplotOutput.cpp
+++ b/src/TecplotOutput.cpp
@@ -114,7 +114,7 @@ void
 TecplotOutput::set_file_name()
 {
     _F_;
-    if (comm().size() == 1)
+    if (get_comm().size() == 1)
         this->file_name = fmt::format("{}.{}", this->file_base, this->get_file_ext());
     else
         this->file_name =
@@ -336,10 +336,11 @@ void
 TecplotOutput::write_created_by_ascii()
 {
     _F_;
+    auto app = get_app();
     std::time_t now = std::time(nullptr);
     std::string datetime = fmt::format("{:%d %b %Y, %H:%M:%S}", fmt::localtime(now));
     std::string created_by =
-        fmt::format("Created by {} {}, on {}", get_app()->name(), get_app()->version(), datetime);
+        fmt::format("Created by {} {}, on {}", app->get_name(), app->get_version(), datetime);
     write_line(fmt::format("DATASETAUXDATA {} = \"{}\"\n", "created_by", created_by));
 }
 

--- a/src/TecplotOutput.cpp
+++ b/src/TecplotOutput.cpp
@@ -80,8 +80,8 @@ TecplotOutput::parameters()
 TecplotOutput::TecplotOutput(const Parameters & params) :
     FileOutput(params),
     format(BINARY),
-    dpi(dynamic_cast<DiscreteProblemInterface *>(this->problem)),
-    mesh(this->problem ? dynamic_cast<UnstructuredMesh *>(this->problem->get_mesh()) : nullptr),
+    dpi(dynamic_cast<DiscreteProblemInterface *>(get_problem())),
+    mesh(get_problem() ? dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh()) : nullptr),
     variable_names(get_param<std::vector<std::string>>("variables")),
     file(nullptr),
     header_written(false),
@@ -128,7 +128,7 @@ TecplotOutput::create()
     FileOutput::create();
 
     assert(this->dpi != nullptr);
-    assert(this->problem != nullptr);
+    assert(get_problem() != nullptr);
 
     auto fmt_str = get_param<std::string>("format");
     if (validation::in(fmt_str, { "binary", "ascii" })) {
@@ -359,7 +359,7 @@ TecplotOutput::write_zone_ascii()
     write_line(
         fmt::format(" ZONETYPE={}, Nodes={}, Elements={}\n", zone_type, n_nodes, n_cells_in_block));
 
-    Real time = this->problem->get_time();
+    Real time = get_problem()->get_time();
     write_line(fmt::format(" STRANDID=2, SOLUTIONTIME={}\n", time));
     write_line(fmt::format(" DATAPACKING=BLOCK\n"));
     write_line(fmt::format(" VARLOCATION=([{}]=CELLCENTERED)\n", this->element_id_var_index));

--- a/src/TecplotOutput.cpp
+++ b/src/TecplotOutput.cpp
@@ -111,17 +111,6 @@ TecplotOutput::get_file_ext() const
 }
 
 void
-TecplotOutput::set_file_name()
-{
-    _F_;
-    if (get_comm().size() == 1)
-        this->file_name = fmt::format("{}.{}", this->file_base, this->get_file_ext());
-    else
-        this->file_name =
-            fmt::format("{}.{}.{}", this->file_base, get_processor_id(), this->get_file_ext());
-}
-
-void
 TecplotOutput::create()
 {
     _F_;
@@ -203,8 +192,7 @@ TecplotOutput::output_step()
 {
     _F_;
     // We only have fixed meshes, so no need to deal with a sequence of files
-    set_file_name();
-    TIMED_EVENT(9, "TecplotOutput", "Output to file: {}", this->file_name);
+    TIMED_EVENT(9, "TecplotOutput", "Output to file: {}", get_file_name());
 
     if (this->file == nullptr)
         open_file();
@@ -224,7 +212,7 @@ TecplotOutput::open_file()
 {
     _F_;
     const char * mode = this->format == BINARY ? "wb" : "w";
-    this->file = std::fopen(this->file_name.c_str(), mode);
+    this->file = std::fopen(get_file_name().c_str(), mode);
     if (this->file == nullptr)
         error("Could not open file '{}' for writing.", get_file_name());
 }

--- a/src/TimeSteppingAdaptor.cpp
+++ b/src/TimeSteppingAdaptor.cpp
@@ -48,11 +48,25 @@ TimeSteppingAdaptor::get_dt_max() const
 }
 
 void
+TimeSteppingAdaptor::set_type(const char * type)
+{
+    _F_;
+    PETSC_CHECK(TSAdaptSetType(this->ts_adapt, type));
+}
+
+Problem *
+TimeSteppingAdaptor::get_problem() const
+{
+    _F_;
+    return this->problem;
+}
+
+void
 TimeSteppingAdaptor::create()
 {
     _F_;
     PETSC_CHECK(TSGetAdapt(this->tpi->get_ts(), &this->ts_adapt));
-    set_type();
+    set_type_impl();
     PETSC_CHECK(TSAdaptSetStepLimits(this->ts_adapt, this->dt_min, this->dt_max));
 }
 

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -141,7 +141,7 @@ TransientProblemInterface::init()
     _F_;
     assert(this->problem != nullptr);
     PETSC_CHECK(TSCreate(this->problem->get_comm(), &this->ts));
-    PETSC_CHECK(TSSetDM(this->ts, this->problem->dm()));
+    PETSC_CHECK(TSSetDM(this->ts, this->problem->get_dm()));
     PETSC_CHECK(TSSetApplicationContext(this->ts, this));
 }
 

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -140,7 +140,7 @@ TransientProblemInterface::init()
 {
     _F_;
     assert(this->problem != nullptr);
-    PETSC_CHECK(TSCreate(this->problem->comm(), &this->ts));
+    PETSC_CHECK(TSCreate(this->problem->get_comm(), &this->ts));
     PETSC_CHECK(TSSetDM(this->ts, this->problem->dm()));
     PETSC_CHECK(TSSetApplicationContext(this->ts, this));
 }

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -204,7 +204,7 @@ TransientProblemInterface::ts_monitor_callback(Int stepi, Real t, Vec x)
 {
     _F_;
     Real dt = get_time_step();
-    this->problem->lprintf(6, "{} Time {:f} dt = {:f}", stepi, t, dt);
+    this->problem->lprint(6, "{} Time {:f} dt = {:f}", stepi, t, dt);
 }
 
 void

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -54,9 +54,9 @@ TransientProblemInterface::parameters()
 }
 
 TransientProblemInterface::TransientProblemInterface(Problem * problem, const Parameters & params) :
+    ts(nullptr),
     problem(problem),
     tpi_params(params),
-    ts(nullptr),
     ts_adaptor(nullptr),
     start_time(params.get<Real>("start_time")),
     end_time(params.get<Real>("end_time")),
@@ -133,6 +133,20 @@ TransientProblemInterface::get_max_time() const
     Real time;
     PETSC_CHECK(TSGetMaxTime(this->ts, &time));
     return time;
+}
+
+Real
+TransientProblemInterface::get_time() const
+{
+    _F_;
+    return this->time;
+}
+
+Int
+TransientProblemInterface::get_step_number() const
+{
+    _F_;
+    return this->step_num;
 }
 
 void

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -265,6 +265,13 @@ UnstructuredMesh::set_partitioner_type(const std::string & type)
     this->partitioner.set_type(type);
 }
 
+Int
+UnstructuredMesh::get_partition_overlap()
+{
+    _F_;
+    return this->partition_overlap;
+}
+
 void
 UnstructuredMesh::set_partition_overlap(Int overlap)
 {

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -76,9 +76,9 @@ UnstructuredMesh::create()
     set_up();
     PETSC_CHECK(DMGetDimension(dm(), &this->dim));
 
-    lprintf(9, "Information:");
-    lprintf(9, "- vertices: {}", get_num_vertices());
-    lprintf(9, "- elements: {}", get_num_cells());
+    lprint(9, "Information:");
+    lprint(9, "- vertices: {}", get_num_vertices());
+    lprint(9, "- elements: {}", get_num_cells());
 }
 
 Label

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -57,7 +57,7 @@ UnstructuredMesh::UnstructuredMesh(const Parameters & parameters) :
     common_cells_by_vtx_computed(false)
 {
     _F_;
-    this->partitioner.create(comm());
+    this->partitioner.create(get_comm());
 }
 
 UnstructuredMesh::~UnstructuredMesh()
@@ -552,7 +552,7 @@ UnstructuredMesh::build_from_cell_list(Int dim,
                                        bool interpolate)
 {
     _F_;
-    PETSC_CHECK(DMPlexCreateFromCellListPetsc(comm(),
+    PETSC_CHECK(DMPlexCreateFromCellListPetsc(get_comm(),
                                               dim,
                                               cells.size() / n_corners,
                                               vertices.size() / space_dim,

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -71,10 +71,11 @@ UnstructuredMesh::create()
 {
     _F_;
     create_dm();
-    PETSC_CHECK(DMSetFromOptions(dm()));
-    PETSC_CHECK(DMViewFromOptions(dm(), nullptr, "-dm_view"));
+    auto dm = get_dm();
+    PETSC_CHECK(DMSetFromOptions(dm));
+    PETSC_CHECK(DMViewFromOptions(dm, nullptr, "-dm_view"));
     set_up();
-    PETSC_CHECK(DMGetDimension(dm(), &this->dim));
+    PETSC_CHECK(DMGetDimension(dm, &this->dim));
 
     lprint(9, "Information:");
     lprint(9, "- vertices: {}", get_num_vertices());
@@ -86,7 +87,7 @@ UnstructuredMesh::get_depth_label() const
 {
     _F_;
     DMLabel depth_label;
-    PETSC_CHECK(DMPlexGetDepthLabel(dm(), &depth_label));
+    PETSC_CHECK(DMPlexGetDepthLabel(get_dm(), &depth_label));
     return Label(depth_label);
 }
 
@@ -102,7 +103,7 @@ UnstructuredMesh::get_vertex_range() const
 {
     _F_;
     Int first, last;
-    PETSC_CHECK(DMPlexGetHeightStratum(dm(), this->dim, &first, &last));
+    PETSC_CHECK(DMPlexGetHeightStratum(get_dm(), this->dim, &first, &last));
     return { first, last };
 }
 
@@ -118,7 +119,7 @@ UnstructuredMesh::get_face_range() const
 {
     _F_;
     Int first, last;
-    PETSC_CHECK(DMPlexGetHeightStratum(dm(), 1, &first, &last));
+    PETSC_CHECK(DMPlexGetHeightStratum(get_dm(), 1, &first, &last));
     return { first, last };
 }
 
@@ -141,9 +142,9 @@ UnstructuredMesh::get_cell_range() const
 {
     _F_;
     Int first, last;
-    PETSC_CHECK(DMPlexGetHeightStratum(dm(), 0, &first, &last));
+    PETSC_CHECK(DMPlexGetHeightStratum(get_dm(), 0, &first, &last));
     Int gc_first, gc_last;
-    PETSC_CHECK(DMPlexGetGhostCellStratum(dm(), &gc_first, &gc_last));
+    PETSC_CHECK(DMPlexGetGhostCellStratum(get_dm(), &gc_first, &gc_last));
     if (gc_first != -1)
         last = gc_first;
     return { first, last };
@@ -154,7 +155,7 @@ UnstructuredMesh::get_all_cell_range() const
 {
     _F_;
     Int first, last;
-    PETSC_CHECK(DMPlexGetHeightStratum(dm(), 0, &first, &last));
+    PETSC_CHECK(DMPlexGetHeightStratum(get_dm(), 0, &first, &last));
     return { first, last };
 }
 
@@ -163,11 +164,11 @@ UnstructuredMesh::get_all_cells() const
 {
     _F_;
     Int depth;
-    PETSC_CHECK(DMPlexGetDepth(dm(), &depth));
+    PETSC_CHECK(DMPlexGetDepth(get_dm(), &depth));
     IS cell_is;
-    PETSC_CHECK(DMGetStratumIS(dm(), "dim", depth, &cell_is));
+    PETSC_CHECK(DMGetStratumIS(get_dm(), "dim", depth, &cell_is));
     if (!cell_is)
-        PETSC_CHECK(DMGetStratumIS(dm(), "depth", depth, &cell_is));
+        PETSC_CHECK(DMGetStratumIS(get_dm(), "depth", depth, &cell_is));
     return IndexSet(cell_is);
 }
 
@@ -175,7 +176,7 @@ void
 UnstructuredMesh::get_chart(Int & start, Int & end) const
 {
     _F_;
-    PETSC_CHECK(DMPlexGetChart(dm(), &start, &end));
+    PETSC_CHECK(DMPlexGetChart(get_dm(), &start, &end));
 }
 
 UnstructuredMesh::Range
@@ -183,7 +184,7 @@ UnstructuredMesh::get_chart() const
 {
     _F_;
     Int start, end;
-    PETSC_CHECK(DMPlexGetChart(dm(), &start, &end));
+    PETSC_CHECK(DMPlexGetChart(get_dm(), &start, &end));
     return Range(start, end);
 }
 
@@ -192,7 +193,7 @@ UnstructuredMesh::get_cell_type(Int el) const
 {
     _F_;
     DMPolytopeType polytope_type;
-    PETSC_CHECK(DMPlexGetCellType(dm(), el, &polytope_type));
+    PETSC_CHECK(DMPlexGetCellType(get_dm(), el, &polytope_type));
     return polytope_type;
 }
 
@@ -202,7 +203,7 @@ UnstructuredMesh::get_connectivity(Int point) const
     _F_;
     Int closure_size;
     Int * closure = nullptr;
-    PETSC_CHECK(DMPlexGetTransitiveClosure(dm(), point, PETSC_TRUE, &closure_size, &closure));
+    PETSC_CHECK(DMPlexGetTransitiveClosure(get_dm(), point, PETSC_TRUE, &closure_size, &closure));
 
     auto polytope_type = get_cell_type(point);
     Int n_elem_nodes = UnstructuredMesh::get_num_cell_nodes(polytope_type);
@@ -213,7 +214,8 @@ UnstructuredMesh::get_connectivity(Int point) const
         elem_connect[k] = closure[l];
     }
 
-    PETSC_CHECK(DMPlexRestoreTransitiveClosure(dm(), point, PETSC_TRUE, &closure_size, &closure));
+    PETSC_CHECK(
+        DMPlexRestoreTransitiveClosure(get_dm(), point, PETSC_TRUE, &closure_size, &closure));
 
     return elem_connect;
 }
@@ -223,9 +225,9 @@ UnstructuredMesh::get_support(Int point) const
 {
     _F_;
     Int n_support;
-    PETSC_CHECK(DMPlexGetSupportSize(dm(), point, &n_support));
+    PETSC_CHECK(DMPlexGetSupportSize(get_dm(), point, &n_support));
     const Int * support;
-    PETSC_CHECK(DMPlexGetSupport(dm(), point, &support));
+    PETSC_CHECK(DMPlexGetSupport(get_dm(), point, &support));
     std::vector<Int> v;
     v.resize(n_support);
     for (Int i = 0; i < n_support; i++)
@@ -238,9 +240,9 @@ UnstructuredMesh::get_cone(Int point) const
 {
     _F_;
     Int n;
-    PETSC_CHECK(DMPlexGetConeSize(dm(), point, &n));
+    PETSC_CHECK(DMPlexGetConeSize(get_dm(), point, &n));
     const Int * cone;
-    PETSC_CHECK(DMPlexGetCone(dm(), point, &cone));
+    PETSC_CHECK(DMPlexGetCone(get_dm(), point, &cone));
     std::vector<Int> v;
     v.resize(n);
     for (Int i = 0; i < n; i++)
@@ -253,7 +255,7 @@ UnstructuredMesh::get_cone_recursive_vertices(IndexSet points) const
 {
     _F_;
     IndexSet expanded_points;
-    PETSC_CHECK(DMPlexGetConeRecursiveVertices(dm(), points, expanded_points));
+    PETSC_CHECK(DMPlexGetConeRecursiveVertices(get_dm(), points, expanded_points));
     return expanded_points;
 }
 
@@ -278,13 +280,13 @@ UnstructuredMesh::distribute()
     TIMED_EVENT(9, "MeshDistribution", "Distributing");
     this->partitioner.set_up();
 
-    PETSC_CHECK(DMPlexSetPartitioner(dm(), this->partitioner));
+    PETSC_CHECK(DMPlexSetPartitioner(get_dm(), this->partitioner));
 
     DM dm_dist = nullptr;
-    PETSC_CHECK(DMPlexDistribute(dm(), this->partition_overlap, nullptr, &dm_dist));
+    PETSC_CHECK(DMPlexDistribute(get_dm(), this->partition_overlap, nullptr, &dm_dist));
     if (dm_dist) {
-        PETSC_CHECK(DMDestroy(&this->_dm));
-        this->_dm = dm_dist;
+        PETSC_CHECK(DMDestroy(&this->dm));
+        this->dm = dm_dist;
     }
 }
 
@@ -293,7 +295,7 @@ UnstructuredMesh::is_simplex() const
 {
     _F_;
     PetscBool simplex;
-    PETSC_CHECK(DMPlexIsSimplex(dm(), &simplex));
+    PETSC_CHECK(DMPlexIsSimplex(get_dm(), &simplex));
     return simplex == PETSC_TRUE;
 }
 
@@ -407,7 +409,7 @@ UnstructuredMesh::get_num_cell_sets() const
 {
     _F_;
     Int n_cells_sets;
-    PETSC_CHECK(DMGetLabelSize(dm(), "Cell Sets", &n_cells_sets));
+    PETSC_CHECK(DMGetLabelSize(get_dm(), "Cell Sets", &n_cells_sets));
     return n_cells_sets;
 }
 
@@ -423,7 +425,7 @@ UnstructuredMesh::get_num_face_sets() const
 {
     _F_;
     Int n_face_sets;
-    PETSC_CHECK(DMGetLabelSize(dm(), "Face Sets", &n_face_sets));
+    PETSC_CHECK(DMGetLabelSize(get_dm(), "Face Sets", &n_face_sets));
     return n_face_sets;
 }
 
@@ -432,7 +434,7 @@ UnstructuredMesh::get_num_vertex_sets() const
 {
     _F_;
     Int n_vertex_sets;
-    PETSC_CHECK(DMGetLabelSize(dm(), "Vertex Sets", &n_vertex_sets));
+    PETSC_CHECK(DMGetLabelSize(get_dm(), "Vertex Sets", &n_vertex_sets));
     return n_vertex_sets;
 }
 
@@ -441,16 +443,16 @@ UnstructuredMesh::construct_ghost_cells()
 {
     _F_;
     DM gdm;
-    PETSC_CHECK(DMPlexConstructGhostCells(dm(), nullptr, nullptr, &gdm));
-    PETSC_CHECK(DMDestroy(&this->_dm));
-    this->_dm = gdm;
+    PETSC_CHECK(DMPlexConstructGhostCells(get_dm(), nullptr, nullptr, &gdm));
+    PETSC_CHECK(DMDestroy(&this->dm));
+    this->dm = gdm;
 }
 
 void
 UnstructuredMesh::compute_cell_geometry(Int cell, Real * vol, Real centroid[], Real normal[]) const
 {
     _F_;
-    PETSC_CHECK(DMPlexComputeCellGeometryFVM(dm(), cell, vol, centroid, normal));
+    PETSC_CHECK(DMPlexComputeCellGeometryFVM(get_dm(), cell, vol, centroid, normal));
 }
 
 int
@@ -479,7 +481,7 @@ UnstructuredMesh::vertex_begin() const
 {
     _F_;
     Int idx;
-    PETSC_CHECK(DMPlexGetHeightStratum(dm(), this->dim, &idx, nullptr));
+    PETSC_CHECK(DMPlexGetHeightStratum(get_dm(), this->dim, &idx, nullptr));
     return Iterator(idx);
 }
 
@@ -488,7 +490,7 @@ UnstructuredMesh::vertex_end() const
 {
     _F_;
     Int idx;
-    PETSC_CHECK(DMPlexGetHeightStratum(dm(), this->dim, nullptr, &idx));
+    PETSC_CHECK(DMPlexGetHeightStratum(get_dm(), this->dim, nullptr, &idx));
     return Iterator(idx);
 }
 
@@ -497,7 +499,7 @@ UnstructuredMesh::face_begin() const
 {
     _F_;
     Int idx;
-    PETSC_CHECK(DMPlexGetHeightStratum(dm(), 1, &idx, nullptr));
+    PETSC_CHECK(DMPlexGetHeightStratum(get_dm(), 1, &idx, nullptr));
     return Iterator(idx);
 }
 
@@ -506,7 +508,7 @@ UnstructuredMesh::face_end() const
 {
     _F_;
     Int idx;
-    PETSC_CHECK(DMPlexGetHeightStratum(dm(), 1, nullptr, &idx));
+    PETSC_CHECK(DMPlexGetHeightStratum(get_dm(), 1, nullptr, &idx));
     return Iterator(idx);
 }
 
@@ -515,7 +517,7 @@ UnstructuredMesh::cell_begin() const
 {
     _F_;
     Int idx;
-    PETSC_CHECK(DMPlexGetHeightStratum(dm(), 0, &idx, nullptr));
+    PETSC_CHECK(DMPlexGetHeightStratum(get_dm(), 0, &idx, nullptr));
     return Iterator(idx);
 }
 
@@ -524,7 +526,7 @@ UnstructuredMesh::cell_end() const
 {
     _F_;
     Int idx;
-    PETSC_CHECK(DMPlexGetHeightStratum(dm(), 0, nullptr, &idx));
+    PETSC_CHECK(DMPlexGetHeightStratum(get_dm(), 0, nullptr, &idx));
     return Iterator(idx);
 }
 
@@ -561,7 +563,7 @@ UnstructuredMesh::build_from_cell_list(Int dim,
                                               cells.data(),
                                               space_dim,
                                               vertices.data(),
-                                              &this->_dm));
+                                              &this->dm));
 }
 
 } // namespace godzilla

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -51,7 +51,7 @@ VTKOutput::check()
 {
     _F_;
     FileOutput::check();
-    const auto * mesh = dynamic_cast<UnstructuredMesh *>(this->problem->get_mesh());
+    const auto * mesh = dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh());
     if (mesh == nullptr)
         log_error("VTK output works only with unstructured meshes.");
 }
@@ -60,13 +60,14 @@ void
 VTKOutput::output_step()
 {
     _F_;
-    set_sequence_file_name(this->problem->get_step_num());
+    auto problem = get_problem();
+    set_sequence_file_name(problem->get_step_num());
     PETSC_CHECK(PetscViewerFileSetName(this->viewer, this->file_name.c_str()));
 
     TIMED_EVENT(9, "VTKOutput", "Output to file: {}", this->file_name);
-    auto dm = this->problem->get_dm();
+    auto dm = problem->get_dm();
     PETSC_CHECK(DMView(dm, this->viewer));
-    auto vec = this->problem->get_solution_vector();
+    auto vec = problem->get_solution_vector();
     PETSC_CHECK(VecView(vec, this->viewer));
 }
 

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -64,7 +64,7 @@ VTKOutput::output_step()
     PETSC_CHECK(PetscViewerFileSetName(this->viewer, this->file_name.c_str()));
 
     TIMED_EVENT(9, "VTKOutput", "Output to file: {}", this->file_name);
-    auto dm = this->problem->dm();
+    auto dm = this->problem->get_dm();
     PETSC_CHECK(DMView(dm, this->viewer));
     auto vec = this->problem->get_solution_vector();
     PETSC_CHECK(VecView(vec, this->viewer));

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -61,10 +61,10 @@ VTKOutput::output_step()
 {
     _F_;
     auto problem = get_problem();
-    set_sequence_file_name(problem->get_step_num());
-    PETSC_CHECK(PetscViewerFileSetName(this->viewer, this->file_name.c_str()));
+    set_sequence_file_base(problem->get_step_num());
+    PETSC_CHECK(PetscViewerFileSetName(this->viewer, get_file_name().c_str()));
 
-    TIMED_EVENT(9, "VTKOutput", "Output to file: {}", this->file_name);
+    TIMED_EVENT(9, "VTKOutput", "Output to file: {}", get_file_name());
     auto dm = problem->get_dm();
     PETSC_CHECK(DMView(dm, this->viewer));
     auto vec = problem->get_solution_vector();

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -41,7 +41,7 @@ VTKOutput::create()
     _F_;
     FileOutput::create();
 
-    PETSC_CHECK(PetscViewerCreate(comm(), &this->viewer));
+    PETSC_CHECK(PetscViewerCreate(get_comm(), &this->viewer));
     PETSC_CHECK(PetscViewerSetType(this->viewer, PETSCVIEWERVTK));
     PETSC_CHECK(PetscViewerFileSetMode(this->viewer, FILE_MODE_WRITE));
 }

--- a/test/include/FENonlinearProblem_test.h
+++ b/test/include/FENonlinearProblem_test.h
@@ -29,7 +29,7 @@ public:
             this->prob =
                 this->app->build_object<GTestFENonlinearProblem>(class_name, "prob", params);
         }
-        this->app->problem = this->prob;
+        this->app->set_problem(this->prob);
     }
 
     void
@@ -62,7 +62,7 @@ public:
             this->prob =
                 this->app->build_object<GTest2FieldsFENonlinearProblem>(class_name, "prob", params);
         }
-        this->app->problem = this->prob;
+        this->app->set_problem(this->prob);
     }
 
     void

--- a/test/include/TestApp.h
+++ b/test/include/TestApp.h
@@ -23,8 +23,8 @@ public:
     virtual void
     check_integrity()
     {
-        if (this->log->get_num_entries() > 0)
-            this->log->print();
+        if (get_logger()->get_num_entries() > 0)
+            get_logger()->print();
     }
 
     Problem * problem;

--- a/test/include/TestApp.h
+++ b/test/include/TestApp.h
@@ -6,7 +6,7 @@ using namespace godzilla;
 
 class TestApp : public App {
 public:
-    TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla"), problem(nullptr) {}
+    TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla") {}
 
     const std::string &
     get_input_file_name() const
@@ -14,19 +14,12 @@ public:
         return this->input_file_name;
     }
 
-    virtual Problem *
-    get_problem() const
-    {
-        return this->problem;
-    }
-
-    virtual void
+    void
     check_integrity()
     {
         if (get_logger()->get_num_entries() > 0)
             get_logger()->print();
     }
 
-    Problem * problem;
     std::string input_file_name;
 };

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -46,6 +46,8 @@ TEST_F(AuxiliaryFieldTest, api)
         }
     };
 
+    mesh->create();
+
     prob->set_aux_fe(0, "fld", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
@@ -56,8 +58,6 @@ TEST_F(AuxiliaryFieldTest, api)
     params.set<std::string>("region") = "rgn";
     TestAuxFld aux(params);
     prob->add_auxiliary_field(&aux);
-
-    mesh->create();
 
     EXPECT_EQ(aux.get_label(), nullptr);
     EXPECT_EQ(aux.get_region(), "rgn");
@@ -99,6 +99,8 @@ TEST_F(AuxiliaryFieldTest, non_existent_id)
         }
     };
 
+    mesh->create();
+
     testing::internal::CaptureStderr();
 
     prob->set_aux_fe(0, "aux1", 1, 1);
@@ -110,7 +112,6 @@ TEST_F(AuxiliaryFieldTest, non_existent_id)
     TestAuxFld aux(params);
     prob->add_auxiliary_field(&aux);
 
-    mesh->create();
     prob->create();
 
     app->check_integrity();
@@ -146,6 +147,8 @@ TEST_F(AuxiliaryFieldTest, inconsistent_comp_number)
         }
     };
 
+    mesh->create();
+
     testing::internal::CaptureStderr();
 
     prob->set_aux_fe(0, "aux1", 1, 1);
@@ -157,7 +160,6 @@ TEST_F(AuxiliaryFieldTest, inconsistent_comp_number)
     TestAuxFld aux(params);
     prob->add_auxiliary_field(&aux);
 
-    mesh->create();
     prob->create();
 
     app->check_integrity();
@@ -193,6 +195,8 @@ TEST_F(AuxiliaryFieldTest, non_existent_region)
         }
     };
 
+    mesh->create();
+
     testing::internal::CaptureStderr();
 
     prob->set_aux_fe(0, "aux1", 1, 1);
@@ -205,7 +209,6 @@ TEST_F(AuxiliaryFieldTest, non_existent_region)
     TestAuxFld aux(params);
     prob->add_auxiliary_field(&aux);
 
-    mesh->create();
     prob->create();
 
     app->check_integrity();
@@ -216,6 +219,8 @@ TEST_F(AuxiliaryFieldTest, non_existent_region)
 
 TEST_F(AuxiliaryFieldTest, name_already_taken)
 {
+    mesh->create();
+
     prob->set_aux_fe(0, "fld", 1, 1);
 
     Parameters params = ConstantAuxiliaryField::parameters();
@@ -257,6 +262,8 @@ TEST_F(AuxiliaryFieldTest, get_value)
         }
     };
 
+    mesh->create();
+
     prob->set_aux_fe(0, "aux1", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
@@ -267,7 +274,6 @@ TEST_F(AuxiliaryFieldTest, get_value)
     TestAuxFld aux(params);
     prob->add_auxiliary_field(&aux);
 
-    mesh->create();
     prob->create();
 
     DenseVector<Real, 1> coord({ 2. });
@@ -304,6 +310,8 @@ TEST_F(AuxiliaryFieldTest, get_vector_value)
         }
     };
 
+    mesh->create();
+
     prob->set_aux_fe(0, "aux1", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
@@ -314,7 +322,6 @@ TEST_F(AuxiliaryFieldTest, get_vector_value)
     TestAuxFld aux(params);
     prob->add_auxiliary_field(&aux);
 
-    mesh->create();
     prob->create();
 
     DenseVector<Real, 1> coord({ 3. });

--- a/test/src/BasicTSAdapt_test.cpp
+++ b/test/src/BasicTSAdapt_test.cpp
@@ -29,7 +29,7 @@ TEST(BasicTSAdapt, api)
         params->set<Real>("dt") = 0.1;
         prob = app.build_object<GTestImplicitFENonlinearProblem>(class_name, "prob", params);
     }
-    app.problem = prob;
+    app.set_problem(prob);
 
     Parameters params = BasicTSAdapt::parameters();
     params.set<App *>("_app") = &app;

--- a/test/src/BndJacobianFunc_test.cpp
+++ b/test/src/BndJacobianFunc_test.cpp
@@ -106,7 +106,7 @@ TEST(BndJacobianFuncTest, test)
     prob_pars.set<Real>("end_time") = 20;
     prob_pars.set<Real>("dt") = 5;
     GTestProblem prob(prob_pars);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     Parameters bc_pars = NaturalBC::parameters();
     bc_pars.set<App *>("_app") = &app;

--- a/test/src/BndResidualFunc_test.cpp
+++ b/test/src/BndResidualFunc_test.cpp
@@ -106,7 +106,7 @@ TEST(BndResidualFuncTest, test)
     prob_pars.set<Real>("end_time") = 20;
     prob_pars.set<Real>("dt") = 5;
     GTestProblem prob(prob_pars);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     Parameters bc_pars = NaturalBC::parameters();
     bc_pars.set<App *>("_app") = &app;

--- a/test/src/BoxMesh_test.cpp
+++ b/test/src/BoxMesh_test.cpp
@@ -37,7 +37,7 @@ TEST(BoxMeshTest, api)
     EXPECT_EQ(mesh.get_nz(), 7);
 
     mesh.create();
-    auto dm = mesh.dm();
+    auto dm = mesh.get_dm();
 
     EXPECT_EQ(mesh.get_dimension(), 3);
 

--- a/test/src/CSVOutput_test.cpp
+++ b/test/src/CSVOutput_test.cpp
@@ -13,18 +13,6 @@ public:
     {
         close_file();
     }
-
-    std::vector<std::string>
-    get_pps_names()
-    {
-        return pps_names;
-    }
-
-    const std::FILE *
-    get_f()
-    {
-        return f;
-    }
 };
 
 } // namespace
@@ -54,8 +42,6 @@ TEST_F(CSVOutputTest, create)
 
     auto pps_names = out.get_pps_names();
     EXPECT_EQ(pps_names.size(), 0);
-
-    EXPECT_TRUE(out.get_f() == nullptr);
 }
 
 TEST_F(CSVOutputTest, output)
@@ -92,8 +78,6 @@ TEST_F(CSVOutputTest, output)
 
     auto pps_names = out.get_pps_names();
     EXPECT_EQ(pps_names.size(), 1);
-
-    EXPECT_TRUE(out.get_f() != nullptr);
 
     out.output_step();
     out.close();

--- a/test/src/CSVOutput_test.cpp
+++ b/test/src/CSVOutput_test.cpp
@@ -124,6 +124,5 @@ TEST_F(CSVOutputTest, set_file_name)
     this->mesh->create();
     this->prob->create();
 
-    out.set_file_name();
     EXPECT_EQ(out.get_file_name(), "asdf.csv");
 }

--- a/test/src/ConstantAuxiliaryField_test.cpp
+++ b/test/src/ConstantAuxiliaryField_test.cpp
@@ -19,7 +19,6 @@ TEST(ConstantAuxiliaryFieldTest, create)
     prob_params.set<App *>("_app") = &app;
     prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    prob.set_aux_fe(0, "aux1", 1, 1);
 
     Parameters aux_params = ConstantAuxiliaryField::parameters();
     aux_params.set<App *>("_app") = &app;
@@ -27,10 +26,11 @@ TEST(ConstantAuxiliaryFieldTest, create)
     aux_params.set<DiscreteProblemInterface *>("_dpi") = &prob;
     aux_params.set<std::vector<Real>>("value") = { 1234 };
     ConstantAuxiliaryField aux(aux_params);
-    prob.add_auxiliary_field(&aux);
 
     mesh.create();
     prob.create();
+    prob.set_aux_fe(0, "aux1", 1, 1);
+    prob.add_auxiliary_field(&aux);
 
     EXPECT_EQ(aux.get_field_id(), 0);
 
@@ -58,7 +58,6 @@ TEST(ConstantAuxiliaryFieldTest, evaluate)
     prob_params.set<App *>("_app") = &app;
     prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    prob.set_aux_fe(0, "aux1", 1, 1);
 
     Parameters aux_params = ConstantAuxiliaryField::parameters();
     aux_params.set<App *>("_app") = &app;
@@ -66,10 +65,11 @@ TEST(ConstantAuxiliaryFieldTest, evaluate)
     aux_params.set<DiscreteProblemInterface *>("_dpi") = &prob;
     aux_params.set<std::vector<Real>>("value") = { 1234 };
     ConstantAuxiliaryField aux(aux_params);
-    prob.add_auxiliary_field(&aux);
 
     mesh.create();
     prob.create();
+    prob.set_aux_fe(0, "aux1", 1, 1);
+    prob.add_auxiliary_field(&aux);
 
     PetscFunc * fn = aux.get_func();
     Int dim = 1;

--- a/test/src/DirichletBC_test.cpp
+++ b/test/src/DirichletBC_test.cpp
@@ -21,7 +21,7 @@ TEST(DirichletBCTest, api)
     prob_pars.set<App *>("_app") = &app;
     prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem problem(prob_pars);
-    app.problem = &problem;
+    app.set_problem(&problem);
 
     Parameters params = DirichletBC::parameters();
     params.set<App *>("_app") = &app;
@@ -63,7 +63,7 @@ TEST(DirichletBCTest, with_user_defined_fn)
     prob_pars.set<App *>("_app") = &app;
     prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem problem(prob_pars);
-    app.problem = &problem;
+    app.set_problem(&problem);
 
     std::string class_name = "PiecewiseLinear";
     Parameters * fn_pars = app.get_parameters(class_name);

--- a/test/src/EssentialBC_test.cpp
+++ b/test/src/EssentialBC_test.cpp
@@ -44,7 +44,7 @@ TEST(EssentialBCTest, api)
     prob_pars.set<App *>("_app") = &app;
     prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem problem(prob_pars);
-    app.problem = &problem;
+    app.set_problem(&problem);
 
     Parameters params = TestEssentialBC::parameters();
     params.set<App *>("_app") = &app;
@@ -89,7 +89,7 @@ TEST(EssentialBCTest, non_existing_field)
     prob_pars.set<App *>("_app") = &app;
     prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTest2FieldsFENonlinearProblem problem(prob_pars);
-    app.problem = &problem;
+    app.set_problem(&problem);
 
     Parameters params = TestEssentialBC::parameters();
     params.set<App *>("_app") = &app;
@@ -122,7 +122,7 @@ TEST(EssentialBCTest, field_param_not_specified)
     prob_pars.set<App *>("_app") = &app;
     prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTest2FieldsFENonlinearProblem problem(prob_pars);
-    app.problem = &problem;
+    app.set_problem(&problem);
 
     Parameters params = TestEssentialBC::parameters();
     params.set<App *>("_app") = &app;

--- a/test/src/ExodusIIMesh_test.cpp
+++ b/test/src/ExodusIIMesh_test.cpp
@@ -23,7 +23,7 @@ TEST(ExodusIIMeshTest, api)
     EXPECT_EQ(mesh.get_file_name(), file_name);
 
     mesh.create();
-    auto dm = mesh.dm();
+    auto dm = mesh.get_dm();
 
     EXPECT_EQ(mesh.get_dimension(), 2);
 

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -236,7 +236,6 @@ TEST(ExodusIIOutputTest, set_file_name)
 
     out.create();
 
-    out.set_file_name();
     EXPECT_EQ(out.get_file_name(), "out.exo");
 }
 
@@ -262,6 +261,6 @@ TEST(ExodusIIOutputTest, set_seq_file_name)
 
     out.create();
 
-    out.set_sequence_file_name(2);
+    out.set_sequence_file_base(2);
     EXPECT_EQ(out.get_file_name(), "out.2.exo");
 }

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -119,7 +119,9 @@ TEST(ExodusIIOutputTest, fe_check)
         void
         create() override
         {
-            DMCreate(get_comm(), &this->dm);
+            DM dm;
+            DMCreate(get_comm(), &dm);
+            set_dm(dm);
         }
 
     protected:

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -119,7 +119,7 @@ TEST(ExodusIIOutputTest, fe_check)
         void
         create() override
         {
-            DMCreate(comm(), &this->_dm);
+            DMCreate(get_comm(), &this->_dm);
         }
 
     protected:

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -119,7 +119,7 @@ TEST(ExodusIIOutputTest, fe_check)
         void
         create() override
         {
-            DMCreate(get_comm(), &this->_dm);
+            DMCreate(get_comm(), &this->dm);
         }
 
     protected:

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -40,18 +40,6 @@ public:
         ExplicitFELinearProblem::set_up_time_scheme();
     }
 
-    const Matrix &
-    get_mass_matrix() const
-    {
-        return this->M;
-    }
-
-    const Vector &
-    get_lumped_mass_matrix() const
-    {
-        return this->M_lumped_inv;
-    }
-
 protected:
     void
     set_up_fields() override

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -110,7 +110,7 @@ TEST(ExplicitFELinearProblemTest, test_mass_matrix)
     prob_pars.set<Real>("dt") = 1e-3;
     prob_pars.set<std::string>("scheme") = "euler";
     TestExplicitFELinearProblem prob(prob_pars);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     mesh.create();
     prob.create();
@@ -145,7 +145,7 @@ TEST(ExplicitFELinearProblemTest, test_lumped_mass_matrix)
     prob_pars.set<Real>("dt") = 1e-3;
     prob_pars.set<std::string>("scheme") = "euler";
     TestExplicitFELinearProblem prob(prob_pars);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     mesh.create();
     prob.create_w_lumped_mass_matrix();
@@ -174,7 +174,7 @@ TEST(ExplicitFELinearProblemTest, solve)
     prob_pars.set<Real>("dt") = 1e-3;
     prob_pars.set<std::string>("scheme") = "euler";
     TestExplicitFELinearProblem prob(prob_pars);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     Parameters bc_left_pars = DirichletBC::parameters();
     bc_left_pars.set<App *>("_app") = &app;
@@ -234,7 +234,7 @@ TEST(ExplicitFELinearProblemTest, solve_w_lumped_mass_matrix)
     prob_pars.set<Real>("dt") = 1e-3;
     prob_pars.set<std::string>("scheme") = "euler";
     TestExplicitFELinearProblem prob(prob_pars);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     Parameters bc_left_pars = DirichletBC::parameters();
     bc_left_pars.set<App *>("_app") = &app;

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -206,7 +206,7 @@ TEST(ExplicitFVLinearProblemTest, api)
     prob_pars.set<Real>("dt") = 1e-3;
     prob_pars.set<std::string>("scheme") = "euler";
     TestExplicitFVLinearProblem prob(prob_pars);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     mesh.create();
     prob.create();
@@ -298,7 +298,7 @@ TEST(ExplicitFVLinearProblemTest, fields)
     prob_pars.set<Real>("dt") = 1e-3;
     prob_pars.set<std::string>("scheme") = "euler";
     TestExplicitFVLinearProblem prob(prob_pars);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     prob.add_field(1, "vec", 3);
     EXPECT_EQ(prob.get_field_id("vec"), 0);
@@ -341,7 +341,7 @@ TEST(ExplicitFVLinearProblemTest, test_mass_matrix)
     prob_pars.set<Real>("dt") = 1e-3;
     prob_pars.set<std::string>("scheme") = "euler";
     TestExplicitFVLinearProblem prob(prob_pars);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     mesh.create();
     prob.create();
@@ -373,7 +373,7 @@ TEST(ExplicitFVLinearProblemTest, solve)
     prob_pars.set<Real>("dt") = 1e-3;
     prob_pars.set<std::string>("scheme") = "euler";
     TestExplicitFVLinearProblem prob(prob_pars);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     Parameters bc_left_pars = TestBC::parameters();
     bc_left_pars.set<App *>("_app") = &app;

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -145,18 +145,6 @@ public:
         flux[0] = (wn > 0 ? uL[0] : uR[0]) * wn;
     }
 
-    const Matrix &
-    get_mass_matrix() const
-    {
-        return this->M;
-    }
-
-    const Vector &
-    get_lumped_mass_matrix() const
-    {
-        return this->M_lumped_inv;
-    }
-
 protected:
     void
     set_up_fields() override

--- a/test/src/FEBoundary1D_test.cpp
+++ b/test/src/FEBoundary1D_test.cpp
@@ -51,14 +51,11 @@ protected:
     }
 
     void
-    create_side_set(Label & face_sets,
-                    Int id,
-                    const std::vector<Int> & faces,
-                    const char * name)
+    create_side_set(Label & face_sets, Int id, const std::vector<Int> & faces, const char * name)
     {
         for (auto & f : faces) {
             face_sets.set_value(f, id);
-            PETSC_CHECK(DMSetLabelValue(dm(), name, f, id));
+            PETSC_CHECK(DMSetLabelValue(get_dm(), name, f, id));
         }
     }
 

--- a/test/src/FEBoundary1D_test.cpp
+++ b/test/src/FEBoundary1D_test.cpp
@@ -26,16 +26,10 @@ class TestMesh1D : public godzilla::UnstructuredMesh {
 public:
     explicit TestMesh1D(const godzilla::Parameters & parameters) : UnstructuredMesh(parameters) {}
 
-protected:
     void
-    create_dm() override
+    create() override
     {
-        const PetscInt DIM = 1;
-        const PetscInt N_ELEM_NODES = 2;
-        std::vector<Int> cells = { 0, 1, 1, 2 };
-        std::vector<Real> coords = { 0, 0.4, 1 };
-        build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
-
+        UnstructuredMesh::create();
         // create "side sets"
         auto face_sets = create_label("Face Sets");
 
@@ -48,6 +42,16 @@ protected:
         create_face_set_labels(face_set_names);
         for (auto it : face_set_names)
             set_face_set_name(it.first, it.second);
+    }
+
+    DM
+    create_dm() override
+    {
+        const PetscInt DIM = 1;
+        const PetscInt N_ELEM_NODES = 2;
+        std::vector<Int> cells = { 0, 1, 1, 2 };
+        std::vector<Real> coords = { 0, 0.4, 1 };
+        return build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
     }
 
     void

--- a/test/src/FEBoundary2D_test.cpp
+++ b/test/src/FEBoundary2D_test.cpp
@@ -26,16 +26,10 @@ class TestMesh2D : public godzilla::UnstructuredMesh {
 public:
     explicit TestMesh2D(const godzilla::Parameters & parameters) : UnstructuredMesh(parameters) {}
 
-protected:
     void
-    create_dm() override
+    create() override
     {
-        const PetscInt DIM = 2;
-        const PetscInt N_ELEM_NODES = 3;
-        std::vector<Int> cells = { 0, 1, 2, 1, 3, 2 };
-        std::vector<Real> coords = { 0, 0, 1, 0, 0, 1, 1, 1 };
-        build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
-
+        UnstructuredMesh::create();
         // create "side sets"
         auto face_sets = create_label("Face Sets");
 
@@ -50,6 +44,16 @@ protected:
         create_face_set_labels(face_set_names);
         for (auto it : face_set_names)
             set_face_set_name(it.first, it.second);
+    }
+
+    DM
+    create_dm() override
+    {
+        const PetscInt DIM = 2;
+        const PetscInt N_ELEM_NODES = 3;
+        std::vector<Int> cells = { 0, 1, 2, 1, 3, 2 };
+        std::vector<Real> coords = { 0, 0, 1, 0, 0, 1, 1, 1 };
+        return build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
     }
 
     void

--- a/test/src/FEBoundary2D_test.cpp
+++ b/test/src/FEBoundary2D_test.cpp
@@ -53,14 +53,11 @@ protected:
     }
 
     void
-    create_side_set(Label & face_sets,
-                    Int id,
-                    const std::vector<Int> & faces,
-                    const char * name)
+    create_side_set(Label & face_sets, Int id, const std::vector<Int> & faces, const char * name)
     {
         for (auto & f : faces) {
             face_sets.set_value(f, id);
-            PETSC_CHECK(DMSetLabelValue(dm(), name, f, id));
+            PETSC_CHECK(DMSetLabelValue(get_dm(), name, f, id));
         }
     }
 

--- a/test/src/FEBoundary3D_test.cpp
+++ b/test/src/FEBoundary3D_test.cpp
@@ -59,7 +59,7 @@ protected:
     {
         for (auto & f : faces) {
             face_sets.set_value(f, id);
-            PETSC_CHECK(DMSetLabelValue(dm(), name, f, id));
+            PETSC_CHECK(DMSetLabelValue(get_dm(), name, f, id));
         }
     }
 

--- a/test/src/FEBoundary3D_test.cpp
+++ b/test/src/FEBoundary3D_test.cpp
@@ -26,16 +26,10 @@ class TestMesh3D : public godzilla::UnstructuredMesh {
 public:
     explicit TestMesh3D(const godzilla::Parameters & parameters) : UnstructuredMesh(parameters) {}
 
-protected:
     void
-    create_dm() override
+    create() override
     {
-        const PetscInt DIM = 3;
-        const PetscInt N_ELEM_NODES = 4;
-        std::vector<Int> cells = { 0, 1, 2, 3 };
-        std::vector<Real> coords = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1 };
-        build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
-
+        UnstructuredMesh::create();
         // create "side sets"
         auto face_sets = create_label("Face Sets");
 
@@ -52,6 +46,16 @@ protected:
         create_face_set_labels(face_set_names);
         for (auto it : face_set_names)
             set_face_set_name(it.first, it.second);
+    }
+
+    DM
+    create_dm() override
+    {
+        const PetscInt DIM = 3;
+        const PetscInt N_ELEM_NODES = 4;
+        std::vector<Int> cells = { 0, 1, 2, 3 };
+        std::vector<Real> coords = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+        return build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
     }
 
     void

--- a/test/src/FENonlinearProblemJFNK_test.cpp
+++ b/test/src/FENonlinearProblemJFNK_test.cpp
@@ -135,7 +135,7 @@ TEST(FENonlinearProblemJFNKTest, solve)
     prob_params.set<godzilla::App *>("_app") = &app;
     prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblemJFNK prob(prob_params);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     Parameters ic_params = ConstantInitialCondition::parameters();
     ic_params.set<godzilla::App *>("_app") = &app;

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -41,11 +41,12 @@ REGISTER_OBJECT(GTest2CompIC);
 
 TEST_F(FENonlinearProblemTest, fields)
 {
+    mesh->create();
+
     prob->set_fe(1, "vec", 3, 1);
 
     Int aux_fld1_idx = prob->add_aux_fe("aux_fld1", 2, 1);
 
-    mesh->create();
     prob->create();
 
     EXPECT_EQ(prob->get_field_name(0), "u");
@@ -94,6 +95,7 @@ TEST_F(FENonlinearProblemTest, fields)
 
 TEST_F(FENonlinearProblemTest, add_duplicate_field_id)
 {
+    mesh->create();
     prob->set_fe(0, "first", 1, 1);
     EXPECT_DEATH(prob->set_fe(0, "second", 1, 1),
                  "\\[ERROR\\] Cannot add field 'second' with ID = 0. ID already exists.");
@@ -139,6 +141,7 @@ TEST_F(FENonlinearProblemTest, get_aux_fields)
 
 TEST_F(FENonlinearProblemTest, add_duplicate_aux_field_id)
 {
+    mesh->create();
     prob->set_aux_fe(0, "first", 1, 1);
     EXPECT_DEATH(
         prob->set_aux_fe(0, "second", 1, 1),

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -271,8 +271,8 @@ TEST(TwoFieldFENonlinearProblemTest, err_duplicate_ics)
         void
         check_integrity() override
         {
-            if (this->log->get_num_entries() > 0)
-                this->log->print();
+            if (get_logger()->get_num_entries() > 0)
+                get_logger()->print();
         }
     } app;
 
@@ -327,8 +327,8 @@ TEST(TwoFieldFENonlinearProblemTest, err_not_enough_ics)
         void
         check_integrity() override
         {
-            if (this->log->get_num_entries() > 0)
-                this->log->print();
+            if (get_logger()->get_num_entries() > 0)
+                get_logger()->print();
         }
     } app;
 

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -269,7 +269,7 @@ TEST(TwoFieldFENonlinearProblemTest, err_duplicate_ics)
         TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla") {}
 
         void
-        check_integrity() override
+        check_integrity()
         {
             if (get_logger()->get_num_entries() > 0)
                 get_logger()->print();
@@ -325,7 +325,7 @@ TEST(TwoFieldFENonlinearProblemTest, err_not_enough_ics)
         TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla") {}
 
         void
-        check_integrity() override
+        check_integrity()
         {
             if (get_logger()->get_num_entries() > 0)
                 get_logger()->print();

--- a/test/src/FunctionAuxiliaryField_test.cpp
+++ b/test/src/FunctionAuxiliaryField_test.cpp
@@ -19,7 +19,6 @@ TEST(FunctionAuxiliaryFieldTest, create)
     prob_params.set<App *>("_app") = &app;
     prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    prob.set_aux_fe(0, "aux1", 1, 1);
 
     Parameters aux_params = FunctionAuxiliaryField::parameters();
     aux_params.set<App *>("_app") = &app;
@@ -27,9 +26,10 @@ TEST(FunctionAuxiliaryFieldTest, create)
     aux_params.set<DiscreteProblemInterface *>("_dpi") = &prob;
     aux_params.set<std::vector<std::string>>("value") = { "1234" };
     FunctionAuxiliaryField aux(aux_params);
-    prob.add_auxiliary_field(&aux);
 
     mesh.create();
+    prob.set_aux_fe(0, "aux1", 1, 1);
+    prob.add_auxiliary_field(&aux);
     prob.create();
 
     EXPECT_EQ(aux.get_field_id(), 0);
@@ -58,7 +58,6 @@ TEST(FunctionAuxiliaryFieldTest, evaluate)
     prob_params.set<App *>("_app") = &app;
     prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    prob.set_aux_fe(0, "aux1", 1, 1);
 
     Parameters aux_params = FunctionAuxiliaryField::parameters();
     aux_params.set<App *>("_app") = &app;
@@ -66,9 +65,10 @@ TEST(FunctionAuxiliaryFieldTest, evaluate)
     aux_params.set<DiscreteProblemInterface *>("_dpi") = &prob;
     aux_params.set<std::vector<std::string>>("value") = { "1234" };
     FunctionAuxiliaryField aux(aux_params);
-    prob.add_auxiliary_field(&aux);
 
     mesh.create();
+    prob.set_aux_fe(0, "aux1", 1, 1);
+    prob.add_auxiliary_field(&aux);
     prob.create();
 
     PetscFunc * fn = aux.get_func();

--- a/test/src/GYMLFile_test.cpp
+++ b/test/src/GYMLFile_test.cpp
@@ -32,9 +32,7 @@ public:
     {
     }
 
-    ~GTestProblem() override {
-        this->x.destroy();
-    }
+    ~GTestProblem() override { this->x.destroy(); }
 
     const Vector &
     get_solution_vector() const override

--- a/test/src/GYMLFile_test.cpp
+++ b/test/src/GYMLFile_test.cpp
@@ -187,7 +187,7 @@ TEST_F(GYMLFileTest, mesh_partitioner)
     EXPECT_NE(mesh, nullptr);
     mesh->create();
 
-    auto dm = mesh->dm();
+    auto dm = mesh->get_dm();
     PetscBool distr;
     DMPlexIsDistributed(dm, &distr);
     if (sz > 1)

--- a/test/src/GmshMesh_test.cpp
+++ b/test/src/GmshMesh_test.cpp
@@ -21,7 +21,7 @@ TEST(GmshMeshTest, api)
     EXPECT_EQ(mesh.get_file_name(), file_name);
 
     mesh.create();
-    auto dm = mesh.dm();
+    auto dm = mesh.get_dm();
 
     EXPECT_EQ(mesh.get_dimension(), 2);
 

--- a/test/src/GodzillaApp_test.cpp
+++ b/test/src/GodzillaApp_test.cpp
@@ -76,7 +76,7 @@ TEST_F(GodzillaAppTest, verbose)
     App app(comm, "godzilla", argc, argv);
 
     app.run();
-    EXPECT_EQ(app.verbosity_level(), 2);
+    EXPECT_EQ(app.get_verbosity_level(), 2);
 }
 
 TEST_F(GodzillaAppTest, check_integrity)
@@ -88,8 +88,8 @@ TEST_F(GodzillaAppTest, check_integrity)
         void
         run()
         {
-            this->yml = allocate_input_file();
-            this->log->error("error1");
+            set_input_file(new GYMLFile(this));
+            get_logger()->error("error1");
             check_integrity();
         }
     } app;
@@ -111,7 +111,7 @@ TEST_F(GodzillaAppTest, run_problem)
         void
         set_problem(Problem * prob)
         {
-            this->yml = new TestFile(this, prob);
+            set_input_file(new TestFile(this, prob));
         }
 
         void

--- a/test/src/GodzillaApp_test.cpp
+++ b/test/src/GodzillaApp_test.cpp
@@ -97,41 +97,6 @@ TEST_F(GodzillaAppTest, check_integrity)
     EXPECT_DEATH(app.run(), "error1");
 }
 
-TEST_F(GodzillaAppTest, run_problem)
-{
-    class TestFile : public GYMLFile {
-    public:
-        TestFile(App * app, Problem * prob) : GYMLFile(app) { this->problem = prob; }
-    };
-
-    class TestApp : public App {
-    public:
-        TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla") {}
-
-        void
-        set_problem(Problem * prob)
-        {
-            set_input_file(new TestFile(this, prob));
-        }
-
-        void
-        run()
-        {
-            run_problem();
-        }
-    } app;
-
-    const std::string & class_name = "MockProblem";
-    Parameters * pars = app.get_parameters(class_name);
-    MockProblem * prob = app.build_object<MockProblem>(class_name, "prob", pars);
-
-    app.set_problem(prob);
-
-    EXPECT_EQ(app.get_problem(), prob);
-    EXPECT_CALL(*prob, run);
-    app.run();
-}
-
 TEST_F(GodzillaAppTest, unknown_command_line_switch)
 {
     int argc = 2;

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -13,7 +13,7 @@ TEST_F(ImplicitFENonlinearProblemTest, run)
 {
     auto mesh = gMesh1d();
     auto prob = gProblem1d(mesh);
-    this->app->problem = prob;
+    this->app->set_problem(prob);
 
     {
         const std::string class_name = "ConstantInitialCondition";

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -10,7 +10,7 @@ TEST(IndexSetTest, create)
     TestApp app;
     IndexSet is;
     EXPECT_TRUE(is.empty());
-    is.create(app.comm());
+    is.create(app.get_comm());
     EXPECT_TRUE((IS) is != nullptr);
     is.destroy();
 }
@@ -18,7 +18,7 @@ TEST(IndexSetTest, create)
 TEST(IndexSetTest, data)
 {
     TestApp app;
-    IndexSet is = IndexSet::create_general(app.comm(), { 3, 5, 1, 8 });
+    IndexSet is = IndexSet::create_general(app.get_comm(), { 3, 5, 1, 8 });
     is.get_indices();
     auto data = is.data();
     EXPECT_THAT(data[0], 3);
@@ -32,7 +32,7 @@ TEST(IndexSetTest, data)
 TEST(IndexSetTest, create_general)
 {
     TestApp app;
-    IndexSet is = IndexSet::create_general(app.comm(), { 3, 5, 1, 8 });
+    IndexSet is = IndexSet::create_general(app.get_comm(), { 3, 5, 1, 8 });
     is.get_indices();
     auto idx = is.to_std_vector();
     EXPECT_THAT(idx, UnorderedElementsAre(1, 3, 5, 8));
@@ -43,7 +43,7 @@ TEST(IndexSetTest, create_general)
 TEST(IndexSetTest, get_id)
 {
     TestApp app;
-    auto is = IndexSet::create_general(app.comm(), { 1, 2, 3 });
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 2, 3 });
     EXPECT_TRUE(is.get_id() != 0);
     is.destroy();
 }
@@ -51,7 +51,7 @@ TEST(IndexSetTest, get_id)
 TEST(IndexSetTest, inc_ref)
 {
     TestApp app;
-    auto is = IndexSet::create_general(app.comm(), { 1, 2, 3 });
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 2, 3 });
     is.inc_ref();
     Int cnt = 0;
     PetscObjectGetReference((PetscObject) (IS) is, &cnt);
@@ -62,7 +62,7 @@ TEST(IndexSetTest, inc_ref)
 TEST(IndexSetTest, sort)
 {
     TestApp app;
-    IndexSet is = IndexSet::create_general(app.comm(), { 3, 5, 1, 8 });
+    IndexSet is = IndexSet::create_general(app.get_comm(), { 3, 5, 1, 8 });
     EXPECT_EQ(is.sorted(), false);
     is.sort();
     is.get_indices();
@@ -75,7 +75,7 @@ TEST(IndexSetTest, sort)
 TEST(IndexSetTest, sort_remove_dups)
 {
     TestApp app;
-    IndexSet is = IndexSet::create_general(app.comm(), { 3, 1, 5, 3, 1, 8 });
+    IndexSet is = IndexSet::create_general(app.get_comm(), { 3, 1, 5, 3, 1, 8 });
     is.sort_remove_dups();
     is.get_indices();
     auto idx = is.to_std_vector();
@@ -87,8 +87,8 @@ TEST(IndexSetTest, sort_remove_dups)
 TEST(IndexSetTest, intersect_caching)
 {
     TestApp app;
-    auto is1 = IndexSet::create_general(app.comm(), { 1, 2, 3 });
-    auto is2 = IndexSet::create_general(app.comm(), { 3, 4, 5 });
+    auto is1 = IndexSet::create_general(app.get_comm(), { 1, 2, 3 });
+    auto is2 = IndexSet::create_general(app.get_comm(), { 3, 4, 5 });
     IndexSet isect = IndexSet::intersect_caching(is1, is2);
     EXPECT_EQ(isect.get_size(), 1);
     isect.get_indices();
@@ -110,8 +110,8 @@ TEST(IndexSetTest, intersect_caching_empty)
 TEST(IndexSetTest, intersect)
 {
     TestApp app;
-    auto is1 = IndexSet::create_general(app.comm(), { 1, 2, 3 });
-    auto is2 = IndexSet::create_general(app.comm(), { 3, 4, 5 });
+    auto is1 = IndexSet::create_general(app.get_comm(), { 1, 2, 3 });
+    auto is2 = IndexSet::create_general(app.get_comm(), { 3, 4, 5 });
     IndexSet isect = IndexSet::intersect(is1, is2);
     EXPECT_EQ(isect.get_size(), 1);
     isect.get_indices();
@@ -125,7 +125,7 @@ TEST(IndexSetTest, intersect)
 TEST(IndexSetTest, range)
 {
     TestApp app;
-    auto is = IndexSet::create_general(app.comm(), { 1, 3, 4, 5, 8, 10 });
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
     std::vector<Int> vals;
     for (auto & i : is)
         vals.push_back(i);
@@ -135,7 +135,7 @@ TEST(IndexSetTest, range)
 TEST(IndexSetTest, for_loop)
 {
     TestApp app;
-    auto is = IndexSet::create_general(app.comm(), { 1, 3, 4, 5, 8, 10 });
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
     std::vector<Int> vals;
     for (auto i = is.begin(); i != is.end(); i++)
         vals.push_back(*i);
@@ -145,7 +145,7 @@ TEST(IndexSetTest, for_loop)
 TEST(IndexSetTest, iters)
 {
     TestApp app;
-    auto is = IndexSet::create_general(app.comm(), { 1, 3, 4, 5, 8, 10 });
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
 
     auto iter = is.begin();
     for (int i = 0; i < 6; i++, iter++)

--- a/test/src/InitialCondition_test.cpp
+++ b/test/src/InitialCondition_test.cpp
@@ -91,6 +91,8 @@ TEST_F(InitialConditionTest, api)
 
 TEST_F(InitialConditionTest, test)
 {
+    this->mesh->create();
+
     this->prob->add_aux_fe("a", 1, 1);
 
     Parameters params = InitialCondition::parameters();
@@ -109,8 +111,6 @@ TEST_F(InitialConditionTest, test)
 
     this->prob->add_initial_condition(&ic);
     this->prob->add_initial_condition(&aux_ic);
-
-    this->mesh->create();
     this->prob->create();
 
     this->app->check_integrity();
@@ -179,9 +179,9 @@ TEST_F(InitialCondition2FieldTest, no_field_param)
     params.set<std::string>("_name") = "obj";
     MockInitialCondition ic(params);
 
-    this->prob->add_initial_condition(&ic);
-
     this->mesh->create();
+
+    this->prob->add_initial_condition(&ic);
     this->prob->create();
 
     this->app->check_integrity();
@@ -203,9 +203,9 @@ TEST_F(InitialCondition2FieldTest, non_existing_field)
     params.set<std::string>("field") = "asdf";
     MockInitialCondition ic(params);
 
-    this->prob->add_initial_condition(&ic);
-
     this->mesh->create();
+
+    this->prob->add_initial_condition(&ic);
     this->prob->create();
 
     this->app->check_integrity();

--- a/test/src/L2Diff_test.cpp
+++ b/test/src/L2Diff_test.cpp
@@ -18,7 +18,7 @@ TEST(L2DiffTest, compute)
     prob_params.set<App *>("_app") = &app;
     prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     Parameters bc_left_params = DirichletBC::parameters();
     bc_left_params.set<App *>("_app") = &app;

--- a/test/src/Label_test.cpp
+++ b/test/src/Label_test.cpp
@@ -9,7 +9,7 @@ TEST(Label, create_destroy)
 {
     TestApp app;
     Label l;
-    l.create(app.comm(), "name");
+    l.create(app.get_comm(), "name");
     EXPECT_EQ(l.is_null(), false);
     l.destroy();
     EXPECT_EQ(l.is_null(), true);
@@ -19,7 +19,7 @@ TEST(Label, default_value)
 {
     TestApp app;
     Label l;
-    l.create(app.comm(), "name");
+    l.create(app.get_comm(), "name");
     l.set_default_value(-10);
     EXPECT_EQ(l.get_value(0), -10);
     EXPECT_EQ(l.get_default_value(), -10);
@@ -30,7 +30,7 @@ TEST(Label, set_value)
 {
     TestApp app;
     Label l;
-    l.create(app.comm(), "name");
+    l.create(app.get_comm(), "name");
     l.set_value(1, 101);
     EXPECT_EQ(l.get_value(1), 101);
     l.destroy();
@@ -40,7 +40,7 @@ TEST(Label, reset)
 {
     TestApp app;
     Label l;
-    l.create(app.comm(), "name");
+    l.create(app.get_comm(), "name");
     l.set_value(100, 1001);
     l.reset();
     EXPECT_EQ(l.get_value(100), -1);
@@ -52,7 +52,7 @@ TEST(Label, get_num_values)
 {
     TestApp app;
     Label l;
-    l.create(app.comm(), "name");
+    l.create(app.get_comm(), "name");
     l.set_value(0, 1001);
     l.set_value(1, 1001);
     l.set_value(2, 1002);
@@ -66,7 +66,7 @@ TEST(Label, get_values)
 {
     TestApp app;
     Label l;
-    l.create(app.comm(), "name");
+    l.create(app.get_comm(), "name");
     l.set_value(0, 1001);
     l.set_value(1, 1001);
     l.set_value(2, 1002);
@@ -82,9 +82,9 @@ TEST(Label, get_values)
 TEST(Label, set_stratum)
 {
     TestApp app;
-    IndexSet is = IndexSet::create_general(app.comm(), { 1, 2, 3, 4, 5 });
+    IndexSet is = IndexSet::create_general(app.get_comm(), { 1, 2, 3, 4, 5 });
     Label l;
-    l.create(app.comm(), "name");
+    l.create(app.get_comm(), "name");
     l.set_stratum(101, is);
     EXPECT_EQ(l.get_value(1), 101);
     EXPECT_EQ(l.get_value(2), 101);
@@ -100,7 +100,7 @@ TEST(Label, get_stratum)
 {
     TestApp app;
     Label l;
-    l.create(app.comm(), "name");
+    l.create(app.get_comm(), "name");
     l.set_value(1, 101);
     l.set_value(3, 101);
     l.set_value(4, 101);
@@ -121,7 +121,7 @@ TEST(Label, view)
 
     TestApp app;
     Label l;
-    l.create(app.comm(), "name");
+    l.create(app.get_comm(), "name");
     l.set_value(1, 101);
     l.set_value(3, 101);
     l.set_value(4, 102);

--- a/test/src/LineMesh_test.cpp
+++ b/test/src/LineMesh_test.cpp
@@ -24,7 +24,7 @@ TEST(LineMeshTest, api)
     EXPECT_EQ(mesh.get_nx(), 10);
 
     mesh.create();
-    auto dm = mesh.dm();
+    auto dm = mesh.get_dm();
 
     EXPECT_EQ(mesh.get_dimension(), 1);
 
@@ -77,7 +77,7 @@ TEST(LineMeshTest, distribute)
     mesh.create();
 
     PetscBool distr;
-    DMPlexIsDistributed(mesh.dm(), &distr);
+    DMPlexIsDistributed(mesh.get_dm(), &distr);
     if (sz > 1)
         EXPECT_EQ(distr, 1);
     else

--- a/test/src/LinearProblem_test.cpp
+++ b/test/src/LinearProblem_test.cpp
@@ -83,10 +83,10 @@ G1DTestLinearProblem::~G1DTestLinearProblem()
 void
 G1DTestLinearProblem::create()
 {
-    DMSetNumFields(dm(), 1);
+    DMSetNumFields(get_dm(), 1);
     Int nc[1] = { 1 };
     Int n_dofs[2] = { 1, 0 };
-    this->s = Section::create(dm(), nc, n_dofs, 0, nullptr, nullptr, nullptr, nullptr);
+    this->s = Section::create(get_dm(), nc, n_dofs, 0, nullptr, nullptr, nullptr, nullptr);
     set_local_section(this->s);
     LinearProblem::create();
 }
@@ -133,10 +133,10 @@ G2DTestLinearProblem::~G2DTestLinearProblem()
 void
 G2DTestLinearProblem::create()
 {
-    DMSetNumFields(dm(), 1);
+    DMSetNumFields(get_dm(), 1);
     Int nc[1] = { 1 };
     Int n_dofs[3] = { 1, 0, 0 };
-    this->s = Section::create(dm(), nc, n_dofs, 0, nullptr, nullptr, nullptr, nullptr);
+    this->s = Section::create(get_dm(), nc, n_dofs, 0, nullptr, nullptr, nullptr, nullptr);
     set_local_section(this->s);
     LinearProblem::create();
 }
@@ -182,10 +182,10 @@ G3DTestLinearProblem::~G3DTestLinearProblem()
 void
 G3DTestLinearProblem::create()
 {
-    DMSetNumFields(dm(), 1);
+    DMSetNumFields(get_dm(), 1);
     Int nc[1] = { 1 };
     Int n_dofs[4] = { 1, 0, 0, 0 };
-    this->s = Section::create(dm(), nc, n_dofs, 0, nullptr, nullptr, nullptr, nullptr);
+    this->s = Section::create(get_dm(), nc, n_dofs, 0, nullptr, nullptr, nullptr, nullptr);
     set_local_section(this->s);
     LinearProblem::create();
 }

--- a/test/src/MeshPartitioningOutput_test.cpp
+++ b/test/src/MeshPartitioningOutput_test.cpp
@@ -74,9 +74,9 @@ TEST(MeshPartitioningOutputTest, output)
 
     PetscViewer viewer;
     Vec p;
-    VecCreate(app.comm(), &p);
+    VecCreate(app.get_comm(), &p);
     PetscObjectSetName((PetscObject) p, "fields/partitioning");
-    PetscViewerHDF5Open(app.comm(), "part.h5", FILE_MODE_READ, &viewer);
+    PetscViewerHDF5Open(app.get_comm(), "part.h5", FILE_MODE_READ, &viewer);
     VecLoad(p, viewer);
     Real l2_norm;
     VecNorm(p, NORM_2, &l2_norm);

--- a/test/src/Mesh_test.cpp
+++ b/test/src/Mesh_test.cpp
@@ -21,7 +21,7 @@ public:
         Int faces[1] = { 2 };
         DMBoundaryType periodicity[1] = { DM_BOUNDARY_GHOSTED };
 
-        PETSC_CHECK(DMPlexCreateBoxMesh(comm(),
+        PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
                                         1,
                                         PETSC_TRUE,
                                         faces,

--- a/test/src/Mesh_test.cpp
+++ b/test/src/Mesh_test.cpp
@@ -21,6 +21,7 @@ public:
         Int faces[1] = { 2 };
         DMBoundaryType periodicity[1] = { DM_BOUNDARY_GHOSTED };
 
+        DM dm;
         PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
                                         1,
                                         PETSC_TRUE,
@@ -29,7 +30,8 @@ public:
                                         upper,
                                         periodicity,
                                         PETSC_TRUE,
-                                        &this->dm));
+                                        &dm));
+        set_dm(dm);
         set_up();
     }
 

--- a/test/src/Mesh_test.cpp
+++ b/test/src/Mesh_test.cpp
@@ -29,7 +29,7 @@ public:
                                         upper,
                                         periodicity,
                                         PETSC_TRUE,
-                                        &this->_dm));
+                                        &this->dm));
         set_up();
     }
 
@@ -57,7 +57,7 @@ TEST(MeshTest, get_coordinates)
     EXPECT_EQ(coords(2), 1.);
 
     DM cdm;
-    DMGetCoordinateDM(mesh.dm(), &cdm);
+    DMGetCoordinateDM(mesh.get_dm(), &cdm);
     EXPECT_EQ(mesh.get_coordinate_dm(), cdm);
 }
 

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -101,7 +101,7 @@ public:
     set_up_weak_form() override
     {
         add_residual_block(new TestNatF0(this), nullptr);
-        add_jacobian_block(this->fid, new TestNatG0(this), nullptr, nullptr, nullptr);
+        add_jacobian_block(get_field_id(), new TestNatG0(this), nullptr, nullptr, nullptr);
     }
 
 protected:

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -124,7 +124,6 @@ TEST(NaturalBCTest, fe)
     prob_params.set<Mesh *>("_mesh") = &mesh;
     GTest2FieldsFENonlinearProblem prob(prob_params);
     app.set_problem(&prob);
-    prob.set_aux_fe(0, "aux1", 1, 1);
 
     Parameters bc_params = TestNaturalBC::parameters();
     bc_params.set<App *>("_app") = &app;
@@ -133,9 +132,10 @@ TEST(NaturalBCTest, fe)
     bc_params.set<std::vector<std::string>>("boundary") = { "left" };
     bc_params.set<std::string>("field") = "u";
     TestNaturalBC bc(bc_params);
-    prob.add_boundary_condition(&bc);
 
     mesh.create();
+    prob.set_aux_fe(0, "aux1", 1, 1);
+    prob.add_boundary_condition(&bc);
     prob.create();
 
     PetscDS ds = prob.getDS();

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -24,7 +24,7 @@ TEST(NaturalBCTest, api)
     prob_params.set<App *>("_app") = &app;
     prob_params.set<Mesh *>("_mesh") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     class MockNaturalBC : public NaturalBC {
     public:
@@ -123,7 +123,7 @@ TEST(NaturalBCTest, fe)
     prob_params.set<App *>("_app") = &app;
     prob_params.set<Mesh *>("_mesh") = &mesh;
     GTest2FieldsFENonlinearProblem prob(prob_params);
-    app.problem = &prob;
+    app.set_problem(&prob);
     prob.set_aux_fe(0, "aux1", 1, 1);
 
     Parameters bc_params = TestNaturalBC::parameters();
@@ -173,7 +173,7 @@ TEST(NaturalBCTest, non_existing_field)
     prob_pars.set<App *>("_app") = &app;
     prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTest2FieldsFENonlinearProblem problem(prob_pars);
-    app.problem = &problem;
+    app.set_problem(&problem);
 
     Parameters params = TestNaturalBC::parameters();
     params.set<App *>("_app") = &app;
@@ -206,7 +206,7 @@ TEST(NaturalBCTest, field_param_not_specified)
     prob_pars.set<App *>("_app") = &app;
     prob_pars.set<Mesh *>("_mesh") = &mesh;
     GTest2FieldsFENonlinearProblem problem(prob_pars);
-    app.problem = &problem;
+    app.set_problem(&problem);
 
     Parameters params = TestNaturalBC::parameters();
     params.set<App *>("_app") = &app;

--- a/test/src/NaturalRiemannBC_test.cpp
+++ b/test/src/NaturalRiemannBC_test.cpp
@@ -68,7 +68,7 @@ TEST(NaturalRiemannBCTest, api)
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
     TestExplicitFVLinearProblem prob(prob_pars);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     Parameters bc_pars = TestBC::parameters();
     bc_pars.set<App *>("_app") = &app;

--- a/test/src/NeumannProblem_test.cpp
+++ b/test/src/NeumannProblem_test.cpp
@@ -158,7 +158,7 @@ public:
     set_up_weak_form() override
     {
         add_residual_block(new BndF0(this), nullptr);
-        add_jacobian_block(this->fid, new BndG0(this), nullptr, nullptr, nullptr);
+        add_jacobian_block(get_field_id(), new BndG0(this), nullptr, nullptr, nullptr);
     }
 
 protected:

--- a/test/src/NeumannProblem_test.cpp
+++ b/test/src/NeumannProblem_test.cpp
@@ -181,7 +181,7 @@ TEST(NeumannProblemTest, solve)
     prob_params.set<App *>("_app") = &app;
     prob_params.set<Mesh *>("_mesh") = &mesh;
     TestNeumannProblem prob(prob_params);
-    app.problem = &prob;
+    app.set_problem(&prob);
 
     Parameters bc_left_pars = TestNeumannBC::parameters();
     bc_left_pars.set<App *>("_app") = &app;

--- a/test/src/NonlinearProblem_test.cpp
+++ b/test/src/NonlinearProblem_test.cpp
@@ -46,9 +46,10 @@ G1DTestNonlinearProblem::create()
 {
     Int nc[1] = { 1 };
     Int n_dofs[2] = { 1, 0 };
-    DMSetNumFields(dm(), 1);
-    DMPlexCreateSection(dm(), nullptr, nc, n_dofs, 0, nullptr, nullptr, nullptr, nullptr, &this->s);
-    DMSetLocalSection(dm(), this->s);
+    auto dm = get_dm();
+    DMSetNumFields(dm, 1);
+    DMPlexCreateSection(dm, nullptr, nc, n_dofs, 0, nullptr, nullptr, nullptr, nullptr, &this->s);
+    DMSetLocalSection(dm, this->s);
     NonlinearProblem::create();
 }
 

--- a/test/src/Object_test.cpp
+++ b/test/src/Object_test.cpp
@@ -25,8 +25,8 @@ TEST(ObjectTest, api)
     EXPECT_EQ(obj->get_processor_id(), 0);
 
     int sz;
-    MPI_Comm_size(app.comm(), &sz);
-    EXPECT_EQ(obj->comm().size(), sz);
+    MPI_Comm_size(app.get_comm(), &sz);
+    EXPECT_EQ(obj->get_comm().size(), sz);
 
     obj->create();
 }

--- a/test/src/Output_test.cpp
+++ b/test/src/Output_test.cpp
@@ -19,12 +19,6 @@ public:
     output_step() override
     {
     }
-
-    unsigned int
-    get_exec_mask() const
-    {
-        return this->on_mask;
-    }
 };
 
 } // namespace

--- a/test/src/PrintInterface_test.cpp
+++ b/test/src/PrintInterface_test.cpp
@@ -32,7 +32,7 @@ TEST(PrintInterfaceTest, lprintf)
         void
         create() override
         {
-            lprintf(0, "Print");
+            lprint(0, "Print");
         }
     };
 

--- a/test/src/Problem_test.cpp
+++ b/test/src/Problem_test.cpp
@@ -143,7 +143,7 @@ TEST(ProblemTest, local_vec)
     prob_params.set<App *>("_app") = &app;
     prob_params.set<Mesh *>("_mesh") = &mesh;
     TestProblem problem(prob_params);
-    problem.set_local_section(create_section(mesh.dm()));
+    problem.set_local_section(create_section(mesh.get_dm()));
 
     Vector loc_vec = problem.get_local_vector();
     EXPECT_EQ(loc_vec.get_size(), 3);
@@ -168,7 +168,7 @@ TEST(ProblemTest, global_vec)
     prob_params.set<App *>("_app") = &app;
     prob_params.set<Mesh *>("_mesh") = &mesh;
     TestProblem problem(prob_params);
-    problem.set_local_section(create_section(mesh.dm()));
+    problem.set_local_section(create_section(mesh.get_dm()));
 
     Vector glob_vec = problem.get_global_vector();
     EXPECT_EQ(glob_vec.get_size(), 3);
@@ -194,7 +194,7 @@ TEST(ProblemTest, create_matrix)
     prob_params.set<Mesh *>("_mesh") = &mesh;
     TestProblem problem(prob_params);
     problem.create();
-    problem.set_local_section(create_section(mesh.dm()));
+    problem.set_local_section(create_section(mesh.get_dm()));
 
     Matrix mat = problem.create_matrix();
     EXPECT_EQ(mat.get_n_rows(), 3);
@@ -218,7 +218,7 @@ TEST(UnstructuredMeshTest, get_local_section)
     TestProblem problem(prob_params);
     problem.create();
 
-    auto dm = mesh.dm();
+    auto dm = mesh.get_dm();
     Section s = create_section(dm);
     problem.set_local_section(s);
 
@@ -245,7 +245,7 @@ TEST(UnstructuredMeshTest, get_global_section)
     TestProblem problem(prob_params);
     problem.create();
 
-    auto dm = mesh.dm();
+    auto dm = mesh.get_dm();
     Section s = create_section(dm);
     problem.set_local_section(s);
     problem.set_global_section(s);

--- a/test/src/RectangleMesh_test.cpp
+++ b/test/src/RectangleMesh_test.cpp
@@ -30,7 +30,7 @@ TEST(RectangleMeshTest, api)
     EXPECT_EQ(mesh.get_ny(), 8);
 
     mesh.create();
-    auto dm = mesh.dm();
+    auto dm = mesh.get_dm();
 
     EXPECT_EQ(mesh.get_dimension(), 2);
 

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -174,7 +174,7 @@ TEST(TimeSteppingAdaptor, api)
         params->set<Real>("dt") = 0.1;
         prob = app.build_object<TestTSProblem>(class_name, "prob", params);
     }
-    app.problem = prob;
+    app.set_problem(prob);
     mesh->create();
     prob->create();
 
@@ -216,7 +216,7 @@ TEST(TimeSteppingAdaptor, choose)
         params->set<Real>("dt") = 0.1;
         prob = app.build_object<TestTSProblem>(class_name, "prob", params);
     }
-    app.problem = prob;
+    app.set_problem(prob);
 
     {
         const std::string class_name = "DirichletBC";

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -50,9 +50,9 @@ public:
 
 protected:
     void
-    set_type() override
+    set_type_impl() override
     {
-        PETSC_CHECK(TSAdaptSetType(this->ts_adapt, TS_ADAPT_TEST));
+        set_type(TS_ADAPT_TEST);
     }
 };
 
@@ -81,7 +81,7 @@ TestTSAdaptor::choose(Real h,
                       Real * wltea,
                       Real * wlter)
 {
-    Int idx = this->problem->get_step_num();
+    Int idx = get_problem()->get_step_num();
     *next_sc = 0;
     if (idx < 3) {
         *next_h = this->dts[idx];
@@ -151,7 +151,7 @@ TEST(TimeSteppingAdaptor, api)
     public:
         explicit MockTSAdaptor(const Parameters & params) : TimeSteppingAdaptor(params) {}
 
-        MOCK_METHOD((void), set_type, ());
+        MOCK_METHOD((void), set_type_impl, ());
     };
 
     TestApp app;
@@ -189,7 +189,7 @@ TEST(TimeSteppingAdaptor, api)
     EXPECT_DOUBLE_EQ(adaptor.get_dt_min(), 1e-3);
     EXPECT_DOUBLE_EQ(adaptor.get_dt_max(), 1e3);
 
-    EXPECT_CALL(adaptor, set_type);
+    EXPECT_CALL(adaptor, set_type_impl);
     adaptor.create();
 }
 

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -40,12 +40,6 @@ public:
                                         &dm));
         return dm;
     }
-
-    Int
-    get_partition_overlap()
-    {
-        return this->partition_overlap;
-    }
 };
 
 class TestUnstructuredMesh3D : public UnstructuredMesh {

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -36,7 +36,7 @@ public:
                                         upper,
                                         periodicity,
                                         PETSC_TRUE,
-                                        &this->_dm));
+                                        &this->dm));
     }
 
     Int
@@ -74,7 +74,7 @@ public:
                                         upper,
                                         periodicity,
                                         PETSC_TRUE,
-                                        &this->_dm));
+                                        &this->dm));
         // create "side sets"
         std::map<Int, std::string> face_set_names;
         face_set_names[1] = "back";

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -28,7 +28,7 @@ public:
         Int faces[1] = { 2 };
         DMBoundaryType periodicity[1] = { DM_BOUNDARY_GHOSTED };
 
-        PETSC_CHECK(DMPlexCreateBoxMesh(comm(),
+        PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
                                         1,
                                         PETSC_TRUE,
                                         faces,
@@ -66,7 +66,7 @@ public:
                                           DM_BOUNDARY_GHOSTED,
                                           DM_BOUNDARY_GHOSTED };
 
-        PETSC_CHECK(DMPlexCreateBoxMesh(comm(),
+        PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
                                         3,
                                         PETSC_FALSE,
                                         faces,

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -20,14 +20,15 @@ class TestUnstructuredMesh : public UnstructuredMesh {
 public:
     explicit TestUnstructuredMesh(const Parameters & params) : UnstructuredMesh(params) {}
 
-    void
-    create_dm()
+    DM
+    create_dm() override
     {
         Real lower[1] = { -1 };
         Real upper[1] = { 1 };
         Int faces[1] = { 2 };
         DMBoundaryType periodicity[1] = { DM_BOUNDARY_GHOSTED };
 
+        DM dm;
         PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
                                         1,
                                         PETSC_TRUE,
@@ -36,7 +37,8 @@ public:
                                         upper,
                                         periodicity,
                                         PETSC_TRUE,
-                                        &this->dm));
+                                        &dm));
+        return dm;
     }
 
     Int
@@ -56,8 +58,8 @@ public:
     {
     }
 
-    void
-    create_dm()
+    DM
+    create_dm() override
     {
         Real lower[3] = { 0, 0, 0 };
         Real upper[3] = { 1, 1, 1 };
@@ -66,6 +68,7 @@ public:
                                           DM_BOUNDARY_GHOSTED,
                                           DM_BOUNDARY_GHOSTED };
 
+        DM dm;
         PETSC_CHECK(DMPlexCreateBoxMesh(get_comm(),
                                         3,
                                         PETSC_FALSE,
@@ -74,7 +77,14 @@ public:
                                         upper,
                                         periodicity,
                                         PETSC_TRUE,
-                                        &this->dm));
+                                        &dm));
+        return dm;
+    }
+
+    void
+    create() override
+    {
+        UnstructuredMesh::create();
         // create "side sets"
         std::map<Int, std::string> face_set_names;
         face_set_names[1] = "back";
@@ -471,12 +481,12 @@ TEST(UnstructuredMesh, build_from_cell_list_2d)
         }
 
     protected:
-        void
+        DM
         create_dm() override
         {
             std::vector<Int> cells = { 0, 1, 2, 1, 3, 2 };
             std::vector<Real> vertices = { 0, 0, 1, 0, 0, 1, 1, 1 };
-            build_from_cell_list(2, 3, cells, 2, vertices, true);
+            return build_from_cell_list(2, 3, cells, 2, vertices, true);
         }
     };
 

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -73,7 +73,9 @@ TEST_F(VTKOutputTest, wrong_mesh_type)
         void
         create() override
         {
-            DMDACreate1d(get_comm(), DM_BOUNDARY_NONE, 1, 1, 1, nullptr, &this->dm);
+            DM dm;
+            DMDACreate1d(get_comm(), DM_BOUNDARY_NONE, 1, 1, 1, nullptr, &dm);
+            set_dm(dm);
             set_up();
         }
 

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -73,7 +73,7 @@ TEST_F(VTKOutputTest, wrong_mesh_type)
         void
         create() override
         {
-            DMDACreate1d(comm(), DM_BOUNDARY_NONE, 1, 1, 1, nullptr, &this->_dm);
+            DMDACreate1d(get_comm(), DM_BOUNDARY_NONE, 1, 1, 1, nullptr, &this->_dm);
             set_up();
         }
 

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -73,7 +73,7 @@ TEST_F(VTKOutputTest, wrong_mesh_type)
         void
         create() override
         {
-            DMDACreate1d(get_comm(), DM_BOUNDARY_NONE, 1, 1, 1, nullptr, &this->_dm);
+            DMDACreate1d(get_comm(), DM_BOUNDARY_NONE, 1, 1, 1, nullptr, &this->dm);
             set_up();
         }
 

--- a/tools/mesh-part/main.cpp
+++ b/tools/mesh-part/main.cpp
@@ -13,7 +13,7 @@ class MeshPartApp : public App {
 public:
     MeshPartApp(int argc, const char * const * argv);
 
-    void process_command_line(cxxopts::ParseResult & result) override;
+    void process_command_line(const cxxopts::ParseResult & result) override;
 
 protected:
     void create_command_line_options() override;
@@ -39,34 +39,34 @@ MeshPartApp::get_input_file_name() const
 }
 
 void
-MeshPartApp::process_command_line(cxxopts::ParseResult & result)
+MeshPartApp::process_command_line(const cxxopts::ParseResult & result)
 {
-    this->cmdln_opts.parse_positional({ "mesh-file" });
-    auto res = this->cmdln_opts.parse(argc, argv);
+    get_command_line_opts().parse_positional({ "mesh-file" });
+    auto res = parse_command_line();
     if (res.count("help"))
-        fmt::print("{}", this->cmdln_opts.help());
+        fmt::print("{}", get_command_line_opts().help());
     else if (res.count("version"))
-        fmt::print("{}, version {}\n", name(), version());
+        fmt::print("{}, version {}\n", get_name(), get_version());
     else if (res.count("mesh-file"))
         partition_mesh_file(res["mesh-file"].as<std::string>());
     else
-        fmt::print("{}", this->cmdln_opts.help());
+        fmt::print("{}", get_command_line_opts().help());
 }
 
 void
 MeshPartApp::create_command_line_options()
 {
-    this->cmdln_opts.add_option("", "h", "help", "Show this help page", cxxopts::value<bool>(), "");
-    this->cmdln_opts.add_option("", "v", "version", "Show the version", cxxopts::value<bool>(), "");
-    this->cmdln_opts.add_option("",
-                                "p",
-                                "partitioner",
-                                "Name of the partitioner",
-                                cxxopts::value<std::string>(),
-                                "");
-    this->cmdln_opts
-        .add_option("", "", "mesh-file", "The mesh file name", cxxopts::value<std::string>(), "");
-    this->cmdln_opts.positional_help("<mesh-file>");
+    auto opts = get_command_line_opts();
+    opts.add_option("", "h", "help", "Show this help page", cxxopts::value<bool>(), "");
+    opts.add_option("", "v", "version", "Show the version", cxxopts::value<bool>(), "");
+    opts.add_option("",
+                    "p",
+                    "partitioner",
+                    "Name of the partitioner",
+                    cxxopts::value<std::string>(),
+                    "");
+    opts.add_option("", "", "mesh-file", "The mesh file name", cxxopts::value<std::string>(), "");
+    opts.positional_help("<mesh-file>");
 }
 
 UnstructuredMesh *


### PR DESCRIPTION
- PrintInterface::TimedEvent data are private
- Deprecating lprintf in favor of lprint
- Refactoring App class interface
- Opening the App API more
- InputFile: refactoring getters
- Mesh::get_dm() is back
- Mesh: Member variables are private
- UnstructuredMesh: Member variables are private
- AuxiliaryField: Member variables are private
- BoundaryCondition: Member variables are private
- BoxMesh: Member variables are private
- CallStack: Member variables are private
- ConstantAuxiliaryField: Member variables are private
- No need for num_comps in ConstantAuxiliaryField
- ConstantInitialCondition: Member variables are private
- Output: Member variables are private
- FileOutput: Member variables are private
- ExodusIIOutput: Member variables are private
- VtkOutput: Member variables are private
- TecplotOutput: Member variables are private
- CSVOutput: Member variables are private
- DependencyGraph: Member variables are private
- DirichletBC: Member variables are private
- EssentialBC: Member variables are private
- ExplicitFELinearProblem: Member variables are private
- ExplicitFVLinearProblem: Member variables are private
- Factory: Member variables are private
- FEProblemInterface: Member variables are private
- FieldValue: Member variables are private
- FileMesh: Member variables are private
- FunctionEvaluator: Member variables are private
- FunctionInterface: Member variables are private
- FVProblemInterface: Member variables are private
- ImplicitFENonlinearProblem: Member variables are private
- InitialCondition: Member variables are private
- L2Diff: Member variables are private
- L2FieldDiff: Member variables are private
- LinearInterpolation: Member variables are private
- LinearProblem: Member variables are private
- LineMesh: Member variables are private
- Logger: Member variables are private
- LoggingInterface: Member variables are private
- NaturalBC: Member variables are private
- NaturalRiemannBC: Member variables are private
- ParsedFunction: Member variables are private
- PerfLog: Member variables are private
- PiecewiseConstant: Member variables are private
- PiecewiseLinear: Member variables are private
- Postprocessor: Member variables are private
- Problem: Member variables are private
- RectangleMesh: Member variables are private
- TimeSteppingAdaptor: Member variables are private
- TransientProblemInterface: Member variables are private
- ValueFunctional: Member variables are private
- WeakForm: Member variables are private
