### PR TITLE
Improving code coverage

### DIFF
--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -90,8 +90,6 @@ public:
     TSConvergedReason get_converged_reason() const;
 
 protected:
-    /// Get `Problem`
-    Problem * get_problem();
     /// Get underlying SNES object
     SNES get_snes() const;
     /// Get time

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -79,13 +79,6 @@ TransientProblemInterface::~TransientProblemInterface()
     TSDestroy(&this->ts);
 }
 
-Problem *
-TransientProblemInterface::get_problem()
-{
-    CALL_STACK_MSG();
-    return this->problem;
-}
-
 SNES
 TransientProblemInterface::get_snes() const
 {

--- a/test/include/GTestFENonlinearProblem.h
+++ b/test/include/GTestFENonlinearProblem.h
@@ -37,6 +37,12 @@ public:
         return DiscreteProblemInterface::get_boundary_conditions();
     }
 
+    const std::vector<EssentialBC *> &
+    get_essential_bcs() const
+    {
+        return DiscreteProblemInterface::get_essential_bcs();
+    }
+
 protected:
     void set_up_fields() override;
     void set_up_weak_form() override;

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -45,6 +45,12 @@ TEST_F(AuxiliaryFieldTest, api)
         {
             return AuxiliaryField::get_mesh();
         }
+
+        Problem *
+        get_prblm() const
+        {
+            return AuxiliaryField::get_problem();
+        }
     };
 
     mesh->create();
@@ -67,6 +73,7 @@ TEST_F(AuxiliaryFieldTest, api)
     EXPECT_EQ(aux.get_func(), nullptr);
     EXPECT_EQ(aux.get_context(), &aux);
     EXPECT_EQ(aux.get_msh(), this->mesh);
+    EXPECT_EQ(aux.get_prblm(), prob);
 
     EXPECT_TRUE(prob->has_aux("aux"));
     EXPECT_FALSE(prob->has_aux("no-aux"));

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -206,6 +206,10 @@ TEST_F(FENonlinearProblemTest, solve)
     EXPECT_EQ(bcs.size(), 1);
     EXPECT_EQ(bcs[0]->get_type(), "DirichletBC");
 
+    auto ess_bcs = prob->get_essential_bcs();
+    ASSERT_EQ(ess_bcs.size(), 1);
+    EXPECT_EQ(bcs[0]->get_type(), "DirichletBC");
+
     prob->solve();
 
     bool conv = prob->converged();

--- a/test/src/FileMesh_test.cpp
+++ b/test/src/FileMesh_test.cpp
@@ -1,0 +1,24 @@
+#include "gmock/gmock.h"
+#include "TestApp.h"
+#include "godzilla/FileMesh.h"
+
+using namespace godzilla;
+using namespace testing;
+
+TEST(FileMesh, check)
+{
+    testing::internal::CaptureStderr();
+
+    TestApp app;
+
+    Parameters mesh_pars = FileMesh::parameters();
+    mesh_pars.set<godzilla::App *>("_app") = &app;
+    mesh_pars.set<std::string>("file") =
+        std::string(GODZILLA_UNIT_TESTS_ROOT) + std::string("/assets/empty.yml");
+    FileMesh mesh(mesh_pars);
+    mesh.check();
+
+    ASSERT_FALSE(app.check_integrity());
+    auto out = testing::internal::GetCapturedStderr();
+    EXPECT_THAT(out, HasSubstr("[ERROR] Unknown mesh format"));
+}

--- a/test/src/KrylovSolver_test.cpp
+++ b/test/src/KrylovSolver_test.cpp
@@ -250,3 +250,17 @@ TEST(KrylovSolver, set_opers_rhs_c_version)
 
     ks.destroy();
 }
+
+TEST(KrylovSolver, ctor_ksp)
+{
+    TestApp app;
+    auto comm = app.get_comm();
+
+    KSP ksp;
+    KSPCreate(comm, &ksp);
+
+    KrylovSolver ks(ksp);
+    EXPECT_EQ(static_cast<KSP>(ks), ksp);
+
+    KSPDestroy(&ksp);
+}

--- a/test/src/ResidualFunc_test.cpp
+++ b/test/src/ResidualFunc_test.cpp
@@ -7,67 +7,63 @@
 using namespace godzilla;
 using namespace testing;
 
-namespace {
-
-class GTestProblem : public ImplicitFENonlinearProblem {
-public:
-    explicit GTestProblem(const Parameters & params) : ImplicitFENonlinearProblem(params) {}
-
-    MOCK_METHOD(const Int &, get_spatial_dimension, (), (const));
-    MOCK_METHOD(const FieldValue &, get_field_value, (const std::string & field_name), (const));
-    MOCK_METHOD(const FieldGradient &,
-                get_field_gradient,
-                (const std::string & field_name),
-                (const));
-    MOCK_METHOD(const FieldValue &, get_field_dot, (const std::string & field_name), (const));
-    MOCK_METHOD(const Real &, get_time_shift, (), (const));
-    MOCK_METHOD(const Real &, get_assembly_time, (), (const));
-    MOCK_METHOD(const Normal &, get_normal, (), (const));
-    MOCK_METHOD(const Point &, get_xyz, (), (const));
-
-protected:
-    void
-    set_up_fields() override
-    {
-        set_fe(0, "u", 1, 1);
-    }
-
-    void
-    set_up_weak_form() override
-    {
-    }
-};
-
-class TestF : public ResidualFunc {
-public:
-    explicit TestF(GTestProblem * prob) :
-        ResidualFunc(prob),
-        dim(get_spatial_dimension()),
-        u(get_field_value("u")),
-        u_x(get_field_gradient("u")),
-        u_t(get_field_dot("u")),
-        t(get_time())
-    {
-    }
-
-    void
-    evaluate(Scalar f[]) const override
-    {
-        f[0] = 0.;
-    }
-
-protected:
-    const Int & dim;
-    const FieldValue & u;
-    const FieldGradient & u_x;
-    const FieldValue & u_t;
-    const Real & t;
-};
-
-} // namespace
-
 TEST(ResidualFuncTest, test)
 {
+    class GTestProblem : public ImplicitFENonlinearProblem {
+    public:
+        explicit GTestProblem(const Parameters & params) : ImplicitFENonlinearProblem(params) {}
+
+        MOCK_METHOD(const Int &, get_spatial_dimension, (), (const));
+        MOCK_METHOD(const FieldValue &, get_field_value, (const std::string & field_name), (const));
+        MOCK_METHOD(const FieldGradient &,
+                    get_field_gradient,
+                    (const std::string & field_name),
+                    (const));
+        MOCK_METHOD(const FieldValue &, get_field_dot, (const std::string & field_name), (const));
+        MOCK_METHOD(const Real &, get_time_shift, (), (const));
+        MOCK_METHOD(const Real &, get_assembly_time, (), (const));
+        MOCK_METHOD(const Normal &, get_normal, (), (const));
+        MOCK_METHOD(const Point &, get_xyz, (), (const));
+
+    protected:
+        void
+        set_up_fields() override
+        {
+            set_fe(0, "u", 1, 1);
+        }
+
+        void
+        set_up_weak_form() override
+        {
+        }
+    };
+
+    class TestF : public ResidualFunc {
+    public:
+        explicit TestF(GTestProblem * prob) :
+            ResidualFunc(prob),
+            dim(get_spatial_dimension()),
+            u(get_field_value("u")),
+            u_x(get_field_gradient("u")),
+            u_t(get_field_dot("u")),
+            t(get_time())
+        {
+        }
+
+        void
+        evaluate(Scalar f[]) const override
+        {
+            f[0] = 0.;
+        }
+
+    protected:
+        const Int & dim;
+        const FieldValue & u;
+        const FieldGradient & u_x;
+        const FieldValue & u_t;
+        const Real & t;
+    };
+
     TestApp app;
 
     Parameters mesh_pars = LineMesh::parameters();
@@ -98,4 +94,78 @@ TEST(ResidualFuncTest, test)
     EXPECT_CALL(prob, get_assembly_time()).Times(1).WillOnce(ReturnRef(time));
 
     TestF res(&prob);
+}
+
+TEST(ResidualFuncTest, test_vals)
+{
+    class GTestProblem : public ImplicitFENonlinearProblem {
+    public:
+        explicit GTestProblem(const Parameters & params) : ImplicitFENonlinearProblem(params) {}
+
+    protected:
+        void
+        set_up_fields() override
+        {
+            set_fe(0, "u", 1, 1);
+        }
+
+        void
+        set_up_weak_form() override
+        {
+        }
+    };
+
+    class TestF : public ResidualFunc {
+    public:
+        explicit TestF(GTestProblem * prob) :
+            ResidualFunc(prob),
+            dim(get_spatial_dimension()),
+            u(get_field_value("u")),
+            u_x(get_field_gradient("u")),
+            u_t(get_field_dot("u")),
+            t(get_time())
+        {
+        }
+
+        void
+        evaluate(Scalar f[]) const override
+        {
+            f[0] = dim;
+            f[1] = u(0);
+            f[2] = u_x(0);
+            f[3] = u_t(0);
+            f[4] = t;
+        }
+
+    protected:
+        const Int & dim;
+        const FieldValue & u;
+        const FieldGradient & u_x;
+        const FieldValue & u_t;
+        const Real & t;
+    };
+
+    TestApp app;
+
+    Parameters mesh_pars = LineMesh::parameters();
+    mesh_pars.set<App *>("_app") = &app;
+    mesh_pars.set<Int>("nx") = 2;
+    LineMesh mesh(mesh_pars);
+
+    Parameters prob_pars = GTestProblem::parameters();
+    prob_pars.set<App *>("_app") = &app;
+    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<Real>("start_time") = 1.23;
+    prob_pars.set<Real>("end_time") = 20;
+    prob_pars.set<Real>("dt") = 5;
+    GTestProblem prob(prob_pars);
+
+    mesh.create();
+    prob.create();
+
+    TestF res(&prob);
+    Scalar vals[5];
+    res.evaluate(vals);
+    EXPECT_DOUBLE_EQ(vals[0], 1);
+    EXPECT_DOUBLE_EQ(vals[4], 0.);
 }

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -72,6 +72,7 @@ TestTSAdaptor::create()
 {
     TimeSteppingAdaptor::create();
     set_type(TS_ADAPT_TEST);
+    set_always_accept(true);
 }
 
 void


### PR DESCRIPTION
- Improving coverage of `TimeSteppingAdaptor::set_always_accept`
- Removing unused API: `TransientProblemInterface::get_problem()`
- Improving coverage of `TimeSteppingAdaptor::set_always_accept`
- Adding a unit test for `AuxiliaryField::get_problem`
- Adding a test for `DiscreteProblemInterface::get_essential_bcs()`
- Improving tests for `ResidualFunc`
- Adding unit test for `FileMesh::check()`
