### PR TITLE
Improving code coverage

### DIFF
--- a/include/godzilla/ExplicitProblemInterface.h
+++ b/include/godzilla/ExplicitProblemInterface.h
@@ -14,6 +14,8 @@ public:
     explicit ExplicitProblemInterface(NonlinearProblem * problem, const Parameters & params);
     ~ExplicitProblemInterface();
 
+    const std::string & get_scheme() const;
+
     const Matrix & get_mass_matrix() const;
 
     Matrix & get_mass_matrix();
@@ -23,7 +25,6 @@ public:
     virtual PetscErrorCode compute_rhs(Real time, const Vector & x, Vector & F);
 
 protected:
-    const std::string & get_scheme() const;
     void check();
     void set_up_callbacks();
     void set_up_time_scheme();

--- a/include/godzilla/ExplicitProblemInterface.h
+++ b/include/godzilla/ExplicitProblemInterface.h
@@ -14,8 +14,6 @@ public:
     explicit ExplicitProblemInterface(NonlinearProblem * problem, const Parameters & params);
     ~ExplicitProblemInterface();
 
-    const std::string & get_scheme() const;
-
     const Matrix & get_mass_matrix() const;
 
     Matrix & get_mass_matrix();
@@ -38,8 +36,6 @@ protected:
 private:
     /// Nonlinear problem
     NonlinearProblem * nl_problem;
-    /// Time stepping scheme
-    const std::string & scheme;
     /// Mass matrix
     Matrix M;
     /// Inverse of the lumped mass matrix

--- a/include/godzilla/FVProblemInterface.h
+++ b/include/godzilla/FVProblemInterface.h
@@ -61,6 +61,18 @@ public:
     /// @param k The degree k of the space
     virtual void set_aux_fe(Int id, const std::string & name, Int nc, Int k);
 
+    /// Method to compute flux across an edge
+    ///
+    /// @param dim[in] Spatial dimension
+    /// @param nf[in] Number of fields
+    /// @param x[in] Edge centroid
+    /// @param n[in] Normal
+    /// @param uL[in] Solution on the "left" side
+    /// @param uR[in] Solution on the "right" side
+    /// @param n_consts[in] Number of constants
+    /// @param constants[in] Constants
+    /// @param flux[out] Computed flux
+    /// @return PETSc error code, zero means success
     virtual PetscErrorCode compute_flux(PetscInt dim,
                                         PetscInt nf,
                                         const PetscReal x[],
@@ -69,7 +81,7 @@ public:
                                         const PetscScalar uR[],
                                         PetscInt n_consts,
                                         const PetscScalar constants[],
-                                        PetscScalar flux[]);
+                                        PetscScalar flux[]) = 0;
 
 protected:
     void init() override;

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -49,6 +49,9 @@ public:
     /// @return PETSc TS object
     TS get_ts() const;
 
+    /// Get the name of time stepping scheme
+    const std::string & get_scheme() const;
+
     Vector get_solution() const;
 
     /// Get the current timestep size
@@ -122,6 +125,8 @@ protected:
 private:
     /// PETSc TS object
     TS ts;
+    /// Time stepping scheme
+    const std::string & scheme;
     /// Problem this interface is part of
     Problem * problem;
     /// Parameters

--- a/src/ExplicitProblemInterface.cpp
+++ b/src/ExplicitProblemInterface.cpp
@@ -31,8 +31,7 @@ ExplicitProblemInterface::parameters()
 ExplicitProblemInterface::ExplicitProblemInterface(NonlinearProblem * problem,
                                                    const Parameters & params) :
     TransientProblemInterface(problem, params),
-    nl_problem(problem),
-    scheme(params.get<std::string>("scheme"))
+    nl_problem(problem)
 {
 }
 
@@ -63,20 +62,13 @@ ExplicitProblemInterface::get_lumped_mass_matrix() const
     return this->M_lumped_inv;
 }
 
-const std::string &
-ExplicitProblemInterface::get_scheme() const
-{
-    _F_;
-    return this->scheme;
-}
-
 void
 ExplicitProblemInterface::check()
 {
     _F_;
     TransientProblemInterface::check();
     auto prob = this->nl_problem;
-    if (!validation::in(this->scheme, { "euler", "ssp-rk-2", "ssp-rk-3", "rk-2", "heun" }))
+    if (!validation::in(get_scheme(), { "euler", "ssp-rk-2", "ssp-rk-3", "rk-2", "heun" }))
         prob->log_error("The 'scheme' parameter can be either 'euler', 'ssp-rk-2', 'ssp-rk-3', "
                         "'rk-2' or 'heun'.");
 }
@@ -93,7 +85,7 @@ void
 ExplicitProblemInterface::set_up_time_scheme()
 {
     _F_;
-    std::string name = utils::to_lower(this->scheme);
+    std::string name = utils::to_lower(get_scheme());
     std::map<std::string, TimeScheme> scheme_map = { { "euler", TimeScheme::EULER },
                                                      { "ssp-rk-2", TimeScheme::SSP_RK_2 },
                                                      { "ssp-rk-3", TimeScheme::SSP_RK_3 },

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -447,19 +447,4 @@ FVProblemInterface::get_next_id(const std::vector<Int> & ids) const
     return -1;
 }
 
-PetscErrorCode
-FVProblemInterface::compute_flux(PetscInt dim,
-                                 PetscInt nf,
-                                 const PetscReal x[],
-                                 const PetscReal n[],
-                                 const PetscScalar uL[],
-                                 const PetscScalar uR[],
-                                 PetscInt n_consts,
-                                 const PetscScalar constants[],
-                                 PetscScalar flux[])
-{
-    _F_;
-    return 0;
-}
-
 } // namespace godzilla

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -55,6 +55,7 @@ TransientProblemInterface::parameters()
 
 TransientProblemInterface::TransientProblemInterface(Problem * problem, const Parameters & params) :
     ts(nullptr),
+    scheme(params.get<std::string>("scheme")),
     problem(problem),
     tpi_params(params),
     ts_adaptor(nullptr),
@@ -108,6 +109,13 @@ TransientProblemInterface::get_ts() const
 {
     _F_;
     return this->ts;
+}
+
+const std::string &
+TransientProblemInterface::get_scheme() const
+{
+    _F_;
+    return this->scheme;
 }
 
 Vector

--- a/test/include/GTestFENonlinearProblem.h
+++ b/test/include/GTestFENonlinearProblem.h
@@ -31,6 +31,12 @@ public:
                                                          context);
     }
 
+    const std::vector<BoundaryCondition *> &
+    get_boundary_conditions() const
+    {
+        return DiscreteProblemInterface::get_boundary_conditions();
+    }
+
 protected:
     void set_up_fields() override;
     void set_up_weak_form() override;

--- a/test/include/GTestImplicitFENonlinearProblem.h
+++ b/test/include/GTestImplicitFENonlinearProblem.h
@@ -10,6 +10,12 @@ public:
     explicit GTestImplicitFENonlinearProblem(const Parameters & params);
     void set_up_initial_guess() override;
 
+    void
+    set_scheme(const char * scheme)
+    {
+        ImplicitFENonlinearProblem::set_scheme(scheme);
+    }
+
 protected:
     void set_up_fields() override;
     void set_up_weak_form() override;

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -40,6 +40,18 @@ public:
         ExplicitFELinearProblem::set_up_time_scheme();
     }
 
+    void
+    allocate_mass_matrix()
+    {
+        ExplicitProblemInterface::allocate_mass_matrix();
+    }
+
+    void
+    allocate_lumped_mass_matrix()
+    {
+        ExplicitProblemInterface::allocate_lumped_mass_matrix();
+    }
+
 protected:
     void
     set_up_fields() override
@@ -350,4 +362,58 @@ TEST(ExplicitFELinearProblemTest, wrong_scheme)
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr("The 'scheme' parameter can be either 'euler', 'ssp-rk-2', "
                                    "'ssp-rk-3', 'rk-2' or 'heun'."));
+}
+
+TEST(ExplicitFELinearProblemTest, allocate_mass_matrix)
+{
+    TestApp app;
+
+    Parameters mesh_pars = LineMesh::parameters();
+    mesh_pars.set<App *>("_app") = &app;
+    mesh_pars.set<Int>("nx") = 3;
+    LineMesh mesh(mesh_pars);
+
+    Parameters prob_pars = TestExplicitFELinearProblem::parameters();
+    prob_pars.set<App *>("_app") = &app;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Real>("start_time") = 0.;
+    prob_pars.set<Real>("end_time") = 1e-3;
+    prob_pars.set<Real>("dt") = 1e-3;
+    prob_pars.set<std::string>("scheme") = "euler";
+    TestExplicitFELinearProblem prob(prob_pars);
+    app.set_problem(&prob);
+
+    mesh.create();
+    prob.create();
+
+    prob.allocate_mass_matrix();
+    auto M = prob.get_mass_matrix();
+    EXPECT_NE(M, nullptr);
+}
+
+TEST(ExplicitFELinearProblemTest, allocate_lumped_mass_matrix)
+{
+    TestApp app;
+
+    Parameters mesh_pars = LineMesh::parameters();
+    mesh_pars.set<App *>("_app") = &app;
+    mesh_pars.set<Int>("nx") = 3;
+    LineMesh mesh(mesh_pars);
+
+    Parameters prob_pars = TestExplicitFELinearProblem::parameters();
+    prob_pars.set<App *>("_app") = &app;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Real>("start_time") = 0.;
+    prob_pars.set<Real>("end_time") = 1e-3;
+    prob_pars.set<Real>("dt") = 1e-3;
+    prob_pars.set<std::string>("scheme") = "euler";
+    TestExplicitFELinearProblem prob(prob_pars);
+    app.set_problem(&prob);
+
+    mesh.create();
+    prob.create();
+
+    prob.allocate_lumped_mass_matrix();
+    auto M = prob.get_lumped_mass_matrix();
+    EXPECT_NE(M, nullptr);
 }

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -311,6 +311,7 @@ TEST(ExplicitFELinearProblemTest, set_schemes)
         prob.set_up_time_scheme();
         TSGetType(ts, &type);
         EXPECT_STREQ(type, types[i]);
+        EXPECT_EQ(prob.get_scheme(), schemes[i]);
     }
 }
 

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -103,17 +103,33 @@ TEST(ExplicitFELinearProblemTest, test_mass_matrix)
     mesh.create();
     prob.create();
 
-    auto M = prob.get_mass_matrix();
-    EXPECT_NEAR(M(0, 0), 0.1111111111111111, 1e-9);
-    EXPECT_NEAR(M(0, 1), 0.0555555555555555, 1e-9);
-    EXPECT_NEAR(M(1, 0), 0.0555555555555555, 1e-9);
-    EXPECT_NEAR(M(1, 1), 0.2222222222222222, 1e-9);
-    EXPECT_NEAR(M(1, 2), 0.0555555555555555, 1e-9);
-    EXPECT_NEAR(M(2, 1), 0.0555555555555555, 1e-9);
-    EXPECT_NEAR(M(2, 2), 0.2222222222222222, 1e-9);
-    EXPECT_NEAR(M(2, 3), 0.0555555555555555, 1e-9);
-    EXPECT_NEAR(M(3, 2), 0.0555555555555555, 1e-9);
-    EXPECT_NEAR(M(3, 3), 0.1111111111111111, 1e-9);
+    {
+        auto M = prob.get_mass_matrix();
+        EXPECT_NEAR(M(0, 0), 0.1111111111111111, 1e-9);
+        EXPECT_NEAR(M(0, 1), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(1, 0), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(1, 1), 0.2222222222222222, 1e-9);
+        EXPECT_NEAR(M(1, 2), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(2, 1), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(2, 2), 0.2222222222222222, 1e-9);
+        EXPECT_NEAR(M(2, 3), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(3, 2), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(3, 3), 0.1111111111111111, 1e-9);
+    }
+    {
+        const TestExplicitFELinearProblem * cprob = &prob;
+        auto M = cprob->get_mass_matrix();
+        EXPECT_NEAR(M(0, 0), 0.1111111111111111, 1e-9);
+        EXPECT_NEAR(M(0, 1), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(1, 0), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(1, 1), 0.2222222222222222, 1e-9);
+        EXPECT_NEAR(M(1, 2), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(2, 1), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(2, 2), 0.2222222222222222, 1e-9);
+        EXPECT_NEAR(M(2, 3), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(3, 2), 0.0555555555555555, 1e-9);
+        EXPECT_NEAR(M(3, 3), 0.1111111111111111, 1e-9);
+    }
 }
 
 TEST(ExplicitFELinearProblemTest, test_lumped_mass_matrix)

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -206,6 +206,10 @@ TEST_F(FENonlinearProblemTest, solve)
     mesh->create();
     prob->create();
 
+    auto bcs = prob->get_boundary_conditions();
+    EXPECT_EQ(bcs.size(), 1);
+    EXPECT_EQ(bcs[0]->get_type(), "DirichletBC");
+
     prob->solve();
 
     bool conv = prob->converged();

--- a/test/src/GYMLFile_test.cpp
+++ b/test/src/GYMLFile_test.cpp
@@ -61,6 +61,7 @@ GTestProblem::parameters()
 {
     Parameters params = Problem::parameters();
     params += TransientProblemInterface::parameters();
+    params.add_param<std::string>("scheme", "", "time stepping scheme");
     params.add_param<std::string>("str", "empty", "str doco");
     params.add_param<double>("d", 1.234, "d doco");
     params.add_param<int>("i", -1234, "i doco");

--- a/test/src/GodzillaApp_test.cpp
+++ b/test/src/GodzillaApp_test.cpp
@@ -97,6 +97,23 @@ TEST_F(GodzillaAppTest, check_integrity)
     EXPECT_DEATH(app.run(), "error1");
 }
 
+TEST_F(GodzillaAppTest, command_line_opt)
+{
+    class TestApp : public App {
+    public:
+        TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "test_godzilla_app") {}
+
+        cxxopts::Options &
+        get_command_line_opts()
+        {
+            return App::get_command_line_opts();
+        }
+    } app;
+
+    auto cmd_ln_opts = app.get_command_line_opts();
+    EXPECT_THAT(cmd_ln_opts.help(), testing::HasSubstr("test_godzilla_app"));
+}
+
 TEST_F(GodzillaAppTest, unknown_command_line_switch)
 {
     int argc = 2;

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -136,7 +136,7 @@ TEST_F(ImplicitFENonlinearProblemTest, no_time_stepping_params)
         testing::HasSubstr("prob: You must provide either 'end_time' or 'num_steps' parameter."));
 }
 
-TEST_F(ImplicitFENonlinearProblemTest, set_scheme_str)
+TEST_F(ImplicitFENonlinearProblemTest, set_schemes)
 {
     auto mesh = gMesh1d();
     auto prob = gProblem1d(mesh);
@@ -164,11 +164,15 @@ TEST_F(ImplicitFENonlinearProblemTest, set_scheme_str)
     mesh->create();
     prob->create();
 
-    prob->set_scheme(TSCN);
-    auto ts = prob->get_ts();
+    TS ts = prob->get_ts();
     TSType type;
-    TSGetType(ts, &type);
-    EXPECT_STREQ(type, TSCN);
+    std::vector<std::string> schemes = { "beuler", "cn", };
+    std::vector<TSType> types = { TSBEULER, TSCN };
+    for (std::size_t i = 0; i < schemes.size(); i++) {
+        prob->set_scheme(types[i]);
+        TSGetType(ts, &type);
+        EXPECT_STREQ(type, types[i]);
+    }
 }
 
 TEST_F(ImplicitFENonlinearProblemTest, converged_reason)

--- a/test/src/LinearProblem_test.cpp
+++ b/test/src/LinearProblem_test.cpp
@@ -26,15 +26,30 @@ TEST_F(LinearProblemTest, solve)
     bool conv = prob->converged();
     EXPECT_EQ(conv, true);
 
-    // extract the solution and make sure it is [2, 3]
-    auto x = prob->get_solution_vector();
-    Int ni = 2;
-    Int ix[2] = { 0, 1 };
-    Scalar xx[2];
-    VecGetValues(x, ni, ix, xx);
+    {
+        // extract the solution and make sure it is [2, 3]
+        auto x = prob->get_solution_vector();
+        Int ni = 2;
+        Int ix[2] = { 0, 1 };
+        Scalar xx[2];
+        VecGetValues(x, ni, ix, xx);
 
-    EXPECT_DOUBLE_EQ(xx[0], 2.);
-    EXPECT_DOUBLE_EQ(xx[1], 3.);
+        EXPECT_DOUBLE_EQ(xx[0], 2.);
+        EXPECT_DOUBLE_EQ(xx[1], 3.);
+    }
+
+    // Const-version
+    {
+        const Problem * cprob = prob;
+        const Vector & x = cprob->get_solution_vector();
+        Int ni = 2;
+        Int ix[2] = { 0, 1 };
+        Scalar xx[2];
+        VecGetValues(x, ni, ix, xx);
+
+        EXPECT_DOUBLE_EQ(xx[0], 2.);
+        EXPECT_DOUBLE_EQ(xx[1], 3.);
+    }
 }
 
 TEST_F(LinearProblemTest, run)

--- a/test/src/NaturalRiemannBC_test.cpp
+++ b/test/src/NaturalRiemannBC_test.cpp
@@ -48,6 +48,20 @@ protected:
     {
         add_field(0, "u", 1);
     }
+
+    PetscErrorCode
+    compute_flux(PetscInt dim,
+                 PetscInt nf,
+                 const PetscReal x[],
+                 const PetscReal n[],
+                 const PetscScalar uL[],
+                 const PetscScalar uR[],
+                 PetscInt n_consts,
+                 const PetscScalar constants[],
+                 PetscScalar flux[]) override
+    {
+        return 0;
+    }
 };
 
 } // namespace

--- a/test/src/NonlinearProblem_test.cpp
+++ b/test/src/NonlinearProblem_test.cpp
@@ -147,6 +147,12 @@ TEST(NonlinearProblemTest, solve)
 
     EXPECT_DOUBLE_EQ(xx[0], 2.);
     EXPECT_DOUBLE_EQ(xx[1], 3.);
+
+    auto J = prob.get_jacobian();
+    EXPECT_EQ(J(0, 0), 1.);
+    EXPECT_EQ(J(0, 1), 0.);
+    EXPECT_EQ(J(1, 0), 0.);
+    EXPECT_EQ(J(1, 1), 1.);
 }
 
 TEST(NonlinearProblemTest, compute_callbacks)


### PR DESCRIPTION
- Adding test for Problem::get_solution_vector() const
- Adding a test for NonlinearProblem::get_jacobian()
- FVProblemInterface::compute_flux is pure abstract
- Adding a test for DiscreteProblemInterface::get_boundary_conditions()
- Adding a test for ExplicitProblemInterface::get_mass_matrix() const
- Adding a test for ExplicitProblemInterface::get_scheme() const
- Adding tests for ExplicitProblemInterface::allocate_{lumped_}mass_matrix
- Adding a test for App::get_command_line_opts()
- Moving get_scheme() into TransientProblemInterface
- Adding a test for TransientProblemInterface::{get|set}_converged_reason
- Test more schemes in ImplicitFENonlinearProblemTest.set_schemes
