### PR TITLE
Refactoring output flags

### DIFF
--- a/include/godzilla/ExecuteFlags.h
+++ b/include/godzilla/ExecuteFlags.h
@@ -1,0 +1,44 @@
+#pragma once
+
+namespace godzilla {
+
+class ExecuteOn {
+public:
+    enum ExecuteOnFlag : unsigned int { INITIAL = 0x1, TIMESTEP = 0x2, FINAL = 0x4 };
+
+    ExecuteOn() : mask(0) {}
+
+    ExecuteOn(ExecuteOnFlag flag) : mask(flag) {}
+
+    bool
+    has_flags() const
+    {
+        return this->mask != 0;
+    }
+
+    ExecuteOn &
+    operator|=(ExecuteOnFlag rhs)
+    {
+        this->mask |= rhs;
+        return *this;
+    }
+
+    bool
+    operator&(ExecuteOnFlag flag)
+    {
+        return (this->mask & flag);
+    }
+
+private:
+    unsigned int mask;
+};
+
+inline ExecuteOn
+operator|(ExecuteOn::ExecuteOnFlag one, ExecuteOn::ExecuteOnFlag two)
+{
+    ExecuteOn flags(one);
+    flags |= two;
+    return flags;
+}
+
+} // namespace godzilla

--- a/include/godzilla/Output.h
+++ b/include/godzilla/Output.h
@@ -3,6 +3,7 @@
 #include "godzilla/Object.h"
 #include "godzilla/PrintInterface.h"
 #include "godzilla/Types.h"
+#include "godzilla/ExecuteFlags.h"
 
 namespace godzilla {
 
@@ -20,18 +21,18 @@ public:
     /// Set execute mask
     ///
     /// @param mask Bit mask for execution
-    void set_exec_mask(unsigned int mask);
+    void set_exec_mask(ExecuteOn mask);
 
     /// Get execution mask
     ///
     /// @return execution mask
-    unsigned int get_exec_mask() const;
+    ExecuteOn get_exec_mask() const;
 
     /// Should output happen at a specified occasion
     ///
     /// @param mask Bit mask specifying the occasion, see ON_XYZ below
     /// @return `true` if output should happen, otherwise `false`
-    virtual bool should_output(unsigned int mask);
+    virtual bool should_output(ExecuteOn::ExecuteOnFlag mask);
 
     /// Output a step of a simulation
     virtual void output_step() = 0;
@@ -50,18 +51,13 @@ private:
     Problem * problem;
 
     /// Bitwise mask for determining when this output object should output its content
-    unsigned int on_mask;
+    ExecuteOn on_mask;
 
     ///
     Int interval;
 
 public:
     static Parameters parameters();
-
-    static const unsigned int ON_NONE;
-    static const unsigned int ON_INITIAL;
-    static const unsigned int ON_TIMESTEP;
-    static const unsigned int ON_FINAL;
 };
 
 } // namespace godzilla

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -5,6 +5,7 @@
 #include "godzilla/PrintInterface.h"
 #include "godzilla/Vector.h"
 #include "godzilla/Matrix.h"
+#include "godzilla/ExecuteFlags.h"
 #include "petscdm.h"
 #include "petscpartitioner.h"
 
@@ -84,7 +85,7 @@ public:
     /// Output
     ///
     /// @param mask Bit mask for an output event, see `Output` for valid options.
-    virtual void output(unsigned int mask);
+    virtual void output(ExecuteOn::ExecuteOnFlag flag);
 
     /// Creates a local vector from a DM object
     ///
@@ -127,7 +128,8 @@ public:
     /// Set the `Section` encoding the global data layout for the `DM`.
     void set_global_section(const Section & section) const;
 
-    void set_default_output_on(unsigned int mask);
+    /// Set default execute on flags
+    void set_default_output_on(ExecuteOn flags);
 
 protected:
     /// Called before solving starts
@@ -146,7 +148,7 @@ private:
     std::vector<Output *> outputs;
 
     /// Default output execute mask
-    unsigned int default_output_on;
+    ExecuteOn default_output_on;
 
     /// List of postprocessor objects
     std::map<std::string, Postprocessor *> pps;

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -61,7 +61,7 @@ ExplicitFELinearProblem::ExplicitFELinearProblem(const Parameters & params) :
     scheme(get_param<std::string>("scheme"))
 {
     _F_;
-    set_default_output_on(Output::ON_INITIAL | Output::ON_TIMESTEP);
+    set_default_output_on(ExecuteOn::INITIAL | ExecuteOn::TIMESTEP);
 }
 
 ExplicitFELinearProblem::~ExplicitFELinearProblem()
@@ -254,7 +254,7 @@ ExplicitFELinearProblem::post_step()
     TransientProblemInterface::post_step();
     update_aux_vector();
     compute_postprocessors();
-    output(Output::ON_TIMESTEP);
+    output(ExecuteOn::TIMESTEP);
 }
 
 void

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -36,7 +36,7 @@ ExplicitFVLinearProblem::ExplicitFVLinearProblem(const Parameters & params) :
     scheme(get_param<std::string>("scheme"))
 {
     _F_;
-    set_default_output_on(Output::ON_INITIAL | Output::ON_TIMESTEP);
+    set_default_output_on(ExecuteOn::INITIAL | ExecuteOn::TIMESTEP);
 }
 
 ExplicitFVLinearProblem::~ExplicitFVLinearProblem()
@@ -238,7 +238,7 @@ ExplicitFVLinearProblem::post_step()
     TransientProblemInterface::post_step();
     update_aux_vector();
     compute_postprocessors();
-    output(Output::ON_TIMESTEP);
+    output(ExecuteOn::TIMESTEP);
 }
 
 } // namespace godzilla

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -94,7 +94,7 @@ ImplicitFENonlinearProblem::ImplicitFENonlinearProblem(const Parameters & params
     scheme(get_param<std::string>("scheme"))
 {
     _F_;
-    set_default_output_on(Output::ON_INITIAL | Output::ON_TIMESTEP);
+    set_default_output_on(ExecuteOn::INITIAL | ExecuteOn::TIMESTEP);
 }
 
 ImplicitFENonlinearProblem::~ImplicitFENonlinearProblem()
@@ -279,7 +279,7 @@ ImplicitFENonlinearProblem::post_step()
     TransientProblemInterface::post_step();
     update_aux_vector();
     compute_postprocessors();
-    output(Output::ON_TIMESTEP);
+    output(ExecuteOn::TIMESTEP);
 }
 
 } // namespace godzilla

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -58,7 +58,7 @@ LinearProblem::LinearProblem(const Parameters & parameters) :
     lin_max_iter(get_param<Int>("lin_max_iter"))
 {
     _F_;
-    set_default_output_on(Output::ON_FINAL);
+    set_default_output_on(ExecuteOn::FINAL);
 }
 
 LinearProblem::~LinearProblem()

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -92,7 +92,7 @@ NonlinearProblem::NonlinearProblem(const Parameters & parameters) :
     lin_max_iter(get_param<Int>("lin_max_iter"))
 {
     _F_;
-    set_default_output_on(Output::ON_FINAL);
+    set_default_output_on(ExecuteOn::FINAL);
     line_search_type = utils::to_lower(line_search_type);
 }
 

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -20,7 +20,7 @@ Problem::Problem(const Parameters & parameters) :
     Object(parameters),
     PrintInterface(this),
     mesh(get_param<Mesh *>("_mesh")),
-    default_output_on(Output::ON_NONE)
+    default_output_on()
 {
 }
 
@@ -142,11 +142,11 @@ Problem::get_postprocessor_names() const
 }
 
 void
-Problem::output(unsigned int mask)
+Problem::output(ExecuteOn::ExecuteOnFlag flag)
 {
     _F_;
     for (auto & o : this->outputs)
-        if (o->should_output(mask))
+        if (o->should_output(flag))
             o->output_step();
 }
 
@@ -155,7 +155,7 @@ Problem::on_initial()
 {
     _F_;
     compute_postprocessors();
-    output(Output::ON_INITIAL);
+    output(ExecuteOn::INITIAL);
 }
 
 void
@@ -163,7 +163,7 @@ Problem::on_final()
 {
     _F_;
     compute_postprocessors();
-    output(Output::ON_FINAL);
+    output(ExecuteOn::FINAL);
 }
 
 Vector
@@ -258,9 +258,9 @@ Problem::set_global_section(const Section & section) const
 }
 
 void
-Problem::set_default_output_on(unsigned int mask)
+Problem::set_default_output_on(ExecuteOn flags)
 {
-    this->default_output_on = mask;
+    this->default_output_on = flags;
 }
 
 } // namespace godzilla

--- a/test/src/Output_test.cpp
+++ b/test/src/Output_test.cpp
@@ -32,9 +32,9 @@ TEST_F(OutputTest, exec_masks_1)
     MockOutput out(pars);
     out.create();
 
-    EXPECT_FALSE(out.should_output(Output::ON_FINAL));
-    EXPECT_FALSE(out.should_output(Output::ON_INITIAL));
-    EXPECT_FALSE(out.should_output(Output::ON_TIMESTEP));
+    EXPECT_FALSE(out.should_output(ExecuteOn::FINAL));
+    EXPECT_FALSE(out.should_output(ExecuteOn::INITIAL));
+    EXPECT_FALSE(out.should_output(ExecuteOn::TIMESTEP));
 }
 
 TEST_F(OutputTest, exec_masks_2)
@@ -46,10 +46,10 @@ TEST_F(OutputTest, exec_masks_2)
     MockOutput out(pars);
     out.create();
 
-    EXPECT_EQ(out.get_exec_mask(), Output::ON_FINAL);
-    EXPECT_TRUE(out.should_output(Output::ON_FINAL));
-    EXPECT_FALSE(out.should_output(Output::ON_INITIAL));
-    EXPECT_FALSE(out.should_output(Output::ON_TIMESTEP));
+    EXPECT_TRUE(out.get_exec_mask() & ExecuteOn::FINAL);
+    EXPECT_TRUE(out.should_output(ExecuteOn::FINAL));
+    EXPECT_FALSE(out.should_output(ExecuteOn::INITIAL));
+    EXPECT_FALSE(out.should_output(ExecuteOn::TIMESTEP));
 }
 
 TEST_F(OutputTest, exec_masks_3)
@@ -61,13 +61,13 @@ TEST_F(OutputTest, exec_masks_3)
     MockOutput out(pars);
     out.create();
 
-    EXPECT_EQ(out.get_exec_mask() & Output::ON_FINAL, Output::ON_FINAL);
-    EXPECT_EQ(out.get_exec_mask() & Output::ON_INITIAL, Output::ON_INITIAL);
-    EXPECT_EQ(out.get_exec_mask() & Output::ON_TIMESTEP, Output::ON_TIMESTEP);
+    EXPECT_TRUE(out.get_exec_mask() & ExecuteOn::FINAL);
+    EXPECT_TRUE(out.get_exec_mask() & ExecuteOn::INITIAL);
+    EXPECT_TRUE(out.get_exec_mask() & ExecuteOn::TIMESTEP);
 
-    EXPECT_TRUE(out.should_output(Output::ON_FINAL));
-    EXPECT_TRUE(out.should_output(Output::ON_INITIAL));
-    EXPECT_TRUE(out.should_output(Output::ON_TIMESTEP));
+    EXPECT_TRUE(out.should_output(ExecuteOn::FINAL));
+    EXPECT_TRUE(out.should_output(ExecuteOn::INITIAL));
+    EXPECT_TRUE(out.should_output(ExecuteOn::TIMESTEP));
 }
 
 TEST_F(OutputTest, empty_on)

--- a/test/src/Problem_test.cpp
+++ b/test/src/Problem_test.cpp
@@ -126,7 +126,7 @@ TEST(ProblemTest, add_pp)
     EXPECT_EQ(pps_names[0], "pp");
 
     EXPECT_CALL(out, output_step);
-    problem.output(Output::ON_INITIAL);
+    problem.output(ExecuteOn::INITIAL);
 }
 
 TEST(ProblemTest, local_vec)


### PR DESCRIPTION
- adding global execute on flags as enum (`ExecuteOnFlag`)
- adding `ExecuteOn` type as a combination of `ExecuteOnFlag`s
- adding & and | operators for testing and setting the flags
