### PR TITLE
Improving code coverage for UnstructuredMesh

### DIFF
--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -143,8 +143,6 @@ public:
     explicit UnstructuredMesh(const Parameters & parameters);
     ~UnstructuredMesh() override;
 
-    void create() override;
-
     /// Build from a list of vertices for each cell (common mesh generator output)
     ///
     /// @param dim The topological dimension of the mesh

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -71,12 +71,6 @@ UnstructuredMesh::~UnstructuredMesh()
 }
 
 void
-UnstructuredMesh::create()
-{
-    CALL_STACK_MSG();
-}
-
-void
 UnstructuredMesh::lprint_mesh_info()
 {
     CALL_STACK_MSG();

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -545,3 +545,23 @@ TEST(UnstructuredMesh, mark_boundary_faces)
     EXPECT_THAT(facets_idxs, ElementsAre(6, 8, 9, 10));
     facets.restore_indices();
 }
+
+TEST(UnstructuredMesh, point_star_forrest)
+{
+    TestApp app;
+    auto comm = app.get_comm();
+
+    Parameters params = TestUnstructuredMesh::parameters();
+    params.set<App *>("_app") = &app;
+    params.set<std::string>("_name") = "obj";
+    TestUnstructuredMesh mesh(params);
+    mesh.create();
+
+    StarForest sf;
+    sf.create(comm);
+
+    mesh.set_point_star_forest(sf);
+    EXPECT_EQ(static_cast<PetscSF>(mesh.get_point_star_forest()), static_cast<PetscSF>(sf));
+
+    sf.destroy();
+}


### PR DESCRIPTION
- Removing `UnstructuredMesh:create` since it is empty
- Adding unit tests for `UnstructuredMesh::{set|get}_point_star_forrest`
