### PR TITLE
Refactoring mesh object creation

### DIFF
--- a/include/godzilla/BoxMesh.h
+++ b/include/godzilla/BoxMesh.h
@@ -43,9 +43,6 @@ public:
     /// Get the number of mesh points in z direction
     Int get_nz() const;
 
-protected:
-    DM create_dm() override;
-
 private:
     /// Minimum in the x direction
     const Real & xmin;

--- a/include/godzilla/ExodusIIMesh.h
+++ b/include/godzilla/ExodusIIMesh.h
@@ -13,11 +13,6 @@ class ExodusIIMesh : public FileMesh {
 public:
     explicit ExodusIIMesh(const Parameters & parameters);
 
-    void create() override;
-
-protected:
-    DM create_dm() override;
-
 public:
     static Parameters parameters();
 };

--- a/include/godzilla/FileMesh.h
+++ b/include/godzilla/FileMesh.h
@@ -10,15 +10,28 @@ namespace godzilla {
 /// Mesh loaded from a file
 ///
 class FileMesh : public UnstructuredMesh {
+protected:
+    enum FileFormat { UNKNOWN, EXODUSII, GMSH } file_format;
+
 public:
     explicit FileMesh(const Parameters & parameters);
+
+    void create() override;
+    void check() override;
 
     /// Return file name
     ///
     /// @return Name of the file
     [[nodiscard]] const std::string & get_file_name() const;
 
+protected:
+    void set_file_format(FileFormat fmt);
+
 private:
+    void detect_file_format();
+    void create_from_exodus();
+    void create_from_gmsh();
+
     /// File name with the mesh
     std::string file_name;
 

--- a/include/godzilla/GmshMesh.h
+++ b/include/godzilla/GmshMesh.h
@@ -13,9 +13,6 @@ class GmshMesh : public FileMesh {
 public:
     explicit GmshMesh(const Parameters & parameters);
 
-protected:
-    DM create_dm() override;
-
 public:
     static Parameters parameters();
 };

--- a/include/godzilla/LineMesh.h
+++ b/include/godzilla/LineMesh.h
@@ -30,9 +30,6 @@ public:
     /// @return Number of divisions in the x-direction
     [[nodiscard]] Int get_nx() const;
 
-protected:
-    DM create_dm() override;
-
 private:
     /// Minimum in the x direction
     const Real & xmin;

--- a/include/godzilla/RectangleMesh.h
+++ b/include/godzilla/RectangleMesh.h
@@ -25,9 +25,6 @@ public:
     /// Get the number of mesh points in y direction
     [[nodiscard]] Int get_ny() const;
 
-protected:
-    DM create_dm() override;
-
 private:
     /// Minimum in the x direction
     const Real & xmin;

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -157,12 +157,12 @@ public:
     ///
     /// NOTES:
     /// - only process 0 takes in the input
-    DM build_from_cell_list(Int dim,
-                            Int n_corners,
-                            const std::vector<Int> & cells,
-                            Int space_dim,
-                            const std::vector<Real> & vertices,
-                            bool interpolate);
+    void build_from_cell_list(Int dim,
+                              Int n_corners,
+                              const std::vector<Int> & cells,
+                              Int space_dim,
+                              const std::vector<Real> & vertices,
+                              bool interpolate);
 
     /// Get the `Label` recording the depth of each point
     ///
@@ -348,8 +348,7 @@ public:
     const std::map<Int, std::vector<Int>> & common_cells_by_vertex();
 
 protected:
-    /// Method that builds DM for the mesh
-    virtual DM create_dm() = 0;
+    void lprint_mesh_info();
 
     void create_cell_set(Int id, const std::string & name);
 

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -118,26 +118,6 @@ void
 BoxMesh::create()
 {
     _F_;
-    UnstructuredMesh::create();
-
-    remove_label("marker");
-    // create user-friendly names for sides
-    std::map<Int, std::string> face_set_names;
-    face_set_names[1] = "back";
-    face_set_names[2] = "front";
-    face_set_names[3] = "bottom";
-    face_set_names[4] = "top";
-    face_set_names[5] = "right";
-    face_set_names[6] = "left";
-    create_face_set_labels(face_set_names);
-    for (auto it : face_set_names)
-        set_face_set_name(it.first, it.second);
-}
-
-DM
-BoxMesh::create_dm()
-{
-    _F_;
     std::array<Real, 3> lower = { this->xmin, this->ymin, this->zmin };
     std::array<Real, 3> upper = { this->xmax, this->ymax, this->zmax };
     std::array<Int, 3> faces = { this->nx, this->ny, this->nz };
@@ -157,7 +137,23 @@ BoxMesh::create_dm()
                                     periodicity.data(),
                                     this->interpolate,
                                     &dm));
-    return dm;
+    set_dm(dm);
+
+    remove_label("marker");
+    // create user-friendly names for sides
+    std::map<Int, std::string> face_set_names;
+    face_set_names[1] = "back";
+    face_set_names[2] = "front";
+    face_set_names[3] = "bottom";
+    face_set_names[4] = "top";
+    face_set_names[5] = "right";
+    face_set_names[6] = "left";
+    create_face_set_labels(face_set_names);
+    for (auto it : face_set_names)
+        set_face_set_name(it.first, it.second);
+
+    set_up();
+    lprint_mesh_info();
 }
 
 } // namespace godzilla

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -5,7 +5,6 @@
 #include "godzilla/ExodusIIMesh.h"
 #include "godzilla/App.h"
 #include "godzilla/CallStack.h"
-#include "exodusIIcpp/exodusIIcpp.h"
 
 namespace godzilla {
 
@@ -21,46 +20,7 @@ ExodusIIMesh::parameters()
 ExodusIIMesh::ExodusIIMesh(const Parameters & parameters) : FileMesh(parameters)
 {
     _F_;
-}
-
-void
-ExodusIIMesh::create()
-{
-    _F_;
-    UnstructuredMesh::create();
-
-    // Ideally we would like to use DMPlexCreateExodus here and get rid of the above
-    // DMPlexCreateExodusFromFile, so that we don't open the same file twice. For some reason,
-    // that just doesn't work even though this is just exactly what DMPlexCreateExodusFromFile
-    // is doing :confused:
-    exodusIIcpp::File f(get_file_name(), exodusIIcpp::FileAccess::READ);
-    if (f.is_opened()) {
-        auto blk_names = f.read_block_names();
-        for (auto & it : blk_names) {
-            auto name = it.second;
-            if (name.empty()) {
-                name = std::to_string(it.first);
-                create_cell_set(it.first, name);
-            }
-            else
-                create_cell_set(it.first, it.second);
-        }
-
-        for (auto it : f.read_side_set_names())
-            set_face_set_name(it.first, it.second);
-
-        f.close();
-    }
-}
-
-DM
-ExodusIIMesh::create_dm()
-{
-    _F_;
-    TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", get_file_name());
-    DM dm;
-    PETSC_CHECK(DMPlexCreateExodusFromFile(get_comm(), get_file_name().c_str(), PETSC_TRUE, &dm));
-    return dm;
+    set_file_format(EXODUSII);
 }
 
 } // namespace godzilla

--- a/src/FileMesh.cpp
+++ b/src/FileMesh.cpp
@@ -6,6 +6,7 @@
 #include "godzilla/FileMesh.h"
 #include "godzilla/CallStack.h"
 #include "godzilla/Utils.h"
+#include "exodusIIcpp/exodusIIcpp.h"
 #include <filesystem>
 
 namespace fs = std::filesystem;
@@ -20,7 +21,9 @@ FileMesh::parameters()
     return params;
 }
 
-FileMesh::FileMesh(const Parameters & parameters) : UnstructuredMesh(parameters)
+FileMesh::FileMesh(const Parameters & parameters) :
+    UnstructuredMesh(parameters),
+    file_format(UNKNOWN)
 {
     _F_;
 
@@ -30,7 +33,9 @@ FileMesh::FileMesh(const Parameters & parameters) : UnstructuredMesh(parameters)
     else
         this->file_name = fs::path(get_app()->get_input_file_name()).parent_path() / file;
 
-    if (!utils::path_exists(this->file_name))
+    if (utils::path_exists(this->file_name))
+        detect_file_format();
+    else
         log_error(
             "Unable to open '{}' for reading. Make sure it exists and you have read permissions.",
             this->file_name);
@@ -41,6 +46,91 @@ FileMesh::get_file_name() const
 {
     _F_;
     return this->file_name;
+}
+
+void
+FileMesh::create()
+{
+    _F_;
+    switch (this->file_format) {
+    case EXODUSII:
+        create_from_exodus();
+        break;
+    case GMSH:
+        create_from_gmsh();
+        break;
+    default:
+        break;
+    }
+    set_up();
+    lprint_mesh_info();
+}
+
+void
+FileMesh::check()
+{
+    _F_;
+    if (this->file_format == UNKNOWN)
+        log_error("Unknown mesh format");
+}
+
+void
+FileMesh::create_from_exodus()
+{
+    _F_;
+    DM dm;
+    PETSC_CHECK(DMPlexCreateExodusFromFile(get_comm(), get_file_name().c_str(), PETSC_TRUE, &dm));
+    set_dm(dm);
+
+    // Ideally we would like to use DMPlexCreateExodus here and get rid of the above
+    // DMPlexCreateExodusFromFile, so that we don't open the same file twice. For some reason,
+    // that just doesn't work even though this is just exactly what DMPlexCreateExodusFromFile
+    // is doing :confused:
+    exodusIIcpp::File f(get_file_name(), exodusIIcpp::FileAccess::READ);
+    if (f.is_opened()) {
+        auto blk_names = f.read_block_names();
+        for (auto & it : blk_names) {
+            auto name = it.second;
+            if (name.empty()) {
+                name = std::to_string(it.first);
+                create_cell_set(it.first, name);
+            }
+            else
+                create_cell_set(it.first, it.second);
+        }
+
+        for (auto it : f.read_side_set_names())
+            set_face_set_name(it.first, it.second);
+
+        f.close();
+    }
+}
+
+void
+FileMesh::create_from_gmsh()
+{
+    _F_;
+    PetscOptionsSetValue(nullptr, "-dm_plex_gmsh_use_regions", nullptr);
+    DM dm;
+    PETSC_CHECK(DMPlexCreateGmshFromFile(get_comm(), get_file_name().c_str(), PETSC_TRUE, &dm));
+    set_dm(dm);
+}
+
+void
+FileMesh::set_file_format(FileFormat fmt)
+{
+    _F_;
+    this->file_format = fmt;
+}
+
+void
+FileMesh::detect_file_format()
+{
+    _F_;
+    if (utils::has_suffix(this->file_name, ".exo") || utils::has_suffix(this->file_name, ".e"))
+        this->file_format = EXODUSII;
+    else if (utils::has_suffix(this->file_name, ".gmsh"))
+        this->file_format = GMSH;
 }
 
 } // namespace godzilla

--- a/src/GmshMesh.cpp
+++ b/src/GmshMesh.cpp
@@ -19,17 +19,7 @@ GmshMesh::parameters()
 GmshMesh::GmshMesh(const Parameters & parameters) : FileMesh(parameters)
 {
     _F_;
-}
-
-DM
-GmshMesh::create_dm()
-{
-    _F_;
-    TIMED_EVENT(9, "MeshLoad", "Loading mesh '{}'", get_file_name());
-    PetscOptionsSetValue(nullptr, "-dm_plex_gmsh_use_regions", nullptr);
-    DM dm;
-    PETSC_CHECK(DMPlexCreateGmshFromFile(get_comm(), get_file_name().c_str(), PETSC_TRUE, &dm));
-    return dm;
+    set_file_format(GMSH);
 }
 
 } // namespace godzilla

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -59,22 +59,6 @@ void
 LineMesh::create()
 {
     _F_;
-    UnstructuredMesh::create();
-
-    remove_label("marker");
-    // create user-friendly names for sides
-    std::map<Int, std::string> face_set_names;
-    face_set_names[1] = "left";
-    face_set_names[2] = "right";
-    create_face_set_labels(face_set_names);
-    for (auto it : face_set_names)
-        set_face_set_name(it.first, it.second);
-}
-
-DM
-LineMesh::create_dm()
-{
-    _F_;
     std::array<Real, 1> lower = { this->xmin };
     std::array<Real, 1> upper = { this->xmax };
     std::array<Int, 1> faces = { this->nx };
@@ -90,7 +74,19 @@ LineMesh::create_dm()
                                     periodicity.data(),
                                     this->interpolate,
                                     &dm));
-    return dm;
+    set_dm(dm);
+
+    remove_label("marker");
+    // create user-friendly names for sides
+    std::map<Int, std::string> face_set_names;
+    face_set_names[1] = "left";
+    face_set_names[2] = "right";
+    create_face_set_labels(face_set_names);
+    for (auto it : face_set_names)
+        set_face_set_name(it.first, it.second);
+
+    set_up();
+    lprint_mesh_info();
 }
 
 } // namespace godzilla

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -89,24 +89,6 @@ void
 RectangleMesh::create()
 {
     _F_;
-    UnstructuredMesh::create();
-
-    remove_label("marker");
-    // create user-friendly names for sides
-    std::map<Int, std::string> face_set_names;
-    face_set_names[1] = "bottom";
-    face_set_names[2] = "right";
-    face_set_names[3] = "top";
-    face_set_names[4] = "left";
-    create_face_set_labels(face_set_names);
-    for (auto it : face_set_names)
-        set_face_set_name(it.first, it.second);
-}
-
-DM
-RectangleMesh::create_dm()
-{
-    _F_;
     std::array<Real, 2> lower = { this->xmin, this->ymin };
     std::array<Real, 2> upper = { this->xmax, this->ymax };
     std::array<Int, 2> faces = { this->nx, this->ny };
@@ -125,7 +107,21 @@ RectangleMesh::create_dm()
                                     periodicity.data(),
                                     this->interpolate,
                                     &dm));
-    return dm;
+    set_dm(dm);
+
+    remove_label("marker");
+    // create user-friendly names for sides
+    std::map<Int, std::string> face_set_names;
+    face_set_names[1] = "bottom";
+    face_set_names[2] = "right";
+    face_set_names[3] = "top";
+    face_set_names[4] = "left";
+    create_face_set_labels(face_set_names);
+    for (auto it : face_set_names)
+        set_face_set_name(it.first, it.second);
+
+    set_up();
+    lprint_mesh_info();
 }
 
 } // namespace godzilla

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -73,12 +73,12 @@ void
 UnstructuredMesh::create()
 {
     _F_;
-    DM dm = create_dm();
-    PETSC_CHECK(DMSetFromOptions(dm));
-    PETSC_CHECK(DMViewFromOptions(dm, nullptr, "-dm_view"));
-    set_dm(dm);
-    set_up();
+}
 
+void
+UnstructuredMesh::lprint_mesh_info()
+{
+    _F_;
     lprint(9, "Information:");
     lprint(9, "- vertices: {}", get_num_vertices());
     lprint(9, "- elements: {}", get_num_cells());
@@ -551,7 +551,7 @@ UnstructuredMesh::common_cells_by_vertex()
     return this->common_cells_by_vtx;
 }
 
-DM
+void
 UnstructuredMesh::build_from_cell_list(Int dim,
                                        Int n_corners,
                                        const std::vector<Int> & cells,
@@ -571,7 +571,7 @@ UnstructuredMesh::build_from_cell_list(Int dim,
                                               space_dim,
                                               vertices.data(),
                                               &dm));
-    return dm;
+    set_dm(dm);
 }
 
 } // namespace godzilla

--- a/test/src/FEBoundary1D_test.cpp
+++ b/test/src/FEBoundary1D_test.cpp
@@ -29,7 +29,12 @@ public:
     void
     create() override
     {
-        UnstructuredMesh::create();
+        const PetscInt DIM = 1;
+        const PetscInt N_ELEM_NODES = 2;
+        std::vector<Int> cells = { 0, 1, 1, 2 };
+        std::vector<Real> coords = { 0, 0.4, 1 };
+        build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
+
         // create "side sets"
         auto face_sets = create_label("Face Sets");
 
@@ -42,16 +47,8 @@ public:
         create_face_set_labels(face_set_names);
         for (auto it : face_set_names)
             set_face_set_name(it.first, it.second);
-    }
 
-    DM
-    create_dm() override
-    {
-        const PetscInt DIM = 1;
-        const PetscInt N_ELEM_NODES = 2;
-        std::vector<Int> cells = { 0, 1, 1, 2 };
-        std::vector<Real> coords = { 0, 0.4, 1 };
-        return build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
+        set_up();
     }
 
     void

--- a/test/src/FEBoundary2D_test.cpp
+++ b/test/src/FEBoundary2D_test.cpp
@@ -29,7 +29,12 @@ public:
     void
     create() override
     {
-        UnstructuredMesh::create();
+        const PetscInt DIM = 2;
+        const PetscInt N_ELEM_NODES = 3;
+        std::vector<Int> cells = { 0, 1, 2, 1, 3, 2 };
+        std::vector<Real> coords = { 0, 0, 1, 0, 0, 1, 1, 1 };
+        build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
+
         // create "side sets"
         auto face_sets = create_label("Face Sets");
 
@@ -44,16 +49,8 @@ public:
         create_face_set_labels(face_set_names);
         for (auto it : face_set_names)
             set_face_set_name(it.first, it.second);
-    }
 
-    DM
-    create_dm() override
-    {
-        const PetscInt DIM = 2;
-        const PetscInt N_ELEM_NODES = 3;
-        std::vector<Int> cells = { 0, 1, 2, 1, 3, 2 };
-        std::vector<Real> coords = { 0, 0, 1, 0, 0, 1, 1, 1 };
-        return build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
+        set_up();
     }
 
     void

--- a/test/src/FEBoundary3D_test.cpp
+++ b/test/src/FEBoundary3D_test.cpp
@@ -29,7 +29,12 @@ public:
     void
     create() override
     {
-        UnstructuredMesh::create();
+        const PetscInt DIM = 3;
+        const PetscInt N_ELEM_NODES = 4;
+        std::vector<Int> cells = { 0, 1, 2, 3 };
+        std::vector<Real> coords = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+        build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
+
         // create "side sets"
         auto face_sets = create_label("Face Sets");
 
@@ -46,16 +51,8 @@ public:
         create_face_set_labels(face_set_names);
         for (auto it : face_set_names)
             set_face_set_name(it.first, it.second);
-    }
 
-    DM
-    create_dm() override
-    {
-        const PetscInt DIM = 3;
-        const PetscInt N_ELEM_NODES = 4;
-        std::vector<Int> cells = { 0, 1, 2, 3 };
-        std::vector<Real> coords = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1 };
-        return build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
+        set_up();
     }
 
     void

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -20,8 +20,8 @@ class TestUnstructuredMesh : public UnstructuredMesh {
 public:
     explicit TestUnstructuredMesh(const Parameters & params) : UnstructuredMesh(params) {}
 
-    DM
-    create_dm() override
+    void
+    create() override
     {
         Real lower[1] = { -1 };
         Real upper[1] = { 1 };
@@ -38,7 +38,8 @@ public:
                                         periodicity,
                                         PETSC_TRUE,
                                         &dm));
-        return dm;
+        set_dm(dm);
+        set_up();
     }
 };
 
@@ -52,8 +53,8 @@ public:
     {
     }
 
-    DM
-    create_dm() override
+    void
+    create() override
     {
         Real lower[3] = { 0, 0, 0 };
         Real upper[3] = { 1, 1, 1 };
@@ -72,13 +73,8 @@ public:
                                         periodicity,
                                         PETSC_TRUE,
                                         &dm));
-        return dm;
-    }
+        set_dm(dm);
 
-    void
-    create() override
-    {
-        UnstructuredMesh::create();
         // create "side sets"
         std::map<Int, std::string> face_set_names;
         face_set_names[1] = "back";
@@ -90,6 +86,8 @@ public:
         create_face_set_labels(face_set_names);
         for (auto it : face_set_names)
             set_face_set_name(it.first, it.second);
+
+        set_up();
     }
 
     const Int & nx;
@@ -474,13 +472,13 @@ TEST(UnstructuredMesh, build_from_cell_list_2d)
         {
         }
 
-    protected:
-        DM
-        create_dm() override
+        void
+        create() override
         {
             std::vector<Int> cells = { 0, 1, 2, 1, 3, 2 };
             std::vector<Real> vertices = { 0, 0, 1, 0, 0, 1, 1, 1 };
-            return build_from_cell_list(2, 3, cells, 2, vertices, true);
+            build_from_cell_list(2, 3, cells, 2, vertices, true);
+            set_up();
         }
     };
 


### PR DESCRIPTION
All work is now done in create() method. Method `create_dm` is gone.
