### PR TITLE
CALL_STACK_MSG() creates call stack entries only in debug configurations

### DIFF
--- a/include/godzilla/CallStack.h
+++ b/include/godzilla/CallStack.h
@@ -9,6 +9,11 @@
 namespace godzilla {
 namespace internal {
 
+#if defined(NDEBUG)
+    // In Release builds these macros do nothing
+    #define CALL_STACK_MSG(...)
+    #define _F_
+#else
 /// Place at the beginning of a method/function
 ///
 /// @code
@@ -18,27 +23,28 @@ namespace internal {
 ///  ...your code here...
 /// }
 /// @endcode
-#define _F_ godzilla::internal::CallStack::Msg __call_stack_msg(__PRETTY_FUNCTION__)
+    #define _F_ godzilla::internal::CallStack::Msg __call_stack_msg(__PRETTY_FUNCTION__)
 
-#define CALL_STK_MSG0() godzilla::internal::CallStack::Msg __call_stack_msg(__PRETTY_FUNCTION__)
-#define CALL_STK_MSG1(fmt) godzilla::internal::CallStack::Msg __call_stack_msg(fmt)
-#define CALL_STK_MSG2(fmt, p1) godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1)
-#define CALL_STK_MSG3(fmt, p1, p2) godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2)
-#define CALL_STK_MSG4(fmt, p1, p2, p3) \
-    godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3)
-#define CALL_STK_MSG5(fmt, p1, p2, p3, p4) \
-    godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4)
-#define CALL_STK_MSG6(fmt, p1, p2, p3, p4, p5) \
-    godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4, p5)
-#define CALL_STK_MSG7(fmt, p1, p2, p3, p4, p5, p6) \
-    godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4, p5, p6)
-#define CALL_STK_MSG8(fmt, p1, p2, p3, p4, p5, p6, p7) \
-    godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4, p5, p6, p7)
-#define CALL_STK_MSG9(fmt, p1, p2, p3, p4, p5, p6, p7, p8) \
-    godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4, p5, p6, p7, p8)
-#define CALL_STK_MSG10(fmt, p1, p2, p3, p4, p5, p6, p7, p8, p9) \
-    godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4, p5, p6, p7, p8, p9)
-#define GET_CALL_STK_MACRO(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, NAME, ...) NAME
+    #define CALL_STK_MSG0() godzilla::internal::CallStack::Msg __call_stack_msg(__PRETTY_FUNCTION__)
+    #define CALL_STK_MSG1(fmt) godzilla::internal::CallStack::Msg __call_stack_msg(fmt)
+    #define CALL_STK_MSG2(fmt, p1) godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1)
+    #define CALL_STK_MSG3(fmt, p1, p2) \
+        godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2)
+    #define CALL_STK_MSG4(fmt, p1, p2, p3) \
+        godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3)
+    #define CALL_STK_MSG5(fmt, p1, p2, p3, p4) \
+        godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4)
+    #define CALL_STK_MSG6(fmt, p1, p2, p3, p4, p5) \
+        godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4, p5)
+    #define CALL_STK_MSG7(fmt, p1, p2, p3, p4, p5, p6) \
+        godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4, p5, p6)
+    #define CALL_STK_MSG8(fmt, p1, p2, p3, p4, p5, p6, p7) \
+        godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4, p5, p6, p7)
+    #define CALL_STK_MSG9(fmt, p1, p2, p3, p4, p5, p6, p7, p8) \
+        godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4, p5, p6, p7, p8)
+    #define CALL_STK_MSG10(fmt, p1, p2, p3, p4, p5, p6, p7, p8, p9) \
+        godzilla::internal::CallStack::Msg __call_stack_msg(fmt, p1, p2, p3, p4, p5, p6, p7, p8, p9)
+    #define GET_CALL_STK_MACRO(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, NAME, ...) NAME
 
 /// Place at the beginning of a method/function
 ///
@@ -58,21 +64,22 @@ namespace internal {
 ///  ...your code here...
 /// }
 /// @endcode
-#define CALL_STACK_MSG(...)            \
-    GET_CALL_STK_MACRO(_0,             \
-                       ##__VA_ARGS__,  \
-                       CALL_STK_MSG10, \
-                       CALL_STK_MSG9,  \
-                       CALL_STK_MSG8,  \
-                       CALL_STK_MSG7,  \
-                       CALL_STK_MSG6,  \
-                       CALL_STK_MSG5,  \
-                       CALL_STK_MSG4,  \
-                       CALL_STK_MSG3,  \
-                       CALL_STK_MSG2,  \
-                       CALL_STK_MSG1,  \
-                       CALL_STK_MSG0)  \
-    (__VA_ARGS__)
+    #define CALL_STACK_MSG(...)            \
+        GET_CALL_STK_MACRO(_0,             \
+                           ##__VA_ARGS__,  \
+                           CALL_STK_MSG10, \
+                           CALL_STK_MSG9,  \
+                           CALL_STK_MSG8,  \
+                           CALL_STK_MSG7,  \
+                           CALL_STK_MSG6,  \
+                           CALL_STK_MSG5,  \
+                           CALL_STK_MSG4,  \
+                           CALL_STK_MSG3,  \
+                           CALL_STK_MSG2,  \
+                           CALL_STK_MSG1,  \
+                           CALL_STK_MSG0)  \
+        (__VA_ARGS__)
+#endif
 
 /// Call stack object
 ///


### PR DESCRIPTION
On a small-sized 2D problem, the slow down of the call stack capability
was measured about as 2x.
