### PR TITLE
Changing behavior of IndexSet::Iterator()

### DIFF
--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -3,6 +3,7 @@
 
 #include "godzilla/IndexSet.h"
 #include "godzilla/Error.h"
+#include "godzilla/Exception.h"
 #include "godzilla/CallStack.h"
 #include <cassert>
 
@@ -10,13 +11,11 @@ namespace godzilla {
 
 IndexSet::Iterator::Iterator(IndexSet & is, Int idx) : is(is), idx(idx)
 {
-    this->is.get_indices();
+    if (this->is.data() == nullptr)
+        throw Exception("Must call IndexSet::get_indices() first.");
 }
 
-IndexSet::Iterator::~Iterator()
-{
-    this->is.restore_indices();
-}
+IndexSet::Iterator::~Iterator() {}
 
 const IndexSet::Iterator::value_type &
 IndexSet::Iterator::operator*() const

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -100,6 +100,7 @@ IndexSet::restore_indices()
     CALL_STACK_MSG();
     assert(this->is != nullptr);
     PETSC_CHECK(ISRestoreIndices(this->is, &this->indices));
+    this->indices = nullptr;
 }
 
 void

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -70,6 +70,7 @@ TEST(IndexSetTest, sort)
     EXPECT_THAT(idx, ElementsAreArray({ 1, 3, 5, 8 }));
     is.restore_indices();
     EXPECT_EQ(is.sorted(), true);
+    is.destroy();
 }
 
 TEST(IndexSetTest, sort_remove_dups)
@@ -82,6 +83,7 @@ TEST(IndexSetTest, sort_remove_dups)
     EXPECT_THAT(idx, ElementsAreArray({ 1, 3, 5, 8 }));
     is.restore_indices();
     EXPECT_EQ(is.sorted(), true);
+    is.destroy();
 }
 
 TEST(IndexSetTest, intersect_caching)
@@ -105,6 +107,7 @@ TEST(IndexSetTest, intersect_caching_empty)
     IndexSet is2;
     IndexSet isect = IndexSet::intersect_caching(is1, is2);
     EXPECT_TRUE(isect.empty());
+    isect.destroy();
 }
 
 TEST(IndexSetTest, intersect)
@@ -132,6 +135,7 @@ TEST(IndexSetTest, range)
         vals.push_back(i);
     EXPECT_THAT(vals, ElementsAre(1, 3, 4, 5, 8, 10));
     is.restore_indices();
+    is.destroy();
 }
 
 TEST(IndexSetTest, for_loop)
@@ -144,6 +148,7 @@ TEST(IndexSetTest, for_loop)
         vals.push_back(*i);
     EXPECT_THAT(vals, ElementsAre(1, 3, 4, 5, 8, 10));
     is.restore_indices();
+    is.destroy();
 }
 
 TEST(IndexSetTest, iters)
@@ -156,6 +161,7 @@ TEST(IndexSetTest, iters)
         ;
     EXPECT_TRUE(iter == is.end());
     is.restore_indices();
+    is.destroy();
 }
 
 TEST(IndexSetTest, view)
@@ -170,4 +176,5 @@ TEST(IndexSetTest, view)
     EXPECT_THAT(out, HasSubstr("1 5"));
     EXPECT_THAT(out, HasSubstr("2 8"));
     EXPECT_THAT(out, HasSubstr("3 10"));
+    is.destroy();
 }

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -126,31 +126,36 @@ TEST(IndexSetTest, range)
 {
     TestApp app;
     auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    is.get_indices();
     std::vector<Int> vals;
     for (auto & i : is)
         vals.push_back(i);
     EXPECT_THAT(vals, ElementsAre(1, 3, 4, 5, 8, 10));
+    is.restore_indices();
 }
 
 TEST(IndexSetTest, for_loop)
 {
     TestApp app;
     auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    is.get_indices();
     std::vector<Int> vals;
     for (auto i = is.begin(); i != is.end(); i++)
         vals.push_back(*i);
     EXPECT_THAT(vals, ElementsAre(1, 3, 4, 5, 8, 10));
+    is.restore_indices();
 }
 
 TEST(IndexSetTest, iters)
 {
     TestApp app;
     auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
-
+    is.get_indices();
     auto iter = is.begin();
     for (int i = 0; i < 6; i++, iter++)
         ;
     EXPECT_TRUE(iter == is.end());
+    is.restore_indices();
 }
 
 TEST(IndexSetTest, view)


### PR DESCRIPTION
- IndexSet::restore_indices() sets internal pointer to indices to nullptr
- IndexSet::Iterator() assumes that users called {get|restore}_indices() themselves
- Adding missing calls to destroy() in IndexSet test
