### PR TITLE
Refactoring compute_flux

### DIFF
--- a/examples/advect-eqn/include/AdvectionEquation.h
+++ b/examples/advect-eqn/include/AdvectionEquation.h
@@ -11,19 +11,18 @@ public:
     AdvectionEquation(const Parameters & parameters);
     void create() override;
 
-    void compute_flux(PetscInt dim,
-                      PetscInt nf,
-                      const PetscReal x[],
-                      const PetscReal n[],
-                      const PetscScalar uL[],
-                      const PetscScalar uR[],
-                      PetscInt n_consts,
-                      const PetscScalar constants[],
-                      PetscScalar flux[]);
+    PetscErrorCode compute_flux(PetscInt dim,
+                                PetscInt nf,
+                                const PetscReal x[],
+                                const PetscReal n[],
+                                const PetscScalar uL[],
+                                const PetscScalar uR[],
+                                PetscInt n_consts,
+                                const PetscScalar constants[],
+                                PetscScalar flux[]) override;
 
 protected:
     void set_up_fields() override;
-    void set_up_ds() override;
 
 public:
     static Parameters parameters();

--- a/examples/advect-eqn/src/AdvectionEquation.cpp
+++ b/examples/advect-eqn/src/AdvectionEquation.cpp
@@ -7,29 +7,6 @@ using namespace godzilla;
 
 REGISTER_OBJECT(AdvectionEquation);
 
-///
-
-namespace {
-
-void
-compute_flux(Int dim,
-             Int nf,
-             const Real x[],
-             const Real n[],
-             const Scalar uL[],
-             const Scalar uR[],
-             Int n_consts,
-             const Scalar constants[],
-             Scalar flux[],
-             void * ctx)
-{
-    _F_;
-    auto * ae = static_cast<AdvectionEquation *>(ctx);
-    ae->compute_flux(dim, nf, x, n, uL, uR, n_consts, constants, flux);
-}
-
-} // namespace
-
 Parameters
 AdvectionEquation::parameters()
 {
@@ -58,17 +35,7 @@ AdvectionEquation::set_up_fields()
     add_field(0, "u", 1);
 }
 
-void
-AdvectionEquation::set_up_ds()
-{
-    _F_;
-    ExplicitFVLinearProblem::set_up_ds();
-    auto ds = get_ds();
-    PETSC_CHECK(PetscDSSetRiemannSolver(ds, 0, ::compute_flux));
-    PETSC_CHECK(PetscDSSetContext(ds, 0, this));
-}
-
-void
+PetscErrorCode
 AdvectionEquation::compute_flux(PetscInt dim,
                                 PetscInt nf,
                                 const PetscReal x[],
@@ -90,4 +57,5 @@ AdvectionEquation::compute_flux(PetscInt dim,
     PetscReal wn = 0;
     wn += wind[0] * n[0];
     flux[0] = (wn > 0 ? uL[0] : uR[0]) * wn;
+    return 0;
 }

--- a/include/godzilla/FVProblemInterface.h
+++ b/include/godzilla/FVProblemInterface.h
@@ -61,6 +61,16 @@ public:
     /// @param k The degree k of the space
     virtual void set_aux_fe(Int id, const std::string & name, Int nc, Int k);
 
+    virtual PetscErrorCode compute_flux(PetscInt dim,
+                                        PetscInt nf,
+                                        const PetscReal x[],
+                                        const PetscReal n[],
+                                        const PetscScalar uL[],
+                                        const PetscScalar uR[],
+                                        PetscInt n_consts,
+                                        const PetscScalar constants[],
+                                        PetscScalar flux[]);
+
 protected:
     void init() override;
     void create() override;

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -11,6 +11,27 @@
 
 namespace godzilla {
 
+namespace {
+
+void
+compute_flux(Int dim,
+             Int nf,
+             const Real x[],
+             const Real n[],
+             const Scalar uL[],
+             const Scalar uR[],
+             Int n_consts,
+             const Scalar constants[],
+             Scalar flux[],
+             void * ctx)
+{
+    _F_;
+    auto * fvpi = static_cast<FVProblemInterface *>(ctx);
+    fvpi->compute_flux(dim, nf, x, n, uL, uR, n_consts, constants, flux);
+}
+
+} // namespace
+
 const std::string FVProblemInterface::empty_name;
 
 FVProblemInterface::FVProblemInterface(Problem * problem, const Parameters & params) :
@@ -373,6 +394,10 @@ FVProblemInterface::set_up_ds()
     auto dm = get_unstr_mesh()->get_dm();
     PETSC_CHECK(DMAddField(dm, nullptr, (PetscObject) this->fvm));
     create_ds();
+
+    auto ds = get_ds();
+    PETSC_CHECK(PetscDSSetRiemannSolver(ds, 0, godzilla::compute_flux));
+    PETSC_CHECK(PetscDSSetContext(ds, 0, this));
 }
 
 void
@@ -420,6 +445,21 @@ FVProblemInterface::get_next_id(const std::vector<Int> & ids) const
         if (s.find(id) == s.end())
             return id;
     return -1;
+}
+
+PetscErrorCode
+FVProblemInterface::compute_flux(PetscInt dim,
+                                 PetscInt nf,
+                                 const PetscReal x[],
+                                 const PetscReal n[],
+                                 const PetscScalar uL[],
+                                 const PetscScalar uR[],
+                                 PetscInt n_consts,
+                                 const PetscScalar constants[],
+                                 PetscScalar flux[])
+{
+    _F_;
+    return 0;
 }
 
 } // namespace godzilla


### PR DESCRIPTION
FVProblemInterface defines a virtual method compute_flux which is
used by the inherited problem classes.
