### PR TITLE
cmake: using the default rpath handling

### DIFF
--- a/examples/advect-eqn/src/CMakeLists.txt
+++ b/examples/advect-eqn/src/CMakeLists.txt
@@ -26,7 +26,3 @@ target_link_libraries(
     PRIVATE
         ${PETSC_LIBRARY}
 )
-
-if (DEFINED ENV{CONDA_PREFIX})
-    set_target_properties(${PROJECT_NAME} PROPERTIES BUILD_RPATH $ENV{CONDA_PREFIX}/lib)
-endif()

--- a/examples/burgers-eqn/src/CMakeLists.txt
+++ b/examples/burgers-eqn/src/CMakeLists.txt
@@ -22,7 +22,3 @@ target_link_libraries(
     PUBLIC
         godzilla
 )
-
-if (DEFINED ENV{CONDA_PREFIX})
-    set_target_properties(${PROJECT_NAME} PROPERTIES BUILD_RPATH $ENV{CONDA_PREFIX}/lib)
-endif()

--- a/examples/heat-eqn/src/CMakeLists.txt
+++ b/examples/heat-eqn/src/CMakeLists.txt
@@ -24,7 +24,3 @@ target_link_libraries(
     PUBLIC
         godzilla
 )
-
-if (DEFINED ENV{CONDA_PREFIX})
-    set_target_properties(${PROJECT_NAME} PROPERTIES BUILD_RPATH $ENV{CONDA_PREFIX}/lib)
-endif()

--- a/examples/ns-incomp/src/CMakeLists.txt
+++ b/examples/ns-incomp/src/CMakeLists.txt
@@ -26,7 +26,3 @@ target_link_libraries(
     PRIVATE
         ${PETSC_LIBRARY}
 )
-
-if (DEFINED ENV{CONDA_PREFIX})
-    set_target_properties(${PROJECT_NAME} PROPERTIES BUILD_RPATH $ENV{CONDA_PREFIX}/lib)
-endif()

--- a/examples/poisson/src/CMakeLists.txt
+++ b/examples/poisson/src/CMakeLists.txt
@@ -22,7 +22,3 @@ target_link_libraries(
     PUBLIC
         godzilla
 )
-
-if (DEFINED ENV{CONDA_PREFIX})
-    set_target_properties(${PROJECT_NAME} PROPERTIES BUILD_RPATH $ENV{CONDA_PREFIX}/lib)
-endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,10 +130,6 @@ if (GODZILLA_WITH_MPI)
 endif()
 
 
-set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_RPATH OFF)
-set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
-set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-
 # install
 
 configure_package_config_file(

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -121,7 +121,3 @@ target_link_libraries(
 if (GODZILLA_WITH_MPI)
     target_link_libraries(${PROJECT_NAME} PRIVATE MPI::MPI_CXX)
 endif()
-
-if (DEFINED ENV{CONDA_PREFIX})
-    set_target_properties(${PROJECT_NAME} PROPERTIES BUILD_RPATH $ENV{CONDA_PREFIX}/lib)
-endif()


### PR DESCRIPTION
On macOS Sonoma, this rpath handling is rendering the installed library unusable since it damages the code signature
