### PR TITLE
clang tidy

### DIFF
--- a/examples/poisson/src/PoissonEquation.cpp
+++ b/examples/poisson/src/PoissonEquation.cpp
@@ -4,7 +4,6 @@
 #include "PoissonEquation.h"
 #include "PoissonPDE.h"
 #include "godzilla/CallStack.h"
-#include "petscdmlabel.h"
 
 using namespace godzilla;
 

--- a/include/godzilla/BoxMesh.h
+++ b/include/godzilla/BoxMesh.h
@@ -15,31 +15,31 @@ public:
     void create() override;
 
     /// Get lower limit in x-direction
-    NO_DISCARD Real get_x_min() const;
+    Real get_x_min() const;
 
     /// Get upper limit in x-direction
-    NO_DISCARD Real get_x_max() const;
+    Real get_x_max() const;
 
     /// Get the number of mesh points in x direction
-    NO_DISCARD Int get_nx() const;
+    Int get_nx() const;
 
     /// Get lower limit in y-direction
-    NO_DISCARD Real get_y_min() const;
+    Real get_y_min() const;
 
     /// Get upper limit in y-direction
-    NO_DISCARD Real get_y_max() const;
+    Real get_y_max() const;
 
     /// Get the number of mesh points in y-direction
-    NO_DISCARD Int get_ny() const;
+    Int get_ny() const;
 
     /// Get lower limit in z-direction
-    NO_DISCARD Real get_z_min() const;
+    Real get_z_min() const;
 
     /// Get upper limit in z-direction
-    NO_DISCARD Real get_z_max() const;
+    Real get_z_max() const;
 
     /// Get the number of mesh points in z direction
-    NO_DISCARD Int get_nz() const;
+    Int get_nz() const;
 
 protected:
     DM create_dm() override;

--- a/include/godzilla/LinearProblem.h
+++ b/include/godzilla/LinearProblem.h
@@ -29,7 +29,7 @@ protected:
     /// Initialize the problem
     virtual void init();
     /// Allocate Jacobian/residual objects
-    virtual void allocate_objects();
+    void allocate_objects() override;
     /// Setup computation of residual and Jacobian callbacks
     virtual void set_up_callbacks();
     /// Setup monitors

--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -37,7 +37,7 @@ protected:
     /// Set up initial guess
     virtual void set_up_initial_guess();
     /// Allocate Jacobian/residual objects
-    virtual void allocate_objects();
+    void allocate_objects() override;
     /// Set up line search
     virtual void set_up_line_search();
     /// Set up computation of residual and Jacobian callbacks

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -135,7 +135,7 @@ public:
 
 protected:
     /// Allocate objects
-    void allocate_objects();
+    virtual void allocate_objects();
     /// Called before solving starts
     virtual void on_initial();
     /// Called after solve has successfully finished

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -8,11 +8,9 @@
 #include "godzilla/Postprocessor.h"
 #include "godzilla/IndexSet.h"
 #include "exodusIIcpp/exodusIIcpp.h"
-#include "fmt/printf.h"
 #include "fmt/format.h"
 #include "fmt/chrono.h"
 #include <set>
-#include <cassert>
 
 namespace godzilla {
 

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -4,7 +4,6 @@
 #include "godzilla/Problem.h"
 #include "godzilla/AuxiliaryField.h"
 #include "godzilla/NaturalBC.h"
-#include "godzilla/Types.h"
 #include "godzilla/App.h"
 #include "godzilla/Logger.h"
 #include "godzilla/PetscFEGodzilla.h"

--- a/src/NaturalBC.cpp
+++ b/src/NaturalBC.cpp
@@ -1,7 +1,6 @@
 #include "godzilla/NaturalBC.h"
 #include "godzilla/CallStack.h"
 #include "godzilla/App.h"
-#include "godzilla/Problem.h"
 #include "godzilla/FEProblemInterface.h"
 #include "godzilla/BndResidualFunc.h"
 #include "godzilla/BndJacobianFunc.h"

--- a/src/TecplotOutput.cpp
+++ b/src/TecplotOutput.cpp
@@ -2,7 +2,6 @@
 #include "godzilla/App.h"
 #include "godzilla/CallStack.h"
 #include "godzilla/TecplotOutput.h"
-#include "godzilla/Problem.h"
 #include "godzilla/DiscreteProblemInterface.h"
 #include "godzilla/UnstructuredMesh.h"
 #include "godzilla/Validation.h"

--- a/test/src/Factory_test.cpp
+++ b/test/src/Factory_test.cpp
@@ -1,7 +1,6 @@
 #include "gtest/gtest.h"
 #include "godzilla/Factory.h"
 #include "godzilla/App.h"
-#include "godzilla/LineMesh.h"
 #include "godzilla/RectangleMesh.h"
 
 using namespace godzilla;

--- a/test/src/HashMap_test.cpp
+++ b/test/src/HashMap_test.cpp
@@ -1,6 +1,5 @@
 #include "gmock/gmock.h"
 #include "godzilla/HashMap.h"
-#include "godzilla/Types.h"
 
 using namespace godzilla;
 using namespace testing;

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -1,6 +1,4 @@
 #include "gmock/gmock.h"
-#include "godzilla/CallStack.h"
-#include "godzilla/Factory.h"
 #include "ImplicitFENonlinearProblem_test.h"
 #include "godzilla/Parameters.h"
 #include "godzilla/InitialCondition.h"


### PR DESCRIPTION
- Removing NO_DISCARD in BoxMesh
- Making `Problem::allocate_objects` virtual
- Removing unused `#include`s
