### PR TITLE
Adding Vector::duplicate() with return

### DIFF
--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -36,6 +36,7 @@ public:
     Scalar dot(const Vector & y) const;
     void scale(Scalar alpha);
     void duplicate(Vector & b) const;
+    Vector duplicate() const;
 
     /// Copy this vector into `y`
     ///

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -112,6 +112,14 @@ Vector::duplicate(Vector & b) const
     VecDuplicate(this->vec, &b.vec);
 }
 
+Vector
+Vector::duplicate() const
+{
+    Vec dup;
+    PETSC_CHECK(VecDuplicate(this->vec, &dup));
+    return { dup };
+}
+
 void
 Vector::copy(Vector & y) const
 {

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -105,6 +105,20 @@ TEST(VectorTest, duplicate)
     v.destroy();
 }
 
+TEST(VectorTest, duplicate_ret)
+{
+    Vector v = Vector::create_seq(MPI_COMM_WORLD, 3);
+    v.set_value(0, 1.);
+    v.set_value(1, 3.);
+    v.set_value(2, 7.);
+    Vector dup = v.duplicate();
+    v.copy(dup);
+    EXPECT_DOUBLE_EQ(dup(0), 1.);
+    EXPECT_DOUBLE_EQ(dup(1), 3.);
+    EXPECT_DOUBLE_EQ(dup(2), 7.);
+    v.destroy();
+}
+
 TEST(VectorTest, sum)
 {
     Vector v = Vector::create_seq(MPI_COMM_WORLD, 3);


### PR DESCRIPTION
This version is used like so: `dup = vec.duplicate()` which is more legible.
