### PR TITLE
Using C++17 for tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(godzilla-test)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 file(GLOB SRCS CONFIGURE_DEPENDS src/*.cpp)


### PR DESCRIPTION
We already use C++17 for the main library, so just bump this.
