### PR TITLE
TimeSteppingAdaptor improvements

### DIFF
--- a/include/godzilla/BasicTSAdapt.h
+++ b/include/godzilla/BasicTSAdapt.h
@@ -13,8 +13,7 @@ class BasicTSAdapt : public TimeSteppingAdaptor {
 public:
     explicit BasicTSAdapt(const Parameters & params);
 
-protected:
-    void set_type_impl() override;
+    void create() override;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/TimeSteppingAdaptor.h
+++ b/include/godzilla/TimeSteppingAdaptor.h
@@ -39,6 +39,12 @@ public:
     /// @param type Type of time adaptor
     void set_type(const char * type);
 
+    /// Set whether to always accept steps regardless of any error or stability condition not
+    /// meeting the prescribed goal
+    ///
+    /// @param flag Whether to always accept steps
+    void set_always_accept(bool flag);
+
 protected:
     /// Get problem this time adaptor is part of
     ///

--- a/include/godzilla/TimeSteppingAdaptor.h
+++ b/include/godzilla/TimeSteppingAdaptor.h
@@ -34,15 +34,12 @@ public:
     /// @return Maximum time step size
     [[nodiscard]] Real get_dt_max() const;
 
-protected:
     /// Set time adaptor type
     ///
     /// @param type Type of time adaptor
     void set_type(const char * type);
 
-    /// Set the type of time stepping adaptivity
-    virtual void set_type_impl() = 0;
-
+protected:
     /// Get problem this time adaptor is part of
     ///
     /// @return Problem this time adaptor is part of

--- a/include/godzilla/TimeSteppingAdaptor.h
+++ b/include/godzilla/TimeSteppingAdaptor.h
@@ -56,7 +56,7 @@ private:
     Problem * problem;
 
     /// Transient problem interface this adaptor is part of
-    const TransientProblemInterface * tpi;
+    TransientProblemInterface * tpi;
 
     /// TSAdapt object
     TSAdapt ts_adapt;

--- a/src/BasicTSAdapt.cpp
+++ b/src/BasicTSAdapt.cpp
@@ -19,9 +19,10 @@ BasicTSAdapt::parameters()
 BasicTSAdapt::BasicTSAdapt(const Parameters & params) : TimeSteppingAdaptor(params) {}
 
 void
-BasicTSAdapt::set_type_impl()
+BasicTSAdapt::create()
 {
     _F_;
+    TimeSteppingAdaptor::create();
     set_type(TSADAPTBASIC);
 }
 

--- a/src/GYMLFile.cpp
+++ b/src/GYMLFile.cpp
@@ -82,7 +82,6 @@ GYMLFile::build_ts_adapt(const Block & problem_node)
         auto ts_adapt_node = get_block(problem_node, "ts_adapt");
         Parameters * params = build_params(ts_adapt_node);
         params->set<Problem *>("_problem") = get_problem();
-        params->set<const TransientProblemInterface *>("_tpi") = tpi;
 
         const auto & class_name = params->get<std::string>("_type");
         auto * ts_adaptor =

--- a/src/TimeSteppingAdaptor.cpp
+++ b/src/TimeSteppingAdaptor.cpp
@@ -27,6 +27,7 @@ TimeSteppingAdaptor::TimeSteppingAdaptor(const Parameters & params) :
     dt_max(get_param<Real>("dt_max"))
 {
     _F_;
+    PETSC_CHECK(TSGetAdapt(this->tpi->get_ts(), &this->ts_adapt));
 }
 
 TSAdapt
@@ -68,8 +69,6 @@ void
 TimeSteppingAdaptor::create()
 {
     _F_;
-    PETSC_CHECK(TSGetAdapt(this->tpi->get_ts(), &this->ts_adapt));
-    set_type_impl();
     PETSC_CHECK(TSAdaptSetStepLimits(this->ts_adapt, this->dt_min, this->dt_max));
 }
 

--- a/src/TimeSteppingAdaptor.cpp
+++ b/src/TimeSteppingAdaptor.cpp
@@ -72,4 +72,11 @@ TimeSteppingAdaptor::create()
     PETSC_CHECK(TSAdaptSetStepLimits(this->ts_adapt, this->dt_min, this->dt_max));
 }
 
+void
+TimeSteppingAdaptor::set_always_accept(bool flag)
+{
+    _F_;
+    PETSC_CHECK(TSAdaptSetAlwaysAccept(this->ts_adapt, flag ? PETSC_TRUE : PETSC_FALSE));
+}
+
 } // namespace godzilla

--- a/src/TimeSteppingAdaptor.cpp
+++ b/src/TimeSteppingAdaptor.cpp
@@ -3,6 +3,7 @@
 
 #include "godzilla/TimeSteppingAdaptor.h"
 #include "godzilla/CallStack.h"
+#include "godzilla/Problem.h"
 #include "godzilla/TransientProblemInterface.h"
 
 namespace godzilla {
@@ -12,7 +13,6 @@ TimeSteppingAdaptor::parameters()
 {
     Parameters params = Object::parameters();
     params.add_private_param<Problem *>("_problem", nullptr);
-    params.add_private_param<const TransientProblemInterface *>("_tpi", nullptr);
     params.add_param<Real>("dt_min", PETSC_DEFAULT, "Minimum time step");
     params.add_param<Real>("dt_max", PETSC_DEFAULT, "Maximum time step");
     return params;
@@ -21,13 +21,14 @@ TimeSteppingAdaptor::parameters()
 TimeSteppingAdaptor::TimeSteppingAdaptor(const Parameters & params) :
     Object(params),
     problem(get_param<Problem *>("_problem")),
-    tpi(get_param<const TransientProblemInterface *>("_tpi")),
+    tpi(dynamic_cast<TransientProblemInterface *>(problem)),
     ts_adapt(nullptr),
     dt_min(get_param<Real>("dt_min")),
     dt_max(get_param<Real>("dt_max"))
 {
     _F_;
-    PETSC_CHECK(TSGetAdapt(this->tpi->get_ts(), &this->ts_adapt));
+    if (this->tpi)
+        PETSC_CHECK(TSGetAdapt(this->tpi->get_ts(), &this->ts_adapt));
 }
 
 TSAdapt

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -70,6 +70,7 @@ TransientProblemInterface::TransientProblemInterface(Problem * problem, const Pa
     step_num(0)
 {
     _F_;
+    PETSC_CHECK(TSCreate(this->problem->get_comm(), &this->ts));
 }
 
 TransientProblemInterface::~TransientProblemInterface()
@@ -180,7 +181,6 @@ TransientProblemInterface::init()
 {
     _F_;
     assert(this->problem != nullptr);
-    PETSC_CHECK(TSCreate(this->problem->get_comm(), &this->ts));
     PETSC_CHECK(TSSetDM(this->ts, this->problem->get_dm()));
     PETSC_CHECK(TSSetApplicationContext(this->ts, this));
 }

--- a/test/src/BasicTSAdapt_test.cpp
+++ b/test/src/BasicTSAdapt_test.cpp
@@ -34,7 +34,6 @@ TEST(BasicTSAdapt, api)
     Parameters params = BasicTSAdapt::parameters();
     params.set<App *>("_app") = &app;
     params.set<Problem *>("_problem") = prob;
-    params.set<const TransientProblemInterface *>("_tpi") = prob;
     BasicTSAdapt adaptor(params);
     prob->set_time_stepping_adaptor(&adaptor);
 

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -175,7 +175,6 @@ TEST(TimeSteppingAdaptor, api)
     Parameters params = TimeSteppingAdaptor::parameters();
     params.set<App *>("_app") = &app;
     params.set<Problem *>("_problem") = prob;
-    params.set<const TransientProblemInterface *>("_tpi") = prob;
     params.set<Real>("dt_min") = 1e-3;
     params.set<Real>("dt_max") = 1e3;
     TimeSteppingAdaptor adaptor(params);
@@ -225,7 +224,6 @@ TEST(TimeSteppingAdaptor, choose)
         const std::string class_name = "TestTSAdaptor";
         Parameters * params = app.get_parameters(class_name);
         params->set<Problem *>("_problem") = prob;
-        params->set<const TransientProblemInterface *>("_tpi") = prob;
         auto * ts_adaptor = app.build_object<TestTSAdaptor>(class_name, "ts_adapt", params);
         prob->set_time_stepping_adaptor(ts_adaptor);
     }

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -36,6 +36,8 @@ class TestTSAdaptor : public TimeSteppingAdaptor {
 public:
     explicit TestTSAdaptor(const Parameters & params);
 
+    void create() override;
+
     void choose(Real h,
                 Int * next_sc,
                 Real * next_h,
@@ -47,13 +49,6 @@ public:
     std::vector<Real> dts;
 
     static Parameters parameters();
-
-protected:
-    void
-    set_type_impl() override
-    {
-        set_type(TS_ADAPT_TEST);
-    }
 };
 
 } // namespace
@@ -70,6 +65,13 @@ TestTSAdaptor::parameters()
 TestTSAdaptor::TestTSAdaptor(const Parameters & params) : TimeSteppingAdaptor(params)
 {
     this->dts = { 0.2, 0.3, 0.4, 1 };
+}
+
+void
+TestTSAdaptor::create()
+{
+    TimeSteppingAdaptor::create();
+    set_type(TS_ADAPT_TEST);
 }
 
 void
@@ -146,13 +148,6 @@ TestTSProblem::ts_monitor_callback(Int stepi, Real time, Vec x)
 
 TEST(TimeSteppingAdaptor, api)
 {
-    class MockTSAdaptor : public TimeSteppingAdaptor {
-    public:
-        explicit MockTSAdaptor(const Parameters & params) : TimeSteppingAdaptor(params) {}
-
-        MOCK_METHOD((void), set_type_impl, ());
-    };
-
     TestApp app;
 
     LineMesh * mesh;
@@ -177,18 +172,17 @@ TEST(TimeSteppingAdaptor, api)
     mesh->create();
     prob->create();
 
-    Parameters params = MockTSAdaptor::parameters();
+    Parameters params = TimeSteppingAdaptor::parameters();
     params.set<App *>("_app") = &app;
     params.set<Problem *>("_problem") = prob;
     params.set<const TransientProblemInterface *>("_tpi") = prob;
     params.set<Real>("dt_min") = 1e-3;
     params.set<Real>("dt_max") = 1e3;
-    MockTSAdaptor adaptor(params);
+    TimeSteppingAdaptor adaptor(params);
 
     EXPECT_DOUBLE_EQ(adaptor.get_dt_min(), 1e-3);
     EXPECT_DOUBLE_EQ(adaptor.get_dt_max(), 1e3);
 
-    EXPECT_CALL(adaptor, set_type_impl);
     adaptor.create();
 }
 


### PR DESCRIPTION
- TimeSteppingAdaptor: removing set_type_impl()
- Adding TimeSteppingAdaptor::set_always_accept
- Removing "_tpi" parameter from TimeSteppingAdaptor
