### PR TITLE
Fixing FileMesh

### DIFF
--- a/include/godzilla/FileMesh.h
+++ b/include/godzilla/FileMesh.h
@@ -17,7 +17,6 @@ public:
     explicit FileMesh(const Parameters & parameters);
 
     void create() override;
-    void check() override;
 
     /// Return file name
     ///

--- a/src/FileMesh.cpp
+++ b/src/FileMesh.cpp
@@ -13,6 +13,8 @@ namespace fs = std::filesystem;
 
 namespace godzilla {
 
+REGISTER_OBJECT(FileMesh);
+
 Parameters
 FileMesh::parameters()
 {
@@ -60,18 +62,11 @@ FileMesh::create()
         create_from_gmsh();
         break;
     default:
-        break;
+        log_error("Unknown mesh format");
+        return;
     }
     set_up();
     lprint_mesh_info();
-}
-
-void
-FileMesh::check()
-{
-    CALL_STACK_MSG();
-    if (this->file_format == UNKNOWN)
-        log_error("Unknown mesh format");
 }
 
 void
@@ -129,7 +124,7 @@ FileMesh::detect_file_format()
     CALL_STACK_MSG();
     if (utils::has_suffix(this->file_name, ".exo") || utils::has_suffix(this->file_name, ".e"))
         this->file_format = EXODUSII;
-    else if (utils::has_suffix(this->file_name, ".gmsh"))
+    else if (utils::has_suffix(this->file_name, ".msh"))
         this->file_format = GMSH;
 }
 

--- a/test/src/FileMesh_test.cpp
+++ b/test/src/FileMesh_test.cpp
@@ -16,7 +16,7 @@ TEST(FileMesh, check)
     mesh_pars.set<std::string>("file") =
         std::string(GODZILLA_UNIT_TESTS_ROOT) + std::string("/assets/empty.yml");
     FileMesh mesh(mesh_pars);
-    mesh.check();
+    mesh.create();
 
     ASSERT_FALSE(app.check_integrity());
     auto out = testing::internal::GetCapturedStderr();


### PR DESCRIPTION
- class was not registered, so users were not able to use it
- GMSH file extension was `gmsh`, but should be `msh`
- checking is moved into `create`
