### PR TITLE
More const correctness

### DIFF
--- a/include/godzilla/AuxiliaryField.h
+++ b/include/godzilla/AuxiliaryField.h
@@ -41,7 +41,7 @@ public:
 
     [[nodiscard]] virtual PetscFunc * get_func() const = 0;
 
-    virtual void * get_context();
+    virtual const void * get_context() const;
 
     virtual void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) = 0;
 

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -323,7 +323,7 @@ protected:
     /// Create underlying PetscDS object
     void create_ds();
     /// Get underlying PetscDS object
-    PetscDS get_ds();
+    PetscDS get_ds() const;
     /// Set up discrete system
     virtual void set_up_ds() = 0;
 

--- a/include/godzilla/EssentialBC.h
+++ b/include/godzilla/EssentialBC.h
@@ -51,7 +51,7 @@ public:
     virtual PetscFunc * get_function_t();
 
     /// Get the pointer to the context that will be passed into PETSc API
-    virtual void * get_context();
+    virtual const void * get_context() const;
 
     void set_up() override;
 

--- a/include/godzilla/InitialCondition.h
+++ b/include/godzilla/InitialCondition.h
@@ -27,7 +27,7 @@ public:
     virtual PetscFunc * get_function();
 
     /// Get the pointer to the context that will be passed into PETSc API
-    virtual void * get_context();
+    virtual const void * get_context() const;
 
     /// Evaluate the initial condition
     ///

--- a/include/godzilla/PCComposite.h
+++ b/include/godzilla/PCComposite.h
@@ -33,7 +33,7 @@ public:
 
     /// Gets the type of composite preconditioner
     ///
-    Type get_type();
+    Type get_type() const;
 
     /// Adds another PC to the composite PC.
     ///

--- a/include/godzilla/PCFactor.h
+++ b/include/godzilla/PCFactor.h
@@ -78,7 +78,7 @@ public:
     /// Get the precoditioner type
     ///
     /// @return Preconditioner type
-    Type get_type();
+    Type get_type() const;
 
     /// Determines if all diagonal matrix entries are treated as level 0 fill even if there is no
     /// non-zero location

--- a/include/godzilla/PCJacobi.h
+++ b/include/godzilla/PCJacobi.h
@@ -32,7 +32,7 @@ public:
     /// Gets how the diagonal matrix is produced for the preconditioner
     ///
     /// @return How the diagonal matrix is produced
-    Type get_type();
+    Type get_type() const;
 
     /// Determines if the preconditioner checks for zero diagonal terms
     ///

--- a/include/godzilla/ParsedFunction.h
+++ b/include/godzilla/ParsedFunction.h
@@ -34,7 +34,7 @@ public:
     virtual PetscFunc * get_function();
 
     /// Get the pointer to the context that will be passed into PETSc API
-    virtual void * get_context();
+    virtual const void * get_context() const;
 
 private:
     /// Text representation of the function to evaluate (one per component)

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -93,8 +93,8 @@ AuxiliaryField::get_field_id() const
         return this->dpi->get_aux_field_id(this->get_name());
 }
 
-void *
-AuxiliaryField::get_context()
+const void *
+AuxiliaryField::get_context() const
 {
     CALL_STACK_MSG();
     return this;

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -487,7 +487,7 @@ DiscreteProblemInterface::set_initial_guess_from_ics()
     for (auto & ic : this->ics) {
         Int fid = ic->get_field_id();
         ic_funcs[fid] = ic->get_function();
-        ic_ctxs[fid] = ic->get_context();
+        ic_ctxs[fid] = const_cast<void *>(ic->get_context());
     }
 
     PETSC_CHECK(DMProjectFunction(this->unstr_mesh->get_dm(),

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -389,7 +389,7 @@ DiscreteProblemInterface::compute_global_aux_fields(DM dm,
     for (const auto & aux : auxs) {
         Int fid = aux->get_field_id();
         func[fid] = aux->get_func();
-        ctxs[fid] = aux->get_context();
+        ctxs[fid] = const_cast<void *>(aux->get_context());
     }
 
     PETSC_CHECK(DMProjectFunctionLocal(dm,
@@ -414,7 +414,7 @@ DiscreteProblemInterface::compute_label_aux_fields(DM dm,
     for (const auto & aux : auxs) {
         Int fid = aux->get_field_id();
         func[fid] = aux->get_func();
-        ctxs[fid] = aux->get_context();
+        ctxs[fid] = const_cast<void *>(aux->get_context());
     }
 
     auto ids = label.get_value_index_set();

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -219,7 +219,7 @@ DiscreteProblemInterface::create_ds()
 }
 
 PetscDS
-DiscreteProblemInterface::get_ds()
+DiscreteProblemInterface::get_ds() const
 {
     CALL_STACK_MSG();
     return this->ds;

--- a/src/EssentialBC.cpp
+++ b/src/EssentialBC.cpp
@@ -100,8 +100,8 @@ EssentialBC::get_function_t()
     return essential_boundary_condition_function_t;
 }
 
-void *
-EssentialBC::get_context()
+const void *
+EssentialBC::get_context() const
 {
     CALL_STACK_MSG();
     return this;

--- a/src/InitialCondition.cpp
+++ b/src/InitialCondition.cpp
@@ -86,8 +86,8 @@ InitialCondition::get_function()
     return initial_condition_function;
 }
 
-void *
-InitialCondition::get_context()
+const void *
+InitialCondition::get_context() const
 {
     CALL_STACK_MSG();
     return this;

--- a/src/L2FieldDiff.cpp
+++ b/src/L2FieldDiff.cpp
@@ -84,7 +84,7 @@ L2FieldDiff::compute()
         ParsedFunction * pfn = it.second;
 
         pfns[fid] = pfn->get_function();
-        ctxs[fid] = pfn->get_context();
+        ctxs[fid] = const_cast<void *>(pfn->get_context());
     }
 
     auto * problem = get_problem();

--- a/src/PCComposite.cpp
+++ b/src/PCComposite.cpp
@@ -34,7 +34,7 @@ PCComposite::set_type(Type type)
 }
 
 PCComposite::Type
-PCComposite::get_type()
+PCComposite::get_type() const
 {
     CALL_STACK_MSG();
     PCCompositeType type;

--- a/src/PCFactor.cpp
+++ b/src/PCFactor.cpp
@@ -32,7 +32,7 @@ PCFactor::set_type(Type type)
 }
 
 PCFactor::Type
-PCFactor::get_type()
+PCFactor::get_type() const
 {
     CALL_STACK_MSG();
     const char * name;

--- a/src/PCJacobi.cpp
+++ b/src/PCJacobi.cpp
@@ -34,7 +34,7 @@ PCJacobi::set_type(Type type)
 }
 
 PCJacobi::Type
-PCJacobi::get_type()
+PCJacobi::get_type() const
 {
     CALL_STACK_MSG();
     PCJacobiType type;

--- a/src/ParsedFunction.cpp
+++ b/src/ParsedFunction.cpp
@@ -56,8 +56,8 @@ ParsedFunction::get_function()
     return parsed_function;
 }
 
-void *
-ParsedFunction::get_context()
+const void *
+ParsedFunction::get_context() const
 {
     CALL_STACK_MSG();
     return this;


### PR DESCRIPTION
- AuxiliaryField::get_context is const
- DiscreteProblemInterface::get_ds() is const
- EssentialBC::get_context() is const
- InitialCondition::get_context is const
- ParsedFunction::get_context() is const
- PCComposite::get_type() is const
- PCFactor::get_type() is const
- PCJacobi::get_type() is const
