### PR TITLE
GODZILLA_UNIT_TESTS_ROOT is no longer in GodzillaConfig.h

### DIFF
--- a/include/GodzillaConfig.h.in
+++ b/include/GodzillaConfig.h.in
@@ -6,8 +6,6 @@
 
 #cmakedefine GODZILLA_WITH_PERF_LOG
 
-#define GODZILLA_UNIT_TESTS_ROOT "@GODZILLA_UNIT_TESTS_ROOT@"
-
 #define GODZILLA_UNUSED_STRINGIFY(param_string_literal) #param_string_literal
 #define GODZILLA_UNUSED_VAR(param) _Pragma(GODZILLA_UNUSED_STRINGIFY(unused(#param)))
 #define GODZILLA_UNUSED(x) (void)(x)

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -93,6 +93,11 @@ add_executable(${PROJECT_NAME}
 target_code_coverage(${PROJECT_NAME})
 target_sanitization(${PROJECT_NAME})
 
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+        -DGODZILLA_UNIT_TESTS_ROOT="${GODZILLA_UNIT_TESTS_ROOT}"
+)
+
 target_include_directories(
     ${PROJECT_NAME}
     PUBLIC


### PR DESCRIPTION
This variable is only relevant to the unit test binary, thus it is passed
into the build process via compiler definition flag.
