### PR TITLE
Refactoring API in App class

### DIFF
--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -62,6 +62,11 @@ public:
     /// @param result Result from calling `parse_command_line` or `cxxopt::parse`
     virtual void process_command_line(const cxxopts::ParseResult & result);
 
+    /// Check integrity of the application
+    ///
+    /// @return `true` if the check passed, `false` otherwise
+    bool check_integrity();
+
     /// Run the application
     virtual void run();
 
@@ -132,9 +137,6 @@ protected:
     ///
     /// @param file_name The input file name
     void build_from_yml(const std::string & file_name);
-
-    /// Check integrity of the application
-    void check_integrity();
 
     /// Run the input file
     ///

--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -83,7 +83,7 @@ public:
     /// Get MPI communicator
     ///
     /// @return MPI communicator
-    virtual const mpi::Communicator & get_comm() const;
+    const mpi::Communicator & get_comm() const;
 
     /// Get parameters for a class
     ///

--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -78,7 +78,7 @@ public:
     /// Get the input file name
     ///
     /// @return The input file name
-    virtual const std::string & get_input_file_name() const;
+    const std::string & get_input_file_name() const;
 
     /// Get MPI communicator
     ///

--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -70,6 +70,11 @@ public:
     /// @return The verbosity level
     const unsigned int & get_verbosity_level() const;
 
+    /// Set verbosity level
+    ///
+    /// @param level Verbosity level
+    void set_verbosity_level(unsigned int level);
+
     /// Get the input file name
     ///
     /// @return The input file name

--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -68,7 +68,7 @@ public:
     /// Get level of verbosity
     ///
     /// @return The verbosity level
-    virtual const unsigned int & get_verbosity_level() const;
+    const unsigned int & get_verbosity_level() const;
 
     /// Get the input file name
     ///

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -211,8 +211,10 @@ App::run_input_file(const std::string & input_file_name)
         build_from_yml(input_file_name);
         if (this->logger->get_num_errors() == 0)
             this->yml->create_objects();
-        check_integrity();
-        run_problem();
+        if (check_integrity())
+            run_problem();
+        else
+            godzilla::internal::terminate();
     }
     else
         error("Unable to open '{}' for reading. Make sure it exists and you have read permissions.",
@@ -229,16 +231,19 @@ App::build_from_yml(const std::string & file_name)
     }
 }
 
-void
+bool
 App::check_integrity()
 {
     _F_;
     lprint(9, "Checking integrity");
-    this->yml->check();
+    if (this->yml)
+        this->yml->check();
     if (this->logger->get_num_entries() > 0) {
         this->logger->print();
-        godzilla::internal::terminate();
+        return false;
     }
+    else
+        return true;
 }
 
 void

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -129,8 +129,11 @@ const std::string &
 App::get_input_file_name() const
 {
     _F_;
-    assert(this->yml != nullptr);
-    return this->yml->get_file_name();
+    static std::string empty_file_name;
+    if (this->yml != nullptr)
+        return this->yml->get_file_name();
+    else
+        return empty_file_name;
 }
 
 const mpi::Communicator &

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -118,6 +118,13 @@ App::get_verbosity_level() const
     return this->verbosity_level;
 }
 
+void
+App::set_verbosity_level(unsigned int level)
+{
+    _F_;
+    this->verbosity_level = level;
+}
+
 const std::string &
 App::get_input_file_name() const
 {
@@ -166,7 +173,7 @@ App::process_command_line(const cxxopts::ParseResult & result)
             Terminal::num_colors = 1;
 
         if (result.count("verbose"))
-            this->verbosity_level = result["verbose"].as<unsigned int>();
+            set_verbosity_level(result["verbose"].as<unsigned int>());
 
         if (result.count("input-file")) {
             auto input_file_name = result["input-file"].as<std::string>();

--- a/src/FileMesh.cpp
+++ b/src/FileMesh.cpp
@@ -21,8 +21,11 @@ FileMesh::FileMesh(const Parameters & parameters) : UnstructuredMesh(parameters)
 {
     _F_;
 
-    this->file_name =
-        fs::path(get_app()->get_input_file_name()).parent_path() / get_param<std::string>("file");
+    std::filesystem::path file(get_param<std::string>("file"));
+    if (file.is_absolute())
+        this->file_name = file;
+    else
+        this->file_name = fs::path(get_app()->get_input_file_name()).parent_path() / file;
 
     if (!utils::path_exists(this->file_name))
         log_error(

--- a/test/include/TestApp.h
+++ b/test/include/TestApp.h
@@ -7,11 +7,4 @@ using namespace godzilla;
 class TestApp : public App {
 public:
     TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla") {}
-
-    void
-    check_integrity()
-    {
-        if (get_logger()->get_num_entries() > 0)
-            get_logger()->print();
-    }
 };

--- a/test/include/TestApp.h
+++ b/test/include/TestApp.h
@@ -8,18 +8,10 @@ class TestApp : public App {
 public:
     TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla") {}
 
-    const std::string &
-    get_input_file_name() const
-    {
-        return this->input_file_name;
-    }
-
     void
     check_integrity()
     {
         if (get_logger()->get_num_entries() > 0)
             get_logger()->print();
     }
-
-    std::string input_file_name;
 };

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -274,13 +274,6 @@ TEST(TwoFieldFENonlinearProblemTest, err_duplicate_ics)
     class TestApp : public App {
     public:
         TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla") {}
-
-        void
-        check_integrity()
-        {
-            if (get_logger()->get_num_entries() > 0)
-                get_logger()->print();
-        }
     } app;
 
     Mesh * mesh;
@@ -330,13 +323,6 @@ TEST(TwoFieldFENonlinearProblemTest, err_not_enough_ics)
     class TestApp : public App {
     public:
         TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla") {}
-
-        void
-        check_integrity()
-        {
-            if (get_logger()->get_num_entries() > 0)
-                get_logger()->print();
-        }
     } app;
 
     UnstructuredMesh * mesh;

--- a/test/src/GodzillaApp_test.cpp
+++ b/test/src/GodzillaApp_test.cpp
@@ -80,20 +80,15 @@ TEST_F(GodzillaAppTest, verbose)
 
 TEST_F(GodzillaAppTest, check_integrity)
 {
-    class TestApp : public App {
-    public:
-        TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla") {}
+    testing::internal::CaptureStderr();
+    TestApp app;
+    app.get_logger()->error("error1");
 
-        void
-        run()
-        {
-            set_input_file(new GYMLFile(this));
-            get_logger()->error("error1");
-            check_integrity();
-        }
-    } app;
+    EXPECT_FALSE(app.check_integrity());
 
-    EXPECT_DEATH(app.run(), "error1");
+    auto out = testing::internal::GetCapturedStderr();
+    EXPECT_THAT(out, testing::HasSubstr("[ERROR] error1"));
+    EXPECT_THAT(out, testing::HasSubstr("1 error(s) found"));
 }
 
 TEST_F(GodzillaAppTest, command_line_opt)

--- a/tools/mesh-part/main.cpp
+++ b/tools/mesh-part/main.cpp
@@ -17,25 +17,14 @@ public:
 
 protected:
     void create_command_line_options() override;
-    const std::string & get_input_file_name() const override;
     UnstructuredMesh * load_mesh(const std::string & file_name);
     void partition_mesh_file(const std::string & mesh_file_name);
     void save_partition(UnstructuredMesh * mesh, const std::string & file_name);
-
-private:
-    std::string input_file_name;
 };
 
 MeshPartApp::MeshPartApp(int argc, const char * const * argv) :
-    App(mpi::Communicator(PETSC_COMM_WORLD), "mesh-part", argc, argv),
-    input_file_name(".")
+    App(mpi::Communicator(PETSC_COMM_WORLD), "mesh-part", argc, argv)
 {
-}
-
-const std::string &
-MeshPartApp::get_input_file_name() const
-{
-    return this->input_file_name;
 }
 
 void


### PR DESCRIPTION
- App::get_verbosity_level is not virtual any more
- Adding App::set_verbosity_level
- App::get_comm is not virtual any more
- FileMesh: Don't prepend input file path when file is specified using absolute path.
- App::get_input_file_name() is no longer virtual
- App::check_integrity() is public and returns the result of the check
