### PR TITLE
Adding wrapper around preconditioners

### DIFF
--- a/examples/ns-incomp/include/NSIncompressibleProblem.h
+++ b/examples/ns-incomp/include/NSIncompressibleProblem.h
@@ -17,7 +17,7 @@ protected:
     void set_up_weak_form() override;
     void set_up_matrix_properties() override;
     void set_up_field_null_space(DM dm) override;
-    void set_up_preconditioning() override;
+    Preconditioner create_preconditioner(PC pc) override;
 
     PetscInt velocity_id;
     PetscInt pressure_id;

--- a/include/godzilla/KrylovSolver.h
+++ b/include/godzilla/KrylovSolver.h
@@ -162,6 +162,17 @@ public:
     /// typecast operator so we can use our class directly with PETSc API
     operator KSP() const;
 
+    /// Set preconditioner type
+    ///
+    /// @tparam PCTYPE C++ class of a Preconditioner type
+    /// @return Preconditioner class
+    template <class PCTYPE>
+    PCTYPE
+    set_pc_type() const
+    {
+        return PCTYPE(get_pc());
+    }
+
 private:
     /// PETSc object
     KSP ksp;

--- a/include/godzilla/LinearProblem.h
+++ b/include/godzilla/LinearProblem.h
@@ -7,7 +7,7 @@
 #include "godzilla/Vector.h"
 #include "godzilla/Matrix.h"
 #include "godzilla/KrylovSolver.h"
-#include "petscksp.h"
+#include "godzilla/Preconditioner.h"
 
 namespace godzilla {
 
@@ -43,16 +43,20 @@ protected:
     virtual void set_up_solver_parameters();
     /// Method for setting matrix properties
     virtual void set_up_matrix_properties();
-    /// Method for setting preconditioning
-    virtual void set_up_preconditioning();
+    /// Method for creating a preconditioner
+    virtual Preconditioner create_preconditioner(PC pc);
     /// Solve the problem
     virtual void solve();
 
 private:
+    void set_up_preconditioning();
+
     /// KSP object
     KrylovSolver ks;
     /// The right-hand side vector
     Vector b;
+    /// Preconditioner
+    Preconditioner precond;
 
     /// Relative convergence tolerance for the linear solver
     Real lin_rel_tol;

--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -6,6 +6,7 @@
 #include "godzilla/Problem.h"
 #include "godzilla/Vector.h"
 #include "godzilla/Matrix.h"
+#include "godzilla/Preconditioner.h"
 #include "petscsnes.h"
 
 namespace godzilla {
@@ -70,12 +71,14 @@ protected:
     void ksp_monitor_callback(Int it, Real rnorm);
     /// Method for setting matrix properties
     virtual void set_up_matrix_properties();
-    /// Method for setting preconditioning
-    virtual void set_up_preconditioning();
+    /// Method for creating a preconditioner
+    virtual Preconditioner create_preconditioner(PC pc);
     /// Solve the problem
     virtual void solve();
 
 private:
+    void set_up_preconditioning();
+
     /// SNES object
     SNES snes;
     /// KSP object
@@ -86,6 +89,8 @@ private:
     Matrix J;
     /// Converged reason
     SNESConvergedReason converged_reason;
+    /// Preconditioner
+    Preconditioner precond;
 
     /// The type of line search to be used
     std::string line_search_type;

--- a/include/godzilla/PCComposite.h
+++ b/include/godzilla/PCComposite.h
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "godzilla/Preconditioner.h"
+#include "godzilla/Types.h"
+
+namespace godzilla {
+
+class PCComposite : public Preconditioner {
+public:
+    enum Type {
+        ADDITIVE = PC_COMPOSITE_ADDITIVE,
+        MULTIPLICATIVE = PC_COMPOSITE_MULTIPLICATIVE,
+        SYMMETRIC_MULTIPLICATIVE = PC_COMPOSITE_SYMMETRIC_MULTIPLICATIVE,
+        SPECIAL = PC_COMPOSITE_SPECIAL,
+        SCHUR = PC_COMPOSITE_SCHUR,
+        GKB = PC_COMPOSITE_GKB
+    };
+
+    PCComposite();
+    PCComposite(PC pc);
+
+    /// Creates a preconditioner
+    ///
+    /// @param comm MPI communicator
+    void create(MPI_Comm comm);
+
+    /// Sets the type of composite preconditioner
+    ///
+    void set_type(Type type);
+
+    /// Gets the type of composite preconditioner
+    ///
+    Type get_type();
+
+    /// Adds another PC to the composite PC.
+    ///
+    /// @param subpc The new preconditioner
+    void add_pc(const Preconditioner & subpc);
+
+    /// Gets the number of PC objects in the composite PC
+    ///
+    /// @return The number of sub PCs
+    Int get_number_pc() const;
+
+    /// Gets one of the PC objects in the composite PC
+    ///
+    /// @param n The number of the PC requested
+    /// @return The PC requested
+    Preconditioner get_pc(Int n) const;
+
+    /// Sets alpha for the special composite preconditioner
+    void special_set_alpha(Scalar alpha);
+};
+
+} // namespace godzilla

--- a/include/godzilla/PCFactor.h
+++ b/include/godzilla/PCFactor.h
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "godzilla/Preconditioner.h"
+#include "godzilla/Types.h"
+
+namespace godzilla {
+
+class PCFactor : public Preconditioner {
+public:
+    enum Type { ICC, ILU, LU, CHOLESKY };
+
+    enum MatSolverType {
+        SUPERLU,
+        SUPERLU_DIST,
+        STRUMPACK,
+        UMFPACK,
+        CHOLMOD,
+        KLU,
+        ELEMENTAL,
+        SCALAPACK,
+        ESSL,
+        LUSOL,
+        MUMPS,
+        MKL_PARDISO,
+        MKL_CPARDISO,
+        PASTIX,
+        MATLAB,
+        PETSC,
+        BAS,
+        CUSPARSE,
+        CUDA,
+#if PETSC_VERSION_GE(3, 18, 0)
+        HIPSPARSE,
+        HIP,
+#endif
+        KOKKOS,
+        SPQR
+    };
+
+    enum MatShiftType {
+        /// do not shift the matrix diagonal entries
+        NONE = MAT_SHIFT_NONE,
+        /// shift the entries to be non-zero
+        NONZERO = MAT_SHIFT_NONZERO,
+        /// shift the entries to force the factorization to be positive definite
+        POSITIVE_DEFINITE = MAT_SHIFT_POSITIVE_DEFINITE,
+        /// only shift the factors inside the small dense diagonal blocks of the matrix, for
+        /// example with `MATBAIJ`
+        INBLOCKS = MAT_SHIFT_INBLOCKS
+    };
+
+    enum MatOrderingType {
+        NATURAL,
+        ND,
+        ONE_WD,
+        RCM,
+        QMD,
+        ROW_LENGTH,
+        WBM,
+        SPECTRAL,
+        AMD,
+        METISND,
+        NATURAL_OR_ND,
+        EXTERNAL
+    };
+
+    PCFactor();
+    PCFactor(PC pc);
+
+    /// Set the type of preconditioner
+    ///
+    /// @param type Preconditioner type
+    void set_type(Type type);
+
+    /// Get the precoditioner type
+    ///
+    /// @return Preconditioner type
+    Type get_type();
+
+    /// Determines if all diagonal matrix entries are treated as level 0 fill even if there is no
+    /// non-zero location
+    ///
+    /// @return `true` if all diagonal matrix entries are treated as level 0, `false` otherwise
+    bool get_allow_diagonal_fill() const;
+
+    /// Gets the number of levels of fill to use
+    ///
+    /// @return Number of levels of fill
+    Int get_levels() const;
+
+    /// Gets the solver package that is used to perform the factorization
+    ///
+    /// @return The solver package that is used to perform the factorization
+    MatSolverType get_mat_solver_type() const;
+
+    /// Gets the tolerance used to define a zero pivot
+    ///
+    /// @return How much to shift the diagonal entry
+    Real get_shift_amount() const;
+
+    /// Gets the type of shift, if any, done when a zero pivot is detected
+    MatShiftType get_shift_type() const;
+
+    /// Determines if an in-place factorization is being used
+    ///
+    /// @return `true` if an in-place factorization is being used, `false` otherwise
+    bool get_use_in_place() const;
+
+    /// Gets the tolerance used to define a zero pivot
+    ///
+    /// @return The tolerance that defines a zero pivot
+    Real get_zero_pivot() const;
+
+    /// Reorders rows/columns of matrix to remove zeros from diagonal
+    ///
+    /// @param tol Diagonal entries smaller than this in absolute value are considered zero
+    void reorder_for_nonzero_diagonal(Real tol);
+
+    /// Causes all diagonal matrix entries to be treated as level 0 fill even if there is no
+    /// non-zero location.
+    ///
+    /// @param flag `true` to turn on, `false` to turn off
+    void set_allow_diagonal_fill(bool flag);
+
+    /// Determines when column pivoting is done during matrix factorization. For PETSc dense
+    /// matrices column pivoting is always done, for PETSc sparse matrices it is never done.
+    /// For the MATLAB and MATSOLVERSUPERLU factorization this is used.
+    ///
+    /// @param dt_col `0.0` implies no pivoting, `1.0` complete pivoting (slower, requires more
+    /// memory but more stable)
+    void set_column_pivot(Real dt_col);
+
+    /// The preconditioner will use an PCILU based on a drop tolerance.
+    ///
+    /// @param dt The drop tolerance, try from `1.e-10` to `0.1`
+    /// @param dt_col Tolerance for column pivot, good values `[0.1 to 0.01]`
+    /// @param max_row_count The max number of nonzeros allowed in a row, best value depends on the
+    /// number of nonzeros in row of original matrix
+    ///
+    /// NOTE: There are NO default values for the 3 parameters, you must set them with reasonable
+    /// values for your matrix.
+    void set_drop_tolerance(Real dt, Real dt_col, Int max_row_count);
+
+    /// Indicate the amount of fill you expect in the factored matrix, fill = number nonzeros in
+    /// factor/number nonzeros in original matrix.
+    ///
+    /// @param fill Amount of expected fill
+    void set_fill(Real fill);
+
+    /// Sets the number of levels of fill to use
+    ///
+    /// @param levels Number of levels of fill
+    void set_levels(Int levels);
+
+    /// Sets the ordering routine (to reduce fill) to be used in the `LU`, `CHOLESKY`, `ILU`, or
+    /// `ICC` preconditioners
+    ///
+    /// @param ordering The matrix ordering name
+    void set_mat_ordering_type(MatOrderingType ordering);
+
+    /// Sets the solver package that is used to perform the factorization
+    ///
+    /// @param type Matrix solver type
+    void set_mat_solver_type(MatSolverType type);
+
+    /// Sets if pivoting is done while factoring each block with MATBAIJ or MATSBAIJ matrices
+    ///
+    /// @param pivot `true` to turn pivoting on, `false` otherwise
+    void set_pivot_in_blocks(bool pivot);
+
+    /// When matrices with different non-zero structure are factored, this causes later ones to use
+    /// the fill ratio computed in the initial factorization.
+    ///
+    /// @param flag `true` to turn reuse on, `false` to turn it off
+    void set_reuse_fill(bool flag);
+
+    /// When similar matrices are factored, this causes the ordering computed in the first factor
+    /// to be used for all following factors.
+    ///
+    /// @param flag `true` to turn reuse on, `false` to turn it off
+    void set_reuse_ordering(bool flag);
+
+    /// Adds a quantity to the diagonal of the matrix during numerical factorization, thus the
+    /// matrix has nonzero pivots
+    ///
+    /// @param shift_amount Amount of shift or `PETSC_DECIDE` for the default
+    void set_shift_amount(Real shift_amount);
+
+    /// Adds a particular type of quantity to the diagonal of the matrix during numerical
+    /// factorization, thus the matrix has nonzero pivots
+    ///
+    /// @param type Type of shift
+    void set_shift_type(MatShiftType type);
+
+    /// Can be called after KSPSetOperators() or PCSetOperators(), causes MatGetFactor() to be
+    /// called so then one may set the options for that particular factorization object.
+    ///
+    /// NOTE: After you have called this function (which has to be after the KSPSetOperators() or
+    /// PCSetOperators()) you can call PCFactorGetMatrix() and then set factor options on that
+    /// matrix. This function raises an error if the requested combination of solver package and
+    /// matrix type is not supported.
+    void set_up_mat_solver_type();
+
+    /// Tells the preconditioner to do an in-place factorization.
+    ///
+    /// @param flg `true` to enable, `false` to disable
+    void set_use_in_place(bool flg);
+
+    /// Sets the size at which smaller pivots are declared to be zero
+    ///
+    /// @param zero All pivots smaller than this will be considered zero
+    void set_zero_pivot(Real zero);
+};
+
+} // namespace godzilla

--- a/include/godzilla/PCFieldSplit.h
+++ b/include/godzilla/PCFieldSplit.h
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "godzilla/Preconditioner.h"
+#include "godzilla/IndexSet.h"
+#include "godzilla/Matrix.h"
+#include "godzilla/KrylovSolver.h"
+
+namespace godzilla {
+
+class PCFieldSplit : public Preconditioner {
+public:
+    enum Type {
+        ADDITIVE = PC_COMPOSITE_ADDITIVE,
+        COMPOSITE_MULTIPLICATIVE = PC_COMPOSITE_MULTIPLICATIVE,
+        SYMMETRIC_MULTIPLICATIVE = PC_COMPOSITE_SYMMETRIC_MULTIPLICATIVE,
+        SPECIAL = PC_COMPOSITE_SPECIAL,
+        SCHUR = PC_COMPOSITE_SCHUR,
+        GBK = PC_COMPOSITE_GKB
+    };
+
+    enum SchurFactType {
+        SCHUR_FACT_DIAG = PC_FIELDSPLIT_SCHUR_FACT_DIAG,
+        SCHUR_FACT_LOWER = PC_FIELDSPLIT_SCHUR_FACT_LOWER,
+        SCHUR_FACT_UPPER = PC_FIELDSPLIT_SCHUR_FACT_UPPER,
+        SCHUR_FACT_FULL = PC_FIELDSPLIT_SCHUR_FACT_FULL
+    };
+
+    enum SchurPreType {
+        SCHUR_PRE_SELF = PC_FIELDSPLIT_SCHUR_PRE_SELF,
+        SCHUR_PRE_SELFP = PC_FIELDSPLIT_SCHUR_PRE_SELFP,
+        SCHUR_PRE_A11 = PC_FIELDSPLIT_SCHUR_PRE_A11,
+        SCHUR_PRE_USER = PC_FIELDSPLIT_SCHUR_PRE_USER,
+        SCHUR_PRE_FULL = PC_FIELDSPLIT_SCHUR_PRE_FULL
+    };
+
+    struct SchurBlocks {
+        SchurBlocks(Mat A00, Mat A01, Mat A10, Mat A11) : A00(A00), A01(A01), A10(A10), A11(A11) {}
+
+        Matrix A00;
+        Matrix A01;
+        Matrix A10;
+        Matrix A11;
+    };
+
+    struct SchurPC {
+        SchurPC(PCFieldSplitSchurPreType type, Mat pre) :
+            type(static_cast<SchurPreType>(type)),
+            matrix(pre)
+        {
+        }
+
+        SchurPreType type;
+        Matrix matrix;
+    };
+
+    PCFieldSplit();
+    PCFieldSplit(PC pc);
+
+    /// Creates a preconditioner
+    ///
+    /// @param comm MPI communicator
+    void create(MPI_Comm comm);
+
+    /// Sets the type of the field split preconditioner
+    ///
+    /// @param type Type of the preconditioner
+    void set_type(Type type);
+
+    /// Gets the type of the field split preconditioner
+    ///
+    /// @return Type of the preconditioner
+    Type get_type() const;
+
+    /// Returns flag indicating whether `DMCreateFieldDecomposition()` should be used to define the
+    /// splits, whenever possible.
+    bool get_dm_splits() const;
+
+    /// Returns flag indicating whether this preconditioner will attempt to automatically determine
+    /// fields based on zero diagonal entries.
+    bool get_detect_saddle_point() const;
+
+    /// Get the flag indicating whether to extract diagonal blocks from `Amat` (rather than `Pmat`)
+    /// to build the sub-matrices associated with each split. Where
+    /// `KSPSetOperators(ksp, Amat, Pmat)` was used to supply the operators.
+    bool get_diag_use_amat() const;
+
+    /// Retrieves the elements for a split as an IndexSet
+    ///
+    /// @param split_name Name of the split
+    /// @return The `IndexSet` that defines the elements in this split
+    IndexSet get_is(const std::string & split_name) const;
+
+    /// Retrieves the elements for a given split as an IS
+    ///
+    /// @param index Index of the split
+    /// @return The index set that defines the elements in this split
+    IndexSet get_is_by_index(Int index) const;
+
+    /// Get the flag indicating whether to extract off-diagonal blocks from `Amat` (rather than
+    /// `Pmat`) to build the sub-matrices associated with each split. Where
+    /// `KSPSetOperators(ksp, Amat, Pmat)` was used to supply the operators.
+    bool get_off_diag_use_amat() const;
+
+    /// Gets all matrix blocks for the Schur complement
+    SchurBlocks get_schur_blocks() const;
+
+    /// For Schur complement fieldsplit, determine how the Schur complement will be preconditioned.
+    SchurPC get_schur_pre() const;
+
+    /// Gets the `KrylovSolver`s for all splits
+    std::vector<KrylovSolver> get_sub_ksp() const;
+
+    /// Extract the MATSCHURCOMPLEMENT object used by this PCFIELDSPLIT in case it needs to be
+    /// configured separately
+    ///
+    /// @return The Schur complement matrix
+    Matrix schur_get_s() const;
+
+    /// Gets the KSP contexts used inside the Schur complement based PCFIELDSPLIT
+    ///
+    /// @return The array of `KrylovSolver`s
+    std::vector<KrylovSolver> schur_get_sub_ksp() const;
+
+    /// Restore the `MATSCHURCOMPLEMENT` matrix used by this preconditioner
+    ///
+    /// @param s The Schur complement matrix
+    void schur_restore_s(const Matrix & s);
+
+    /// Sets the block size for defining where fields start in the field split preconditioner when
+    /// calling `set_is()`. If not set the matrix block size is used.
+    ///
+    /// @param bs The block size
+    void set_block_size(Int bs);
+
+    /// Flags whether `DMCreateFieldDecomposition()` should be used to define the splits in a
+    /// `PCFIELDSPLIT`, whenever possible.
+    ///
+    /// @param flag Boolean indicating whether to use field splits defined by the DM
+    void set_dm_splits(bool flag);
+
+    /// Sets flag indicating whether PCFIELDSPLIT will attempt to automatically determine fields
+    /// based on zero diagonal entries.
+    ///
+    /// @param flag Boolean indicating whether to detect fields or not
+    void set_detect_saddle_point(bool flag);
+
+    /// Set flag indicating whether to extract diagonal blocks from `Amat` (rather than `Pmat`) to
+    /// build the sub-matrices associated with each split. Where `KSPSetOperators(ksp, Amat, Pmat)`
+    /// was used to supply the operators.
+    ///
+    /// @param flg Boolean flag indicating whether or not to use Amat to extract the diagonal blocks
+    /// from
+    void set_diag_use_amat(bool flg);
+
+    /// Sets the fields that define one particular split in PCFIELDSPLIT
+    ///
+    /// @param split_name Name of this split, if empty the number of the split is used
+    /// @param fields The fields in this split
+    /// @param fields_col Generally the same as `fields`, if it does not match `fields` then the
+    /// matrix block that is solved for this set of fields comes from an off-diagonal block of the
+    /// matrix and `fields_col` provides the column indices for that block
+    void set_fields(const std::string & split_name,
+                    const std::vector<Int> & fields,
+                    const std::vector<Int> & fields_col);
+
+    /// Sets the delay in the lower bound error estimate in the generalized Golub-Kahan
+    /// bidiagonalization [Ari13] in PCFIELDSPLIT preconditioner.
+    ///
+    /// @param delay The delay window in the lower bound estimate
+    void set_gkb_delay(Int delay);
+
+    /// Sets the maximum number of iterations for the generalized Golub-Kahan bidiagonalization
+    /// preconditioner in PCFIELDSPLIT
+    void set_gkb_maxit(Int maxit);
+
+    /// Sets the scalar value nu >= 0 in the transformation H = A00 + nu A01 A01’ of the (1,1) block
+    /// in the Golub-Kahan bidiagonalization preconditioner [Ari13] in PCFIELDSPLIT
+    ///
+    /// @param nu The shift parameter
+    void set_gkb_nu(Real nu);
+
+    /// Sets the solver tolerance for the generalized Golub-Kahan bidiagonalization preconditioner
+    /// [Ari13] in PCFIELDSPLIT
+    ///
+    /// @param tolerance The solver tolerance
+    void set_gkb_tol(Real tolerance);
+
+    /// Sets the exact elements for a split in a PCFIELDSPLIT
+    ///
+    /// @param split_name Name of this split, if empty the number of the split is used
+    /// @param is The `IndexSet` that defines the elements in this split
+    void set_is(const std::string & split_name, const IndexSet & is);
+
+    /// Set flag indicating whether to extract off-diagonal blocks from `Amat` (rather than `Pmat`)
+    /// to build the sub-matrices associated with each split. Where
+    /// `KSPSetOperators(ksp, Amat, Pmat)` was used to supply the operators.
+    ///
+    /// @param flag Boolean flag indicating whether or not to use `Amat` to extract the off-diagonal
+    /// blocks from
+    void set_off_diag_use_amat(bool flag);
+
+    /// Sets which blocks of the approximate block factorization to retain in the preconditioner
+    /// [MGW00] and [Ips01]
+    ///
+    /// @param type Which blocks of factorization to retain
+    void set_schur_fact_type(SchurFactType type);
+
+    /// Indicates from what operator the preconditioner is constructed for the Schur complement.
+    /// The default is the A11 matrix.
+    ///
+    /// @param ptype Which matrix to use for preconditioning the Schur complement
+    /// @param pre Matrix to use for preconditioning
+    void set_schur_pre(SchurPreType ptype, const Matrix & pre);
+
+    /// Controls the sign flip of S for `SCHUR_FACT_DIAG`.
+    ///
+    /// @param scale Scaling factor for the Schur complement
+    void set_schur_scale(Scalar scale);
+};
+
+} // namespace godzilla

--- a/include/godzilla/PCHypre.h
+++ b/include/godzilla/PCHypre.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "godzilla/Preconditioner.h"
+#include "godzilla/Vector.h"
+#include "godzilla/Matrix.h"
+
+namespace godzilla {
+
+class PCHypre : public Preconditioner {
+public:
+    enum Type { EUCLID, PILUT, PARASAILS, BOOMERAMG, AMS, ADS };
+
+    PCHypre();
+    PCHypre(PC pc);
+
+    /// Creates a preconditioner
+    ///
+    /// @param comm MPI communicator
+    void create(MPI_Comm comm);
+
+    /// Sets which HYPRE preconditioner to use
+    ///
+    /// @param type HYPRE preconditioner type
+    void set_type(Type type);
+
+    /// Gets which HYPRE preconditioner is used
+    ///
+    /// @return HYPRE preconditioner type
+    Type get_type() const;
+
+    /// Set the list of interior nodes to a zero-conductivity region for PCHYPRE of type `AMS`
+    ///
+    /// @param interior Vector. Node is interior if its entry in the array is 1.0.
+    void ams_set_interior_nodes(const Vector & interior);
+
+    /// Set vector Poisson matrix for PCHYPRE of type `AMS`
+    ///
+    /// @param A The matrix
+    void set_alpha_poisson_matrix(const Matrix & A);
+
+    /// Set Poisson matrix for PCHYPRE of type `AMS`
+    ///
+    /// @param A The matrix
+    void set_beta_poisson_matrix(const Matrix & A);
+
+    /// Set discrete curl matrix for PCHYPRE type of `ADS`
+    ///
+    /// @param C The discrete curl
+    void set_discrete_curl(const Matrix & C);
+
+    /// Set discrete gradient matrix for PCHYPRE type of `AMS` or `ADS`
+    ///
+    /// @param G The discrete gradient
+    void set_discrete_gradient(const Matrix & G);
+
+    /// Set the representation of the constant vector fields in the edge element basis for PCHYPRE
+    /// of type `AMS` (for 2D)
+    ///
+    /// @param oz Vector representing (1,0)
+    /// @param zo Vector representing (0,1)
+    void set_edge_constant_vectors(const Vector & oz, const Vector & zo);
+
+    /// Set the representation of the constant vector fields in the edge element basis for PCHYPRE
+    /// of type `AMS` (for 3D)
+    ///
+    /// @param ozz Vector representing (1,0,0)
+    /// @param zoz Vector representing (0,1,0)
+    /// @param zzo Vector representing (0,0,1)
+    void set_edge_constant_vectors(const Vector & ozz, const Vector & zoz, const Vector & zzo);
+};
+
+} // namespace godzilla

--- a/include/godzilla/PCJacobi.h
+++ b/include/godzilla/PCJacobi.h
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "godzilla/Preconditioner.h"
+
+namespace godzilla {
+
+class PCJacobi : public Preconditioner {
+public:
+    enum Type {
+        DIAGONAL = PC_JACOBI_DIAGONAL,
+        ROWMAX = PC_JACOBI_ROWMAX,
+        ROWSUM = PC_JACOBI_ROWSUM
+    };
+
+    PCJacobi();
+    PCJacobi(PC pc);
+
+    /// Creates a preconditioner
+    ///
+    /// @param comm MPI communicator
+    void create(MPI_Comm comm);
+
+    /// Causes the preconditioner to use either the diagonal, the maximum entry in each row, or the
+    /// sum of rows entries for the diagonal preconditioner
+    ///
+    /// @param type How the diagonal matrix is produced
+    void set_type(Type type);
+
+    /// Gets how the diagonal matrix is produced for the preconditioner
+    ///
+    /// @return How the diagonal matrix is produced
+    Type get_type();
+
+    /// Determines if the preconditioner checks for zero diagonal terms
+    ///
+    /// @return `true` if check is on, `false` otherwise
+    bool get_fix_diagonal() const;
+
+    /// Determines if the preconditioner uses the absolute values of the diagonal divisors in
+    /// the preconditioner
+    ///
+    /// @return `true` if checking is on, `false` otherwise
+    bool get_use_abs() const;
+
+    /// Check for zero values on the diagonal and replace them with 1.0
+    ///
+    /// @param flag `true` turn the fixing on, `false` otherwise
+    void set_fix_diagonal(bool flag);
+
+    /// Causes the preconditioner to use the absolute values of the diagonal divisors in the
+    /// preconditioner
+    ///
+    /// @param flag `true` to use the absolute value, `false` otherwise
+    void set_use_abs(bool flag);
+};
+
+} // namespace godzilla

--- a/include/godzilla/Preconditioner.h
+++ b/include/godzilla/Preconditioner.h
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "petscpc.h"
+#include "godzilla/Matrix.h"
+
+namespace godzilla {
+
+/// Preconditioner - wrapper around PETSc PC
+class Preconditioner {
+public:
+    Preconditioner();
+    Preconditioner(PC pc);
+    virtual ~Preconditioner() = default;
+
+    /// Creates a preconditioner
+    ///
+    /// @param comm MPI communicator
+    void create(MPI_Comm comm);
+
+    /// Destroys the preconditioner
+    void destroy();
+
+    /// Builds PC for a particular preconditioner type
+    ///
+    /// @param type a known method, see PCType for possible values
+    void set_type(const std::string & type);
+
+    /// Gets the preconditioner type (as a string)
+    ///
+    /// @return name of preconditioner method
+    std::string get_type() const;
+
+    /// Resets the preconditioner and removes any allocated Vectors and Matrices
+    void reset();
+
+    /// Prepares the preconditioner for the use
+    void set_up();
+
+    /// Sets the matrix associated with the linear system and a (possibly) different one associated
+    /// with the preconditioner.
+    ///
+    /// @param A The matrix that defines the linear system
+    /// @param P The matrix to be used in constructing the preconditioner, usually the same as Amat.
+    void set_operators(const Matrix & A, const Matrix & P);
+
+    /// Prints information about the PC
+    ///
+    /// @param viewer Viewer
+    void view(PetscViewer viewer = PETSC_VIEWER_STDOUT_WORLD) const;
+
+    operator PC() const;
+
+protected:
+    /// PETSc PC object
+    PC pc;
+};
+
+} // namespace godzilla

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -26,6 +26,7 @@ LinearProblem::parameters()
 
 LinearProblem::LinearProblem(const Parameters & parameters) :
     Problem(parameters),
+    precond(nullptr),
     lin_rel_tol(get_param<Real>("lin_rel_tol")),
     lin_abs_tol(get_param<Real>("lin_abs_tol")),
     lin_max_iter(get_param<Int>("lin_max_iter"))
@@ -138,6 +139,15 @@ void
 LinearProblem::set_up_preconditioning()
 {
     CALL_STACK_MSG();
+    auto pc = this->ks.get_pc();
+    this->precond = create_preconditioner(pc);
+}
+
+Preconditioner
+LinearProblem::create_preconditioner(PC pc)
+{
+    CALL_STACK_MSG();
+    return Preconditioner(pc);
 }
 
 void

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -333,6 +333,16 @@ void
 NonlinearProblem::set_up_preconditioning()
 {
     CALL_STACK_MSG();
+    PC pc;
+    KSPGetPC(this->ksp, &pc);
+    this->precond = create_preconditioner(pc);
+}
+
+Preconditioner
+NonlinearProblem::create_preconditioner(PC pc)
+{
+    CALL_STACK_MSG();
+    return Preconditioner(pc);
 }
 
 void

--- a/src/PCComposite.cpp
+++ b/src/PCComposite.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "godzilla/PCComposite.h"
+#include "godzilla/CallStack.h"
+#include "godzilla/Error.h"
+
+namespace godzilla {
+
+PCComposite::PCComposite() : Preconditioner()
+{
+    CALL_STACK_MSG();
+}
+
+PCComposite::PCComposite(PC pc) : Preconditioner(pc)
+{
+    CALL_STACK_MSG();
+    Preconditioner::set_type(PCCOMPOSITE);
+}
+
+void
+PCComposite::create(MPI_Comm comm)
+{
+    CALL_STACK_MSG();
+    Preconditioner::create(comm);
+    Preconditioner::set_type(PCCOMPOSITE);
+}
+
+void
+PCComposite::set_type(Type type)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCCompositeSetType(this->pc, static_cast<PCCompositeType>(type)));
+}
+
+PCComposite::Type
+PCComposite::get_type()
+{
+    CALL_STACK_MSG();
+    PCCompositeType type;
+    PETSC_CHECK(PCCompositeGetType(this->pc, &type));
+    return static_cast<Type>(type);
+}
+
+void
+PCComposite::add_pc(const Preconditioner & subpc)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCCompositeAddPC(this->pc, subpc));
+}
+
+Int
+PCComposite::get_number_pc() const
+{
+    CALL_STACK_MSG();
+    Int num;
+    PETSC_CHECK(PCCompositeGetNumberPC(this->pc, &num));
+    return num;
+}
+
+Preconditioner
+PCComposite::get_pc(Int n) const
+{
+    CALL_STACK_MSG();
+    PC subpc;
+    PETSC_CHECK(PCCompositeGetPC(this->pc, n, &subpc));
+    return Preconditioner(subpc);
+}
+
+void
+PCComposite::special_set_alpha(Scalar alpha)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCCompositeSpecialSetAlpha(this->pc, alpha));
+}
+
+} // namespace godzilla

--- a/src/PCFactor.cpp
+++ b/src/PCFactor.cpp
@@ -1,0 +1,345 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "godzilla/PCFactor.h"
+#include "godzilla/CallStack.h"
+#include "godzilla/Error.h"
+
+namespace godzilla {
+
+PCFactor::PCFactor() : Preconditioner()
+{
+    CALL_STACK_MSG();
+}
+
+PCFactor::PCFactor(PC pc) : Preconditioner(pc)
+{
+    CALL_STACK_MSG();
+}
+
+void
+PCFactor::set_type(Type type)
+{
+    CALL_STACK_MSG();
+    if (type == ICC)
+        Preconditioner::set_type(PCICC);
+    else if (type == ILU)
+        Preconditioner::set_type(PCILU);
+    else if (type == LU)
+        Preconditioner::set_type(PCLU);
+    else if (type == CHOLESKY)
+        Preconditioner::set_type(PCCHOLESKY);
+}
+
+PCFactor::Type
+PCFactor::get_type()
+{
+    CALL_STACK_MSG();
+    const char * name;
+    PETSC_CHECK(PCGetType(this->pc, &name));
+    if (strcmp(name, PCICC) == 0)
+        return ICC;
+    else if (strcmp(name, PCILU) == 0)
+        return ILU;
+    else if (strcmp(name, PCLU) == 0)
+        return LU;
+    else if (strcmp(name, PCCHOLESKY) == 0)
+        return CHOLESKY;
+    else
+        throw std::logic_error("Unknown type of PCFactor preconditioner.");
+}
+
+bool
+PCFactor::get_allow_diagonal_fill() const
+{
+    CALL_STACK_MSG();
+    PetscBool flg;
+    PETSC_CHECK(PCFactorGetAllowDiagonalFill(this->pc, &flg));
+    return flg == PETSC_TRUE;
+}
+
+Int
+PCFactor::get_levels() const
+{
+    CALL_STACK_MSG();
+    Int levels;
+    PETSC_CHECK(PCFactorGetLevels(this->pc, &levels));
+    return levels;
+}
+
+PCFactor::MatSolverType
+PCFactor::get_mat_solver_type() const
+{
+    CALL_STACK_MSG();
+    ::MatSolverType stype;
+    PETSC_CHECK(PCFactorGetMatSolverType(this->pc, &stype));
+    if (strcmp(stype, MATSOLVERSUPERLU) == 0)
+        return SUPERLU;
+    else if (strcmp(stype, MATSOLVERSUPERLU_DIST) == 0)
+        return SUPERLU_DIST;
+    else if (strcmp(stype, MATSOLVERSTRUMPACK) == 0)
+        return STRUMPACK;
+    else if (strcmp(stype, MATSOLVERUMFPACK) == 0)
+        return UMFPACK;
+    else if (strcmp(stype, MATSOLVERCHOLMOD) == 0)
+        return CHOLMOD;
+    else if (strcmp(stype, MATSOLVERKLU) == 0)
+        return KLU;
+    else if (strcmp(stype, MATSOLVERELEMENTAL) == 0)
+        return ELEMENTAL;
+    else if (strcmp(stype, MATSOLVERSCALAPACK) == 0)
+        return SCALAPACK;
+    else if (strcmp(stype, MATSOLVERESSL) == 0)
+        return ESSL;
+    else if (strcmp(stype, MATSOLVERLUSOL) == 0)
+        return LUSOL;
+    else if (strcmp(stype, MATSOLVERMUMPS) == 0)
+        return MUMPS;
+    else if (strcmp(stype, MATSOLVERMKL_PARDISO) == 0)
+        return MKL_PARDISO;
+    else if (strcmp(stype, MATSOLVERMKL_CPARDISO) == 0)
+        return MKL_CPARDISO;
+    else if (strcmp(stype, MATSOLVERPASTIX) == 0)
+        return PASTIX;
+    else if (strcmp(stype, MATSOLVERMATLAB) == 0)
+        return MATLAB;
+    else if (strcmp(stype, MATSOLVERPETSC) == 0)
+        return PETSC;
+    else if (strcmp(stype, MATSOLVERBAS) == 0)
+        return BAS;
+    else if (strcmp(stype, MATSOLVERCUSPARSE) == 0)
+        return CUSPARSE;
+    else if (strcmp(stype, MATSOLVERCUDA) == 0)
+        return CUDA;
+#if PETSC_VERSION_GE(3, 18, 0)
+    else if (strcmp(stype, MATSOLVERHIPSPARSE) == 0)
+        return HIPSPARSE;
+    else if (strcmp(stype, MATSOLVERHIP) == 0)
+        return HIP;
+#endif
+    else if (strcmp(stype, MATSOLVERKOKKOS) == 0)
+        return KOKKOS;
+    else if (strcmp(stype, MATSOLVERSPQR) == 0)
+        return SPQR;
+    else
+        throw std::logic_error("Unknown type of MatSolverType preconditioner.");
+}
+
+Real
+PCFactor::get_shift_amount() const
+{
+    CALL_STACK_MSG();
+    Real shift;
+    PETSC_CHECK(PCFactorGetShiftAmount(this->pc, &shift));
+    return shift;
+}
+
+PCFactor::MatShiftType
+PCFactor::get_shift_type() const
+{
+    MatFactorShiftType type;
+    PETSC_CHECK(PCFactorGetShiftType(this->pc, &type));
+    return static_cast<MatShiftType>(type);
+}
+
+bool
+PCFactor::get_use_in_place() const
+{
+    CALL_STACK_MSG();
+    PetscBool flg;
+    PETSC_CHECK(PCFactorGetUseInPlace(this->pc, &flg));
+    return flg == PETSC_TRUE;
+}
+
+Real
+PCFactor::get_zero_pivot() const
+{
+    CALL_STACK_MSG();
+    Real pivot;
+    PETSC_CHECK(PCFactorGetZeroPivot(this->pc, &pivot));
+    return pivot;
+}
+
+void
+PCFactor::reorder_for_nonzero_diagonal(Real tol)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorReorderForNonzeroDiagonal(this->pc, tol));
+}
+
+void
+PCFactor::set_allow_diagonal_fill(bool flag)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetAllowDiagonalFill(this->pc, flag ? PETSC_TRUE : PETSC_FALSE));
+}
+
+void
+PCFactor::set_column_pivot(Real dt_col)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetColumnPivot(this->pc, dt_col));
+}
+
+void
+PCFactor::set_drop_tolerance(Real dt, Real dt_col, Int max_row_count)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetDropTolerance(this->pc, dt, dt_col, max_row_count));
+}
+
+void
+PCFactor::set_fill(Real fill)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetFill(this->pc, fill));
+}
+
+void
+PCFactor::set_levels(Int levels)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetLevels(this->pc, levels));
+}
+
+void
+PCFactor::set_mat_ordering_type(MatOrderingType ordering)
+{
+    CALL_STACK_MSG();
+    if (ordering == NATURAL)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERINGNATURAL));
+    else if (ordering == ND)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERINGND));
+    else if (ordering == ONE_WD)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERING1WD));
+    else if (ordering == RCM)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERINGRCM));
+    else if (ordering == QMD)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERINGQMD));
+    else if (ordering == ROW_LENGTH)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERINGROWLENGTH));
+    else if (ordering == WBM)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERINGWBM));
+    else if (ordering == SPECTRAL)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERINGSPECTRAL));
+    else if (ordering == AMD)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERINGAMD));
+    else if (ordering == METISND)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERINGMETISND));
+    else if (ordering == NATURAL_OR_ND)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERINGNATURAL_OR_ND));
+    else if (ordering == EXTERNAL)
+        PETSC_CHECK(PCFactorSetMatOrderingType(this->pc, MATORDERINGEXTERNAL));
+}
+
+void
+PCFactor::set_mat_solver_type(MatSolverType type)
+{
+    CALL_STACK_MSG();
+    if (type == SUPERLU)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERSUPERLU));
+    else if (type == SUPERLU_DIST)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERSUPERLU_DIST));
+    else if (type == STRUMPACK)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERSTRUMPACK));
+    else if (type == UMFPACK)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERUMFPACK));
+    else if (type == CHOLMOD)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERCHOLMOD));
+    else if (type == KLU)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERKLU));
+    else if (type == ELEMENTAL)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERELEMENTAL));
+    else if (type == SCALAPACK)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERSCALAPACK));
+    else if (type == ESSL)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERESSL));
+    else if (type == LUSOL)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERLUSOL));
+    else if (type == MUMPS)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERMUMPS));
+    else if (type == MKL_PARDISO)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERMKL_PARDISO));
+    else if (type == MKL_CPARDISO)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERMKL_CPARDISO));
+    else if (type == PASTIX)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERPASTIX));
+    else if (type == MATLAB)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERMATLAB));
+    else if (type == PETSC)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERPETSC));
+    else if (type == BAS)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERBAS));
+    else if (type == CUSPARSE)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERCUSPARSE));
+    else if (type == CUDA)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERCUDA));
+#if PETSC_VERSION_GE(3, 18, 0)
+    else if (type == HIPSPARSE)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERHIPSPARSE));
+    else if (type == HIP)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERHIP));
+#endif
+    else if (type == KOKKOS)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERKOKKOS));
+    else if (type == SPQR)
+        PETSC_CHECK(PCFactorSetMatSolverType(this->pc, MATSOLVERSPQR));
+}
+
+void
+PCFactor::set_pivot_in_blocks(bool pivot)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetPivotInBlocks(this->pc, pivot ? PETSC_TRUE : PETSC_FALSE));
+}
+
+void
+PCFactor::set_reuse_fill(bool flag)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetReuseFill(this->pc, flag ? PETSC_TRUE : PETSC_FALSE));
+}
+
+void
+PCFactor::set_reuse_ordering(bool flag)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetReuseOrdering(this->pc, flag ? PETSC_TRUE : PETSC_FALSE));
+}
+
+void
+PCFactor::set_shift_amount(Real shift_amount)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetShiftAmount(this->pc, shift_amount));
+}
+
+void
+PCFactor::set_shift_type(MatShiftType type)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetShiftType(this->pc, static_cast<MatFactorShiftType>(type)));
+}
+
+void
+PCFactor::set_up_mat_solver_type()
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetUpMatSolverType(this->pc));
+}
+
+void
+PCFactor::set_use_in_place(bool flg)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetUseInPlace(this->pc, flg ? PETSC_TRUE : PETSC_FALSE));
+}
+
+void
+PCFactor::set_zero_pivot(Real zero)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFactorSetZeroPivot(this->pc, zero));
+}
+
+} // namespace godzilla

--- a/src/PCFieldSplit.cpp
+++ b/src/PCFieldSplit.cpp
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "godzilla/PCFieldSplit.h"
+#include "godzilla/CallStack.h"
+#include "godzilla/Error.h"
+
+namespace godzilla {
+
+PCFieldSplit::PCFieldSplit() : Preconditioner()
+{
+    CALL_STACK_MSG();
+}
+
+PCFieldSplit::PCFieldSplit(PC pc) : Preconditioner(pc)
+{
+    CALL_STACK_MSG();
+    Preconditioner::set_type(PCFIELDSPLIT);
+}
+
+void
+PCFieldSplit::create(MPI_Comm comm)
+{
+    CALL_STACK_MSG();
+    Preconditioner::create(comm);
+    Preconditioner::set_type(PCFIELDSPLIT);
+}
+
+void
+PCFieldSplit::set_type(Type type)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetType(this->pc, static_cast<PCCompositeType>(type)));
+}
+
+PCFieldSplit::Type
+PCFieldSplit::get_type() const
+{
+    CALL_STACK_MSG();
+    PCCompositeType type;
+    PETSC_CHECK(PCFieldSplitGetType(this->pc, &type));
+    return static_cast<Type>(type);
+}
+
+bool
+PCFieldSplit::get_dm_splits() const
+{
+    CALL_STACK_MSG();
+    PetscBool flg;
+    PETSC_CHECK(PCFieldSplitGetDMSplits(this->pc, &flg));
+    return flg == PETSC_TRUE;
+}
+
+bool
+PCFieldSplit::get_detect_saddle_point() const
+{
+    CALL_STACK_MSG();
+    PetscBool flg;
+    PETSC_CHECK(PCFieldSplitGetDetectSaddlePoint(this->pc, &flg));
+    return flg == PETSC_TRUE;
+}
+
+bool
+PCFieldSplit::get_diag_use_amat() const
+{
+    CALL_STACK_MSG();
+    PetscBool flg;
+    PETSC_CHECK(PCFieldSplitGetDiagUseAmat(this->pc, &flg));
+    return flg == PETSC_TRUE;
+}
+
+IndexSet
+PCFieldSplit::get_is(const std::string & split_name) const
+{
+    CALL_STACK_MSG();
+    IS is;
+    PETSC_CHECK(PCFieldSplitGetIS(this->pc, split_name.c_str(), &is));
+    return IndexSet(is);
+}
+
+IndexSet
+PCFieldSplit::get_is_by_index(Int index) const
+{
+    CALL_STACK_MSG();
+    IS is;
+    PETSC_CHECK(PCFieldSplitGetISByIndex(this->pc, index, &is));
+    return IndexSet(is);
+}
+
+bool
+PCFieldSplit::get_off_diag_use_amat() const
+{
+    CALL_STACK_MSG();
+    PetscBool flg;
+    PETSC_CHECK(PCFieldSplitGetOffDiagUseAmat(this->pc, &flg));
+    return flg == PETSC_TRUE;
+}
+
+PCFieldSplit::SchurBlocks
+PCFieldSplit::get_schur_blocks() const
+{
+    CALL_STACK_MSG();
+    Mat A00, A01, A10, A11;
+    PETSC_CHECK(PCFieldSplitGetSchurBlocks(this->pc, &A00, &A01, &A10, &A11));
+    SchurBlocks blks(A00, A01, A10, A11);
+    return blks;
+}
+
+PCFieldSplit::SchurPC
+PCFieldSplit::get_schur_pre() const
+{
+    CALL_STACK_MSG();
+    PCFieldSplitSchurPreType ptype;
+    Mat pre;
+    PETSC_CHECK(PCFieldSplitGetSchurPre(this->pc, &ptype, &pre));
+    SchurPC spc(ptype, pre);
+    return spc;
+}
+
+std::vector<KrylovSolver>
+PCFieldSplit::get_sub_ksp() const
+{
+    CALL_STACK_MSG();
+    PetscInt n;
+    KSP * subksp;
+    PETSC_CHECK(PCFieldSplitGetSubKSP(this->pc, &n, &subksp));
+    std::vector<KrylovSolver> sks(n);
+    for (Int i = 0; i < n; i++)
+        sks[i] = KrylovSolver(subksp[i]);
+    PetscFree(subksp);
+    return sks;
+}
+
+Matrix
+PCFieldSplit::schur_get_s() const
+{
+    CALL_STACK_MSG();
+    Mat s;
+    PETSC_CHECK(PCFieldSplitSchurGetS(this->pc, &s));
+    return Matrix(s);
+}
+
+std::vector<KrylovSolver>
+PCFieldSplit::schur_get_sub_ksp() const
+{
+    CALL_STACK_MSG();
+    PetscInt n;
+    KSP * subksp;
+    PETSC_CHECK(PCFieldSplitSchurGetSubKSP(this->pc, &n, &subksp));
+    std::vector<KrylovSolver> sks(n);
+    for (Int i = 0; i < n; i++)
+        sks[i] = KrylovSolver(subksp[i]);
+    PetscFree(subksp);
+    return sks;
+}
+
+void
+PCFieldSplit::schur_restore_s(const Matrix & s)
+{
+    CALL_STACK_MSG();
+    Mat m = s;
+    PETSC_CHECK(PCFieldSplitSchurRestoreS(this->pc, &m));
+}
+
+void
+PCFieldSplit::set_block_size(Int bs)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetBlockSize(this->pc, bs));
+}
+
+void
+PCFieldSplit::set_dm_splits(bool flag)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetDMSplits(this->pc, flag ? PETSC_TRUE : PETSC_FALSE));
+}
+
+void
+PCFieldSplit::set_detect_saddle_point(bool flag)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetDetectSaddlePoint(this->pc, flag ? PETSC_TRUE : PETSC_FALSE));
+}
+
+void
+PCFieldSplit::set_diag_use_amat(bool flg)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetDiagUseAmat(this->pc, flg ? PETSC_TRUE : PETSC_FALSE));
+}
+
+void
+PCFieldSplit::set_fields(const std::string & split_name,
+                         const std::vector<Int> & fields,
+                         const std::vector<Int> & fields_col)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetFields(this->pc,
+                                      split_name.c_str(),
+                                      fields.size(),
+                                      fields.data(),
+                                      fields_col.data()));
+}
+
+void
+PCFieldSplit::set_gkb_delay(Int delay)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetGKBDelay(this->pc, delay));
+}
+
+void
+PCFieldSplit::set_gkb_maxit(Int maxit)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetGKBMaxit(this->pc, maxit));
+}
+
+void
+PCFieldSplit::set_gkb_nu(Real nu)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetGKBNu(this->pc, nu));
+}
+
+void
+PCFieldSplit::set_gkb_tol(Real tolerance)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetGKBTol(this->pc, tolerance));
+}
+
+void
+PCFieldSplit::set_is(const std::string & split_name, const IndexSet & is)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetIS(this->pc, split_name.c_str(), is));
+}
+
+void
+PCFieldSplit::set_off_diag_use_amat(bool flag)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetOffDiagUseAmat(this->pc, flag ? PETSC_TRUE : PETSC_FALSE));
+}
+
+void
+PCFieldSplit::set_schur_fact_type(PCFieldSplit::SchurFactType type)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(
+        PCFieldSplitSetSchurFactType(this->pc, static_cast<PCFieldSplitSchurFactType>(type)));
+}
+
+void
+PCFieldSplit::set_schur_pre(PCFieldSplit::SchurPreType ptype, const Matrix & pre)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(
+        PCFieldSplitSetSchurPre(this->pc, static_cast<PCFieldSplitSchurPreType>(ptype), pre));
+}
+
+void
+PCFieldSplit::set_schur_scale(Scalar scale)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCFieldSplitSetSchurScale(this->pc, scale));
+}
+
+} // namespace godzilla

--- a/src/PCHypre.cpp
+++ b/src/PCHypre.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "godzilla/PCHypre.h"
+#include "godzilla/CallStack.h"
+#include "godzilla/Error.h"
+
+namespace godzilla {
+
+PCHypre::PCHypre() : Preconditioner() {}
+
+PCHypre::PCHypre(PC pc) : Preconditioner(pc)
+{
+    CALL_STACK_MSG();
+    Preconditioner::set_type(PCHYPRE);
+}
+
+void
+PCHypre::create(MPI_Comm comm)
+{
+    CALL_STACK_MSG();
+    Preconditioner::create(comm);
+    Preconditioner::set_type(PCHYPRE);
+}
+
+void
+PCHypre::set_type(Type type)
+{
+    CALL_STACK_MSG();
+    if (type == EUCLID)
+        PETSC_CHECK(PCHYPRESetType(this->pc, "euclid"));
+    else if (type == PILUT)
+        PETSC_CHECK(PCHYPRESetType(this->pc, "pilut"));
+    else if (type == PARASAILS)
+        PETSC_CHECK(PCHYPRESetType(this->pc, "parasails"));
+    else if (type == BOOMERAMG)
+        PETSC_CHECK(PCHYPRESetType(this->pc, "boomeramg"));
+    else if (type == AMS)
+        PETSC_CHECK(PCHYPRESetType(this->pc, "ams"));
+    else if (type == ADS)
+        PETSC_CHECK(PCHYPRESetType(this->pc, "ads"));
+}
+
+PCHypre::Type
+PCHypre::get_type() const
+{
+    CALL_STACK_MSG();
+    const char * name;
+    PETSC_CHECK(PCHYPREGetType(this->pc, &name));
+    if (strcmp(name, "euclid") == 0)
+        return EUCLID;
+    else if (strcmp(name, "pilut") == 0)
+        return PILUT;
+    else if (strcmp(name, "parasails") == 0)
+        return PARASAILS;
+    else if (strcmp(name, "boomeramg") == 0)
+        return BOOMERAMG;
+    else if (strcmp(name, "ams") == 0)
+        return AMS;
+    else if (strcmp(name, "ads") == 0)
+        return ADS;
+    else
+        throw std::logic_error("Unknown type of HYPRE preconditioner.");
+}
+
+void
+PCHypre::ams_set_interior_nodes(const Vector & interior)
+{
+    CALL_STACK_MSG();
+#if PETSC_VERSION_GE(3, 18, 0)
+    PETSC_CHECK(PCHYPREAMSSetInteriorNodes(this->pc, interior));
+#endif
+}
+
+void
+PCHypre::set_alpha_poisson_matrix(const Matrix & A)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCHYPRESetAlphaPoissonMatrix(this->pc, A));
+}
+
+void
+PCHypre::set_beta_poisson_matrix(const Matrix & A)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCHYPRESetBetaPoissonMatrix(this->pc, A));
+}
+
+void
+PCHypre::set_discrete_curl(const Matrix & C)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCHYPRESetDiscreteCurl(this->pc, C));
+}
+
+void
+PCHypre::set_discrete_gradient(const Matrix & G)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCHYPRESetDiscreteGradient(this->pc, G));
+}
+
+void
+PCHypre::set_edge_constant_vectors(const Vector & oz, const Vector & zo)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCHYPRESetEdgeConstantVectors(this->pc, oz, zo, nullptr));
+}
+
+void
+PCHypre::set_edge_constant_vectors(const Vector & ozz, const Vector & zoz, const Vector & zzo)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCHYPRESetEdgeConstantVectors(this->pc, ozz, zoz, zzo));
+}
+
+} // namespace godzilla

--- a/src/PCJacobi.cpp
+++ b/src/PCJacobi.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "godzilla/PCJacobi.h"
+#include "godzilla/CallStack.h"
+#include "godzilla/Error.h"
+
+namespace godzilla {
+
+PCJacobi::PCJacobi() : Preconditioner()
+{
+    CALL_STACK_MSG();
+}
+
+PCJacobi::PCJacobi(PC pc) : Preconditioner(pc)
+{
+    CALL_STACK_MSG();
+    Preconditioner::set_type(PCJACOBI);
+}
+
+void
+PCJacobi::create(MPI_Comm comm)
+{
+    CALL_STACK_MSG();
+    Preconditioner::create(comm);
+    Preconditioner::set_type(PCJACOBI);
+}
+
+void
+PCJacobi::set_type(Type type)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCJacobiSetType(this->pc, static_cast<PCJacobiType>(type)));
+}
+
+PCJacobi::Type
+PCJacobi::get_type()
+{
+    CALL_STACK_MSG();
+    PCJacobiType type;
+    PETSC_CHECK(PCJacobiGetType(this->pc, &type));
+    return static_cast<Type>(type);
+}
+
+bool
+PCJacobi::get_fix_diagonal() const
+{
+    CALL_STACK_MSG();
+    PetscBool flag;
+    PETSC_CHECK(PCJacobiGetFixDiagonal(this->pc, &flag));
+    return flag == PETSC_TRUE;
+}
+
+bool
+PCJacobi::get_use_abs() const
+{
+    CALL_STACK_MSG();
+    PetscBool flag;
+    PETSC_CHECK(PCJacobiGetUseAbs(this->pc, &flag));
+    return flag == PETSC_TRUE;
+}
+
+void
+PCJacobi::set_fix_diagonal(bool flag)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCJacobiSetFixDiagonal(this->pc, flag ? PETSC_TRUE : PETSC_FALSE));
+}
+
+void
+PCJacobi::set_use_abs(bool flag)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCJacobiSetUseAbs(this->pc, flag ? PETSC_TRUE : PETSC_FALSE));
+}
+
+} // namespace godzilla

--- a/src/Preconditioner.cpp
+++ b/src/Preconditioner.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2023 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "godzilla/Preconditioner.h"
+#include "godzilla/CallStack.h"
+#include "godzilla/Error.h"
+
+namespace godzilla {
+
+Preconditioner::Preconditioner() : pc(nullptr)
+{
+    CALL_STACK_MSG();
+}
+
+Preconditioner::Preconditioner(PC pc) : pc(pc)
+{
+    CALL_STACK_MSG();
+}
+
+void
+Preconditioner::create(MPI_Comm comm)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCCreate(comm, &this->pc));
+}
+
+void
+Preconditioner::destroy()
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCDestroy(&this->pc));
+    this->pc = nullptr;
+}
+
+void
+Preconditioner::set_type(const std::string & type)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCSetType(this->pc, type.c_str()));
+}
+
+std::string
+Preconditioner::get_type() const
+{
+    CALL_STACK_MSG();
+    PCType type;
+    PETSC_CHECK(PCGetType(this->pc, &type));
+    return { type };
+}
+
+void
+Preconditioner::reset()
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCReset(this->pc));
+}
+
+void
+Preconditioner::set_up()
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCSetUp(this->pc));
+}
+
+void
+Preconditioner::set_operators(const Matrix & A, const Matrix & P)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCSetOperators(this->pc, A, P));
+}
+
+void
+Preconditioner::view(PetscViewer viewer) const
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(PCView(this->pc, viewer));
+}
+
+Preconditioner::operator PC() const
+{
+    CALL_STACK_MSG();
+    return this->pc;
+}
+
+} // namespace godzilla

--- a/test/src/FENonlinearProblemJFNK_test.cpp
+++ b/test/src/FENonlinearProblemJFNK_test.cpp
@@ -7,6 +7,7 @@
 #include "godzilla/JacobianFunc.h"
 #include "godzilla/ConstantInitialCondition.h"
 #include "godzilla/DirichletBC.h"
+#include "godzilla/PCFactor.h"
 
 using namespace godzilla;
 
@@ -23,7 +24,7 @@ protected:
     void set_up_fields() override;
     void set_up_weak_form() override;
     void set_up_solve_type() override;
-    void set_up_preconditioning() override;
+    Preconditioner create_preconditioner(PC pc) override;
 
     const Int iu;
 };
@@ -106,13 +107,12 @@ GTestFENonlinearProblemJFNK::set_up_solve_type()
     set_use_matrix_free(true, false);
 }
 
-void
-GTestFENonlinearProblemJFNK::set_up_preconditioning()
+Preconditioner
+GTestFENonlinearProblemJFNK::create_preconditioner(PC pc)
 {
-    auto ksp = get_ksp();
-    PC pc;
-    PETSC_CHECK(KSPGetPC(ksp, &pc));
-    PETSC_CHECK(PCSetType(pc, PCILU));
+    PCFactor p(pc);
+    p.set_type(PCFactor::ILU);
+    return p;
 }
 
 void

--- a/test/src/KrylovSolver_test.cpp
+++ b/test/src/KrylovSolver_test.cpp
@@ -3,6 +3,7 @@
 #include "godzilla/Matrix.h"
 #include "godzilla/Vector.h"
 #include "godzilla/LineMesh.h"
+#include "godzilla/PCHypre.h"
 #include "TestApp.h"
 
 using namespace godzilla;
@@ -263,4 +264,15 @@ TEST(KrylovSolver, ctor_ksp)
     EXPECT_EQ(static_cast<KSP>(ks), ksp);
 
     KSPDestroy(&ksp);
+}
+
+TEST(KrylovSolver, set_pc_type)
+{
+    TestApp app;
+    auto comm = app.get_comm();
+    KrylovSolver ks;
+    ks.create(comm);
+    Preconditioner pc = ks.set_pc_type<PCHypre>();
+    EXPECT_EQ(pc.get_type(), PCHYPRE);
+    ks.destroy();
 }

--- a/test/src/PCComposite_test.cpp
+++ b/test/src/PCComposite_test.cpp
@@ -1,0 +1,85 @@
+#include "gmock/gmock.h"
+#include "TestApp.h"
+#include "godzilla/PCComposite.h"
+#include "godzilla/PCJacobi.h"
+#include "godzilla/PCFactor.h"
+
+using namespace godzilla;
+using namespace testing;
+
+TEST(PCComposite, ctor_pc)
+{
+    TestApp app;
+    Preconditioner pc;
+    pc.create(app.get_comm());
+    PCComposite composite(pc);
+    EXPECT_EQ(pc.get_type(), PCCOMPOSITE);
+    pc.destroy();
+}
+
+TEST(PCComposite, type)
+{
+    std::vector<PCComposite::Type> types = { PCComposite::ADDITIVE,
+                                             PCComposite::MULTIPLICATIVE,
+                                             PCComposite::SYMMETRIC_MULTIPLICATIVE,
+                                             PCComposite::SPECIAL };
+    std::vector<std::string> type_str = { "ADDITIVE",
+                                          "MULTIPLICATIVE",
+                                          "SYMMETRIC_MULTIPLICATIVE",
+                                          "SPECIAL" };
+
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    for (auto & t : types) {
+        PCComposite pc;
+        pc.create(app.get_comm());
+        pc.set_type(t);
+        EXPECT_EQ(pc.get_type(), t);
+        pc.view();
+        pc.destroy();
+    }
+
+    auto o = testing::internal::GetCapturedStdout();
+    for (auto & t : type_str)
+        EXPECT_THAT(o, HasSubstr(t));
+}
+
+TEST(PCComposite, api)
+{
+    TestApp app;
+    auto comm = app.get_comm();
+
+    PCJacobi pc1;
+    pc1.create(comm);
+
+    PCFactor pc2;
+    pc2.create(comm);
+    pc2.set_type(PCFactor::ICC);
+
+    PCComposite composite;
+    composite.create(comm);
+    composite.set_type(PCComposite::ADDITIVE);
+    composite.add_pc(pc1);
+    composite.add_pc(pc2);
+
+    EXPECT_EQ(composite.get_number_pc(), 2);
+    Preconditioner sub_pc0 = composite.get_pc(0);
+    EXPECT_EQ(sub_pc0.get_type(), PCJACOBI);
+    Preconditioner sub_pc1 = composite.get_pc(1);
+    EXPECT_EQ(sub_pc1.get_type(), PCICC);
+
+    composite.destroy();
+}
+
+TEST(PCComposite, special_set_alpha)
+{
+    TestApp app;
+    auto comm = app.get_comm();
+    PCComposite composite;
+    composite.create(comm);
+    composite.set_type(PCComposite::SPECIAL);
+    composite.special_set_alpha(2.);
+    // TODO: how to test this was set?
+    composite.destroy();
+}

--- a/test/src/PCFactor_test.cpp
+++ b/test/src/PCFactor_test.cpp
@@ -1,0 +1,117 @@
+#include "gmock/gmock.h"
+#include "TestApp.h"
+#include "godzilla/PCFactor.h"
+
+using namespace godzilla;
+using namespace testing;
+
+TEST(PCFactor, ctor_pc)
+{
+    TestApp app;
+    Preconditioner pc;
+    pc.create(app.get_comm());
+    PCFactor factor(pc);
+    factor.set_type(PCFactor::ILU);
+    EXPECT_EQ(pc.get_type(), PCILU);
+    pc.destroy();
+}
+
+TEST(PCFactor, type)
+{
+    std::vector<PCFactor::Type> factor_types = { PCFactor::ICC,
+                                                 PCFactor::ILU,
+                                                 PCFactor::LU,
+                                                 PCFactor::CHOLESKY };
+    std::vector<std::string> factor_type_str = { PCICC, PCILU, PCLU, PCCHOLESKY };
+
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    for (auto & t : factor_types) {
+        PCFactor pc;
+        pc.create(app.get_comm());
+        pc.set_type(t);
+        EXPECT_EQ(pc.get_type(), t);
+        pc.view();
+        pc.destroy();
+    }
+
+    auto o = testing::internal::GetCapturedStdout();
+    for (auto & t : factor_type_str)
+        EXPECT_THAT(o, HasSubstr(t));
+}
+
+TEST(PCFactor, api)
+{
+    TestApp app;
+    PCFactor pc;
+    pc.create(app.get_comm());
+    pc.set_type(PCFactor::ILU);
+
+    pc.set_allow_diagonal_fill(true);
+    EXPECT_TRUE(pc.get_allow_diagonal_fill());
+
+    pc.set_levels(2);
+    EXPECT_EQ(pc.get_levels(), 2);
+
+    std::vector<PCFactor::MatShiftType> shift_type = { PCFactor::NONE,
+                                                       PCFactor::NONZERO,
+                                                       PCFactor::POSITIVE_DEFINITE,
+                                                       PCFactor::INBLOCKS };
+    for (auto & t : shift_type) {
+        pc.set_shift_type(t);
+        EXPECT_EQ(pc.get_shift_type(), t);
+    }
+
+    pc.set_shift_amount(0.1);
+    EXPECT_EQ(pc.get_shift_amount(), 0.1);
+
+    pc.set_use_in_place(true);
+    EXPECT_TRUE(pc.get_use_in_place());
+
+    pc.set_zero_pivot(0.1);
+    EXPECT_DOUBLE_EQ(pc.get_zero_pivot(), 0.1);
+
+    pc.destroy();
+}
+
+TEST(PCFactor, api2)
+{
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    auto comm = app.get_comm();
+    PCFactor pc;
+    pc.create(comm);
+    pc.set_type(PCFactor::ILU);
+    pc.set_mat_solver_type(PCFactor::PETSC);
+    EXPECT_EQ(pc.get_mat_solver_type(), PCFactor::PETSC);
+
+    auto A = Matrix::create_seq_aij(comm, 2, 2, 1);
+    A.set_value(0, 0, 1.);
+    A.set_value(1, 1, 1.);
+    A.assemble();
+    pc.set_operators(A, A);
+
+    pc.reorder_for_nonzero_diagonal(1.e-8);
+    pc.set_column_pivot(1.0);
+    pc.set_drop_tolerance(0.1, 0.05, 2);
+    pc.set_fill(2.5);
+    pc.set_mat_ordering_type(PCFactor::NATURAL);
+    pc.set_pivot_in_blocks(true);
+    pc.set_reuse_fill(true);
+    pc.set_reuse_ordering(true);
+    pc.set_up_mat_solver_type();
+
+    pc.view();
+
+    pc.destroy();
+
+    auto o = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(o, HasSubstr("Reusing fill from past factorization"));
+    EXPECT_THAT(o, HasSubstr("Reusing reordering from past factorization"));
+    EXPECT_THAT(o, HasSubstr("drop tolerance 0.1"));
+    EXPECT_THAT(o, HasSubstr("column permutation tolerance 0.05"));
+    EXPECT_THAT(o, HasSubstr("matrix ordering: natural"));
+    EXPECT_THAT(o, HasSubstr("matrix solver type: petsc"));
+}

--- a/test/src/PCFieldSplit_test.cpp
+++ b/test/src/PCFieldSplit_test.cpp
@@ -1,0 +1,268 @@
+#include "gmock/gmock.h"
+#include "TestApp.h"
+#include "GTestFENonlinearProblem.h"
+#include "godzilla/PCFieldSplit.h"
+#include "godzilla/LineMesh.h"
+
+using namespace godzilla;
+using namespace testing;
+
+TEST(PCFieldSplit, ctor_pc)
+{
+    TestApp app;
+    Preconditioner pc;
+    pc.create(app.get_comm());
+    PCFieldSplit fs(pc);
+    EXPECT_EQ(pc.get_type(), PCFIELDSPLIT);
+    pc.destroy();
+}
+
+TEST(PCFieldSplit, type)
+{
+    std::vector<PCFieldSplit::Type> types = { PCFieldSplit::ADDITIVE,
+                                              PCFieldSplit::COMPOSITE_MULTIPLICATIVE,
+                                              PCFieldSplit::SYMMETRIC_MULTIPLICATIVE,
+                                              PCFieldSplit::SPECIAL,
+                                              PCFieldSplit::SCHUR };
+    std::vector<std::string> type_str = { "ADDITIVE",
+                                          "MULTIPLICATIVE",
+                                          "SYMMETRIC_MULTIPLICATIVE",
+                                          "SPECIAL",
+                                          "Schur" };
+
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    for (auto & t : types) {
+        PCFieldSplit pc;
+        pc.create(app.get_comm());
+        pc.set_type(t);
+        EXPECT_EQ(pc.get_type(), t);
+        pc.view();
+        pc.destroy();
+    }
+
+    auto o = testing::internal::GetCapturedStdout();
+    for (auto & t : type_str)
+        EXPECT_THAT(o, HasSubstr(t));
+}
+
+TEST(PCFieldSplit, schur_fact_type)
+{
+    std::vector<PCFieldSplit::SchurFactType> types = { PCFieldSplit::SCHUR_FACT_DIAG,
+                                                       PCFieldSplit::SCHUR_FACT_LOWER,
+                                                       PCFieldSplit::SCHUR_FACT_UPPER,
+                                                       PCFieldSplit::SCHUR_FACT_FULL };
+    std::vector<std::string> type_str = { "DIAG", "LOWER", "UPPER", "FULL" };
+
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    PCFieldSplit pc;
+    pc.create(app.get_comm());
+    pc.set_type(PCFieldSplit::SCHUR);
+    for (auto & t : types) {
+        pc.set_schur_fact_type(t);
+        pc.view();
+    }
+    pc.destroy();
+
+    auto o = testing::internal::GetCapturedStdout();
+    for (auto & t : type_str)
+        EXPECT_THAT(o, HasSubstr(t));
+}
+
+TEST(PCFieldSplit, schur_pre_type)
+{
+    testing::internal::CaptureStdout();
+
+    std::vector<PCFieldSplit::SchurPreType> types = { PCFieldSplit::SCHUR_PRE_SELF,
+                                                      PCFieldSplit::SCHUR_PRE_A11,
+                                                      PCFieldSplit::SCHUR_PRE_USER,
+                                                      PCFieldSplit::SCHUR_PRE_FULL };
+    std::vector<std::string> type_str = { "S itself",
+                                          "A11",
+                                          "user provided matrix",
+                                          "the exact Schur complement" };
+
+    TestApp app;
+    auto comm = app.get_comm();
+    PCFieldSplit pc;
+    pc.create(comm);
+    pc.set_type(PCFieldSplit::SCHUR);
+    for (auto & t : types) {
+        Matrix pre = Matrix::create_seq_aij(comm, 3, 3, 1);
+        pc.set_schur_pre(t, pre);
+        pc.view();
+        pre.destroy();
+    }
+    pc.destroy();
+
+    auto o = testing::internal::GetCapturedStdout();
+    for (auto & t : type_str)
+        EXPECT_THAT(o, HasSubstr(t));
+}
+
+TEST(PCFieldSplit, schur_scale)
+{
+    TestApp app;
+    auto comm = app.get_comm();
+    PCFieldSplit pc;
+    pc.create(comm);
+    pc.set_type(PCFieldSplit::SCHUR);
+    pc.set_schur_scale(2.);
+    // NOTE: There is no easy way to check this, unless a system is solved
+    pc.destroy();
+}
+
+TEST(PCFieldSplit, detect_saddle_point)
+{
+    TestApp app;
+    PCFieldSplit pc;
+    pc.create(app.get_comm());
+    pc.set_type(PCFieldSplit::SCHUR);
+    pc.set_detect_saddle_point(true);
+    EXPECT_TRUE(pc.get_detect_saddle_point());
+    pc.destroy();
+}
+
+TEST(PCFieldSplit, block_size)
+{
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    PCFieldSplit pc;
+    pc.create(app.get_comm());
+    pc.set_block_size(2);
+    pc.view();
+    pc.destroy();
+
+    auto o = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(o, HasSubstr("blocksize = 2"));
+}
+
+TEST(PCFieldSplit, diag_use_amat)
+{
+    TestApp app;
+    PCFieldSplit pc;
+    pc.create(app.get_comm());
+    pc.set_diag_use_amat(true);
+    EXPECT_TRUE(pc.get_diag_use_amat());
+    pc.destroy();
+}
+
+TEST(PCFieldSplit, off_diag_use_amat)
+{
+    TestApp app;
+    PCFieldSplit pc;
+    pc.create(app.get_comm());
+    pc.set_off_diag_use_amat(true);
+    EXPECT_TRUE(pc.get_off_diag_use_amat());
+    pc.destroy();
+}
+
+TEST(PCFieldSplit, schur)
+{
+    TestApp app;
+    auto comm = app.get_comm();
+
+    Parameters * mesh_pars = app.get_parameters("LineMesh");
+    mesh_pars->set<Int>("nx") = 2;
+    auto mesh = app.build_object<LineMesh>("LineMesh", "mesh", mesh_pars);
+
+    Parameters * prob_pars = app.get_parameters("GTest2FieldsFENonlinearProblem");
+    prob_pars->set<Mesh *>("_mesh") = mesh;
+    auto prob =
+        app.build_object<FENonlinearProblem>("GTest2FieldsFENonlinearProblem", "prob", prob_pars);
+
+    mesh->create();
+    prob->create();
+
+    auto fdecomp = prob->create_field_decomposition();
+
+    auto ksp = prob->get_ksp();
+    PC pc;
+    KSPGetPC(ksp, &pc);
+
+    Matrix pre = Matrix::create_seq_aij(comm, 3, 3, 1);
+    for (Int i = 0; i < 3; i++)
+        pre.set_value(i, i, 2.);
+    pre.assemble();
+
+    PCFieldSplit fs(pc);
+    fs.set_type(PCFieldSplit::SCHUR);
+    fs.set_schur_fact_type(PCFieldSplit::SCHUR_FACT_FULL);
+    fs.set_schur_pre(PCFieldSplit::SCHUR_PRE_USER, pre);
+    fs.set_dm_splits(true);
+    EXPECT_TRUE(fs.get_dm_splits());
+    std::vector<std::string> fld_name = { "split0", "split1" };
+    for (PetscInt i = 0; i < fdecomp.get_num_fields(); i++)
+        fs.set_is(fld_name[i], fdecomp.is[i]);
+
+    auto is0 = fs.get_is("split0");
+    is0.get_indices();
+    EXPECT_THAT(is0.to_std_vector(), ElementsAre(0, 2, 4));
+    is0.restore_indices();
+    auto is1 = fs.get_is("split1");
+    is1.get_indices();
+    EXPECT_THAT(is1.to_std_vector(), ElementsAre(1, 3, 5));
+    is1.restore_indices();
+
+    auto is_idx0 = fs.get_is_by_index(0);
+    is_idx0.get_indices();
+    EXPECT_THAT(is_idx0.to_std_vector(), ElementsAre(0, 2, 4));
+    is_idx0.restore_indices();
+    auto is_idx1 = fs.get_is_by_index(1);
+    is_idx1.get_indices();
+    EXPECT_THAT(is_idx1.to_std_vector(), ElementsAre(1, 3, 5));
+    is_idx1.restore_indices();
+
+    auto J = prob->get_jacobian();
+    fs.set_operators(J, J);
+    fs.set_up();
+
+    auto sub_ksp = fs.get_sub_ksp();
+    ASSERT_EQ(sub_ksp.size(), 2);
+
+    auto schur_sub_ksp = fs.schur_get_sub_ksp();
+    ASSERT_EQ(schur_sub_ksp.size(), 2);
+
+    auto schur_blks = fs.get_schur_blocks();
+    EXPECT_EQ(schur_blks.A00.get_n_cols(), 3);
+    EXPECT_EQ(schur_blks.A00.get_n_rows(), 3);
+
+    EXPECT_EQ(schur_blks.A01.get_n_cols(), 3);
+    EXPECT_EQ(schur_blks.A01.get_n_rows(), 3);
+
+    EXPECT_EQ(schur_blks.A10.get_n_cols(), 3);
+    EXPECT_EQ(schur_blks.A10.get_n_rows(), 3);
+
+    EXPECT_EQ(schur_blks.A11.get_n_cols(), 3);
+    EXPECT_EQ(schur_blks.A11.get_n_rows(), 3);
+
+    auto schur_pc = fs.get_schur_pre();
+    EXPECT_EQ(schur_pc.type, PCFieldSplit::SCHUR_PRE_USER);
+    for (Int i = 0; i < 3; i++)
+        EXPECT_DOUBLE_EQ(schur_pc.matrix.get_value(i, i), 2.);
+
+    auto s = fs.schur_get_s();
+    EXPECT_EQ(s.get_type(), MATSCHURCOMPLEMENT);
+    fs.schur_restore_s(s);
+
+    fdecomp.destroy();
+}
+
+TEST(PCFieldSplit, gbk)
+{
+    TestApp app;
+    PCFieldSplit pc;
+    pc.create(app.get_comm());
+    pc.set_type(PCFieldSplit::GBK);
+    pc.set_gkb_delay(2);
+    pc.set_gkb_maxit(3);
+    pc.set_gkb_nu(0.1);
+    pc.set_gkb_tol(1e-5);
+    // NOTE: pc.view() causes a segfault
+    // pc.view();
+    pc.destroy();
+}

--- a/test/src/PCHypre_test.cpp
+++ b/test/src/PCHypre_test.cpp
@@ -1,0 +1,177 @@
+#include "gmock/gmock.h"
+#include "TestApp.h"
+#include "godzilla/PCHypre.h"
+#include "godzilla/Vector.h"
+#include "godzilla/Matrix.h"
+
+using namespace godzilla;
+using namespace testing;
+
+TEST(PCHypre, ctor_pc)
+{
+    TestApp app;
+    Preconditioner pc;
+    pc.create(app.get_comm());
+    PCHypre hypre(pc);
+    EXPECT_EQ(pc.get_type(), PCHYPRE);
+    pc.destroy();
+}
+
+TEST(PCHypre, boomeramg)
+{
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    PCHypre pc;
+    pc.create(app.get_comm());
+    pc.set_type(PCHypre::BOOMERAMG);
+    EXPECT_EQ(pc.get_type(), PCHypre::BOOMERAMG);
+    pc.view();
+    pc.destroy();
+
+    auto o = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(o, HasSubstr("type: hypre"));
+    EXPECT_THAT(o, HasSubstr("HYPRE BoomerAMG preconditioning"));
+}
+
+TEST(PCHypre, set_type)
+{
+    TestApp app;
+    std::vector<PCHypre::Type> hypre_types = { PCHypre::PILUT,
+                                               PCHypre::PARASAILS,
+                                               PCHypre::BOOMERAMG,
+                                               PCHypre::AMS,
+                                               PCHypre::ADS };
+    for (auto & t : hypre_types) {
+        PCHypre pc;
+        pc.create(app.get_comm());
+        pc.set_type(t);
+        EXPECT_EQ(pc.get_type(), t);
+        pc.destroy();
+    }
+}
+
+#if PETSC_VERSION_GE(3, 18, 0)
+TEST(PCHypre, ams_set_interior_nodes)
+{
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    auto comm = app.get_comm();
+    PCHypre pc;
+    pc.create(comm);
+    pc.set_type(PCHypre::AMS);
+    auto interior = Vector::create_seq(comm, 3);
+    interior.set_values({ 0, 1, 2 }, { 1, 0, 1 });
+    pc.ams_set_interior_nodes(interior);
+    pc.view();
+    pc.destroy();
+
+    auto o = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(o, HasSubstr("compatible subspace projection frequency 0"));
+}
+#endif
+
+TEST(PCHypre, set_alpha_poisson_matrix)
+{
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    auto comm = app.get_comm();
+    PCHypre pc;
+    pc.create(comm);
+    pc.set_type(PCHypre::AMS);
+    auto A = Matrix::create_seq_aij(comm, 2, 2, 1);
+    A.set_value(0, 0, 1.);
+    A.set_value(1, 1, 1.);
+    A.assemble();
+    pc.set_alpha_poisson_matrix(A);
+    pc.view();
+    pc.destroy();
+
+    auto o = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(o, HasSubstr("vector Poisson solver (passed in by user)"));
+}
+
+TEST(PCHypre, set_beta_poisson_matrix)
+{
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    auto comm = app.get_comm();
+    PCHypre pc;
+    pc.create(comm);
+    pc.set_type(PCHypre::AMS);
+    auto A = Matrix::create_seq_aij(comm, 2, 2, 1);
+    A.set_value(0, 0, 1.);
+    A.set_value(1, 1, 1.);
+    A.assemble();
+    pc.set_beta_poisson_matrix(A);
+    pc.view();
+    pc.destroy();
+
+    auto o = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(o, HasSubstr("scalar Poisson solver (passed in by user)"));
+}
+
+TEST(PCHypre, set_discrete_curl)
+{
+    TestApp app;
+    auto comm = app.get_comm();
+    PCHypre pc;
+    pc.create(comm);
+    pc.set_type(PCHypre::AMS);
+    auto C = Matrix::create_seq_aij(comm, 2, 2, 1);
+    C.set_value(0, 0, 1.);
+    C.set_value(1, 1, 1.);
+    C.assemble();
+    pc.set_discrete_curl(C);
+    pc.destroy();
+}
+
+TEST(PCHypre, set_discrete_gradient)
+{
+    TestApp app;
+    auto comm = app.get_comm();
+    PCHypre pc;
+    pc.create(comm);
+    pc.set_type(PCHypre::AMS);
+    auto G = Matrix::create_seq_aij(comm, 2, 2, 1);
+    G.set_value(0, 0, 1.);
+    G.set_value(1, 1, 1.);
+    G.assemble();
+    pc.set_discrete_gradient(G);
+    pc.destroy();
+}
+
+TEST(PCHypre, set_edge_constant_vectors_2d)
+{
+    TestApp app;
+    auto comm = app.get_comm();
+    PCHypre pc;
+    pc.create(comm);
+    pc.set_type(PCHypre::AMS);
+    auto v0 = Vector::create_seq(comm, 2);
+    v0.set_values({ 0, 1 }, { 1, 0 });
+    auto v1 = Vector::create_seq(comm, 2);
+    v1.set_values({ 0, 1 }, { 0, 1 });
+    pc.set_edge_constant_vectors(v0, v1);
+    pc.destroy();
+}
+
+TEST(PCHypre, set_edge_constant_vectors_3d)
+{
+    TestApp app;
+    auto comm = app.get_comm();
+    PCHypre pc;
+    pc.create(comm);
+    pc.set_type(PCHypre::AMS);
+    auto v0 = Vector::create_seq(comm, 3);
+    v0.set_values({ 0, 1, 2 }, { 1, 0, 0 });
+    auto v1 = Vector::create_seq(comm, 3);
+    v1.set_values({ 0, 1, 2 }, { 0, 1, 0 });
+    auto v2 = Vector::create_seq(comm, 3);
+    v2.set_values({ 0, 1, 2 }, { 0, 0, 1 });
+    pc.set_edge_constant_vectors(v0, v1, v2);
+    pc.destroy();
+}

--- a/test/src/PCJacobi_test.cpp
+++ b/test/src/PCJacobi_test.cpp
@@ -1,0 +1,56 @@
+#include "gmock/gmock.h"
+#include "TestApp.h"
+#include "godzilla/PCJacobi.h"
+
+using namespace godzilla;
+using namespace testing;
+
+TEST(PCJacobi, ctor_pc)
+{
+    TestApp app;
+    Preconditioner pc;
+    pc.create(app.get_comm());
+    PCJacobi jacobi(pc);
+    EXPECT_EQ(pc.get_type(), PCJACOBI);
+    pc.destroy();
+}
+
+TEST(PCJacobi, type)
+{
+    std::vector<PCJacobi::Type> jacobi_types = { PCJacobi::DIAGONAL,
+                                                 PCJacobi::ROWMAX,
+                                                 PCJacobi::ROWSUM };
+    std::vector<std::string> jacobi_type_str = { "DIAGONAL", "ROWMAX", "ROWSUM" };
+
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    for (auto & t : jacobi_types) {
+        PCJacobi pc;
+        pc.create(app.get_comm());
+        pc.set_type(t);
+        EXPECT_EQ(pc.get_type(), t);
+        pc.view();
+        pc.destroy();
+    }
+
+    auto o = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(o, HasSubstr("type: jacobi"));
+    for (auto & t : jacobi_type_str)
+        EXPECT_THAT(o, HasSubstr(t));
+}
+
+TEST(PCJacobi, api)
+{
+    TestApp app;
+    PCJacobi pc;
+    pc.create(app.get_comm());
+
+    pc.set_fix_diagonal(true);
+    EXPECT_EQ(pc.get_fix_diagonal(), true);
+
+    pc.set_use_abs(true);
+    EXPECT_EQ(pc.get_use_abs(), true);
+
+    pc.destroy();
+}

--- a/test/src/Preconditioner_test.cpp
+++ b/test/src/Preconditioner_test.cpp
@@ -1,0 +1,85 @@
+#include "gmock/gmock.h"
+#include "TestApp.h"
+#include "godzilla/Preconditioner.h"
+#include "godzilla/Matrix.h"
+
+using namespace godzilla;
+using namespace testing;
+
+TEST(Preconditioner, type)
+{
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+
+    Preconditioner pc;
+    pc.create(app.get_comm());
+    pc.set_type(PCICC);
+    EXPECT_EQ(pc.get_type(), PCICC);
+    pc.view();
+    auto o = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(o, HasSubstr("type: icc"));
+    pc.destroy();
+}
+
+TEST(Preconditioner, set_up)
+{
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    auto comm = app.get_comm();
+
+    Preconditioner pc;
+    pc.create(comm);
+    pc.set_type(PCILU);
+    Matrix A = Matrix::create_seq_aij(comm, 3, 3, 1);
+    A.set_value(0, 0, 1.);
+    A.set_value(1, 1, 1.);
+    A.set_value(2, 2, 1.);
+    A.assemble();
+    pc.set_operators(A, A);
+    pc.set_up();
+    pc.view();
+
+    auto o = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(o, HasSubstr("linear system matrix = precond matrix:"));
+
+    pc.destroy();
+}
+
+TEST(Preconditioner, reset)
+{
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+    auto comm = app.get_comm();
+
+    Preconditioner pc;
+    pc.create(comm);
+    pc.set_type(PCILU);
+    Matrix A = Matrix::create_seq_aij(comm, 3, 3, 1);
+    A.set_value(0, 0, 1.);
+    A.set_value(1, 1, 1.);
+    A.set_value(2, 2, 1.);
+    A.assemble();
+    pc.set_operators(A, A);
+    pc.set_up();
+    pc.reset();
+    pc.view();
+
+    auto o = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(o, HasSubstr("PC has not been set up so information may be incomplete"));
+
+    pc.destroy();
+}
+
+TEST(Preconditioner, oper_pc)
+{
+    TestApp app;
+
+    Preconditioner pc;
+    pc.create(app.get_comm());
+    PCSetType(pc, PCICC);
+    EXPECT_EQ(pc.get_type(), PCICC);
+    pc.destroy();
+}


### PR DESCRIPTION
- Changing the API for creating preconditioners
- Adding PCFactor preconditioner
- Adding PCHypre preconditioner
- Adding PCComposite preconditioner
- Adding PCJacobi preconditioner
- Adding PCFieldSplit preconditioner
- Adding KrylovSolver::set_pc_type
- Updating incompressible NS example to use the new preconditioner API
