### PR TITLE
Adding non-const API to get solution vectors

### DIFF
--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -232,6 +232,11 @@ public:
     /// @return Local auxiliary solution vector
     const Vector & get_aux_solution_vector_local() const;
 
+    /// Get local auxiliary solution vector
+    ///
+    /// @return Local auxiliary solution vector
+    Vector & get_aux_solution_vector_local();
+
     void add_boundary(DMBoundaryConditionType type,
                       const std::string & name,
                       const Label & label,

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -227,6 +227,11 @@ public:
     /// @return Local solution vector
     const Vector & get_solution_vector_local() const;
 
+    /// Get local solution vector
+    ///
+    /// @return Local solution vector
+    Vector & get_solution_vector_local();
+
     /// Get local auxiliary solution vector
     ///
     /// @return Local auxiliary solution vector

--- a/include/godzilla/ExplicitProblemInterface.h
+++ b/include/godzilla/ExplicitProblemInterface.h
@@ -23,6 +23,8 @@ public:
 
     const Vector & get_lumped_mass_matrix() const;
 
+    Vector & get_lumped_mass_matrix();
+
     virtual PetscErrorCode compute_rhs(Real time, const Vector & x, Vector & F);
 
 protected:

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -525,6 +525,13 @@ DiscreteProblemInterface::get_aux_solution_vector_local() const
     return this->a;
 }
 
+Vector &
+DiscreteProblemInterface::get_aux_solution_vector_local()
+{
+    CALL_STACK_MSG();
+    return this->a;
+}
+
 void
 DiscreteProblemInterface::add_boundary(DMBoundaryConditionType type,
                                        const std::string & name,

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -150,6 +150,13 @@ DiscreteProblemInterface::get_solution_vector_local() const
     return this->sln;
 }
 
+Vector &
+DiscreteProblemInterface::get_solution_vector_local()
+{
+    CALL_STACK_MSG();
+    return this->sln;
+}
+
 const std::vector<BoundaryCondition *> &
 DiscreteProblemInterface::get_boundary_conditions() const
 {

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -124,7 +124,7 @@ void
 ExplicitFELinearProblem::compute_solution_vector_local()
 {
     CALL_STACK_MSG();
-    auto loc_sln = get_solution_vector_local();
+    auto & loc_sln = get_solution_vector_local();
     PETSC_CHECK(DMGlobalToLocal(get_dm(), get_solution_vector(), INSERT_VALUES, loc_sln));
     compute_boundary_local(get_time(), loc_sln);
 }

--- a/src/ExplicitProblemInterface.cpp
+++ b/src/ExplicitProblemInterface.cpp
@@ -65,6 +65,13 @@ ExplicitProblemInterface::get_lumped_mass_matrix() const
     return this->M_lumped_inv;
 }
 
+Vector &
+ExplicitProblemInterface::get_lumped_mass_matrix()
+{
+    CALL_STACK_MSG();
+    return this->M_lumped_inv;
+}
+
 void
 ExplicitProblemInterface::check()
 {


### PR DESCRIPTION
- Adding non-const version of DiscreteProblemInterface::get_aux_solution_vector_local
- Adding non-const version of ExplicitProblemInterface::get_lumped_mass_matrix
- Adding non-const version of DiscreteProblemInterface::get_solution_vector_local
- Get local solution vector as a reference
