### PR TITLE
Removing Object::check

### DIFF
--- a/include/godzilla/ExodusIIOutput.h
+++ b/include/godzilla/ExodusIIOutput.h
@@ -36,7 +36,6 @@ public:
 
     [[nodiscard]] std::string get_file_ext() const override;
     void create() override;
-    void check() override;
     void output_mesh();
     void output_step() override;
 

--- a/include/godzilla/ExplicitDGLinearProblem.h
+++ b/include/godzilla/ExplicitDGLinearProblem.h
@@ -15,7 +15,6 @@ public:
     ~ExplicitDGLinearProblem() override;
 
     void create() override;
-    void check() override;
     bool converged() override;
     void solve() override;
     Real get_time() const override;

--- a/include/godzilla/ExplicitFELinearProblem.h
+++ b/include/godzilla/ExplicitFELinearProblem.h
@@ -18,7 +18,6 @@ public:
     Real get_time() const override;
     Int get_step_num() const override;
     void create() override;
-    void check() override;
     bool converged() override;
     void solve() override;
     void compute_solution_vector_local() override;

--- a/include/godzilla/ExplicitFVLinearProblem.h
+++ b/include/godzilla/ExplicitFVLinearProblem.h
@@ -18,7 +18,6 @@ public:
     ~ExplicitFVLinearProblem() override;
 
     void create() override;
-    void check() override;
     bool converged() override;
     void solve() override;
     Real get_time() const override;

--- a/include/godzilla/ExplicitProblemInterface.h
+++ b/include/godzilla/ExplicitProblemInterface.h
@@ -28,7 +28,6 @@ public:
     virtual PetscErrorCode compute_rhs(Real time, const Vector & x, Vector & F);
 
 protected:
-    void check();
     void set_up_callbacks();
     void set_up_time_scheme();
     void allocate_mass_matrix();

--- a/include/godzilla/ImplicitFENonlinearProblem.h
+++ b/include/godzilla/ImplicitFENonlinearProblem.h
@@ -14,7 +14,6 @@ public:
     ~ImplicitFENonlinearProblem() override;
 
     void create() override;
-    void check() override;
     bool converged() override;
     void solve() override;
     Real get_time() const override;

--- a/include/godzilla/LinearInterpolation.h
+++ b/include/godzilla/LinearInterpolation.h
@@ -27,9 +27,6 @@ public:
     /// @param y Dependent values
     void create(const std::vector<Real> & x, const std::vector<Real> & y);
 
-    /// Check that the supplied values are consistent
-    void check() const;
-
     /// Sample the interpolation at a point
     ///
     /// @params x Point where we sample the interpolation

--- a/include/godzilla/MeshPartitioningOutput.h
+++ b/include/godzilla/MeshPartitioningOutput.h
@@ -13,7 +13,6 @@ class MeshPartitioningOutput : public FileOutput {
 public:
     explicit MeshPartitioningOutput(const Parameters & params);
 
-    void check() override;
     [[nodiscard]] std::string get_file_ext() const override;
     void output_step() override;
 

--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -19,7 +19,6 @@ public:
     ~NonlinearProblem() override;
 
     void create() override;
-    void check() override;
     void run() override;
 
     /// Get underlying KSP

--- a/include/godzilla/Object.h
+++ b/include/godzilla/Object.h
@@ -57,9 +57,6 @@ public:
     /// Called to construct the object
     virtual void create();
 
-    /// Called to check object's integrity
-    virtual void check();
-
 private:
     /// Parameters of this object
     const Parameters & pars;

--- a/include/godzilla/PiecewiseConstant.h
+++ b/include/godzilla/PiecewiseConstant.h
@@ -18,8 +18,6 @@ public:
 
     void create() override;
 
-    void check() override;
-
     void register_callback(mu::Parser & parser) override;
 
     /// Evaluate this function at point 'x'

--- a/include/godzilla/PiecewiseLinear.h
+++ b/include/godzilla/PiecewiseLinear.h
@@ -4,9 +4,11 @@
 #pragma once
 
 #include "godzilla/Function.h"
-#include "godzilla/LinearInterpolation.h"
+#include "godzilla/Types.h"
 
 namespace godzilla {
+
+class LinearInterpolation;
 
 /// User-defined piecewise linear function
 ///
@@ -15,8 +17,7 @@ namespace godzilla {
 class PiecewiseLinear : public Function {
 public:
     explicit PiecewiseLinear(const Parameters & params);
-
-    void check() override;
+    ~PiecewiseLinear() override;
 
     void register_callback(mu::Parser & parser) override;
 
@@ -25,7 +26,7 @@ public:
 
 private:
     /// Linear interpolation object used for function evaluation
-    LinearInterpolation linpol;
+    LinearInterpolation * linpol;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -41,8 +41,6 @@ public:
     explicit Problem(const Parameters & parameters);
     virtual ~Problem();
 
-    void check() override;
-
     /// Build the problem to solve
     void create() override;
     /// Run the problem

--- a/include/godzilla/TecplotOutput.h
+++ b/include/godzilla/TecplotOutput.h
@@ -24,7 +24,6 @@ public:
 
     [[nodiscard]] std::string get_file_ext() const override;
     void create() override;
-    void check() override;
     void output_step() override;
 
 protected:

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -100,8 +100,6 @@ protected:
     virtual void init();
     /// Create
     virtual void create();
-    /// Check
-    virtual void check();
     /// Set up monitors
     virtual void set_up_monitors();
     /// Set up time integration scheme

--- a/include/godzilla/VTKOutput.h
+++ b/include/godzilla/VTKOutput.h
@@ -25,7 +25,6 @@ public:
 
     [[nodiscard]] std::string get_file_ext() const override;
     void create() override;
-    void check() override;
     void output_step() override;
 
 private:

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -124,6 +124,9 @@ ExodusIIOutput::ExodusIIOutput(const Parameters & params) :
         this->discont = true;
     else
         this->cont = true;
+
+    if (this->mesh == nullptr)
+        log_error("ExodusII output can be only used with unstructured meshes.");
 }
 
 ExodusIIOutput::~ExodusIIOutput()
@@ -175,15 +178,6 @@ ExodusIIOutput::create()
             }
         }
     }
-}
-
-void
-ExodusIIOutput::check()
-{
-    CALL_STACK_MSG();
-    FileOutput::check();
-    if (this->mesh == nullptr)
-        log_error("ExodusII output can be only used with unstructured meshes.");
 }
 
 void

--- a/src/ExplicitDGLinearProblem.cpp
+++ b/src/ExplicitDGLinearProblem.cpp
@@ -60,14 +60,6 @@ ExplicitDGLinearProblem::create()
     ExplicitProblemInterface::create();
 }
 
-void
-ExplicitDGLinearProblem::check()
-{
-    CALL_STACK_MSG();
-    NonlinearProblem::check();
-    ExplicitProblemInterface::check();
-}
-
 bool
 ExplicitDGLinearProblem::converged()
 {

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -97,14 +97,6 @@ ExplicitFELinearProblem::create()
     ExplicitProblemInterface::create();
 }
 
-void
-ExplicitFELinearProblem::check()
-{
-    CALL_STACK_MSG();
-    FENonlinearProblem::check();
-    ExplicitProblemInterface::check();
-}
-
 bool
 ExplicitFELinearProblem::converged()
 {

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -63,14 +63,6 @@ ExplicitFVLinearProblem::create()
     ExplicitProblemInterface::create();
 }
 
-void
-ExplicitFVLinearProblem::check()
-{
-    CALL_STACK_MSG();
-    NonlinearProblem::check();
-    ExplicitProblemInterface::check();
-}
-
 bool
 ExplicitFVLinearProblem::converged()
 {

--- a/src/ExplicitProblemInterface.cpp
+++ b/src/ExplicitProblemInterface.cpp
@@ -36,6 +36,9 @@ ExplicitProblemInterface::ExplicitProblemInterface(NonlinearProblem * problem,
     TransientProblemInterface(problem, params),
     nl_problem(problem)
 {
+    if (!validation::in(get_scheme(), { "euler", "ssp-rk-2", "ssp-rk-3", "rk-2", "heun" }))
+        this->nl_problem->log_error("The 'scheme' parameter can be either 'euler', 'ssp-rk-2', "
+                                    "'ssp-rk-3', 'rk-2' or 'heun'.");
 }
 
 ExplicitProblemInterface::~ExplicitProblemInterface()
@@ -70,17 +73,6 @@ ExplicitProblemInterface::get_lumped_mass_matrix()
 {
     CALL_STACK_MSG();
     return this->M_lumped_inv;
-}
-
-void
-ExplicitProblemInterface::check()
-{
-    CALL_STACK_MSG();
-    TransientProblemInterface::check();
-    auto prob = this->nl_problem;
-    if (!validation::in(get_scheme(), { "euler", "ssp-rk-2", "ssp-rk-3", "rk-2", "heun" }))
-        prob->log_error("The 'scheme' parameter can be either 'euler', 'ssp-rk-2', 'ssp-rk-3', "
-                        "'rk-2' or 'heun'.");
 }
 
 void

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -69,6 +69,8 @@ ImplicitFENonlinearProblem::ImplicitFENonlinearProblem(const Parameters & params
 {
     CALL_STACK_MSG();
     set_default_output_on(ExecuteOn::INITIAL | ExecuteOn::TIMESTEP);
+    if (!validation::in(this->scheme, { "beuler", "cn" }))
+        log_error("The 'scheme' parameter can be either 'beuler' or 'cn'.");
 }
 
 ImplicitFENonlinearProblem::~ImplicitFENonlinearProblem()
@@ -107,17 +109,6 @@ ImplicitFENonlinearProblem::create()
     CALL_STACK_MSG();
     FENonlinearProblem::create();
     TransientProblemInterface::create();
-}
-
-void
-ImplicitFENonlinearProblem::check()
-{
-    CALL_STACK_MSG();
-    FENonlinearProblem::check();
-    TransientProblemInterface::check();
-
-    if (!validation::in(this->scheme, { "beuler", "cn" }))
-        log_error("The 'scheme' parameter can be either 'beuler' or 'cn'.");
 }
 
 bool

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -119,8 +119,6 @@ void
 InputFile::check()
 {
     CALL_STACK_MSG();
-    for (auto & obj : this->objs)
-        obj->check();
     check_unused_blocks();
 }
 

--- a/src/LinearInterpolation.cpp
+++ b/src/LinearInterpolation.cpp
@@ -18,20 +18,6 @@ LinearInterpolation::LinearInterpolation(const std::vector<Real> & ax,
     y(ay)
 {
     CALL_STACK_MSG();
-}
-
-void
-LinearInterpolation::create(const std::vector<Real> & x, const std::vector<Real> & y)
-{
-    CALL_STACK_MSG();
-    this->x = x;
-    this->y = y;
-}
-
-void
-LinearInterpolation::check() const
-{
-    CALL_STACK_MSG();
     if (this->x.size() != this->y.size())
         throw std::domain_error(fmt::format("Size of 'x' ({}) does not match size of 'y' ({}).",
                                             this->x.size(),
@@ -48,6 +34,14 @@ LinearInterpolation::check() const
                     fmt::format("Values in 'x' must be increasing. Failed at index '{}'.", i + 1));
         }
     }
+}
+
+void
+LinearInterpolation::create(const std::vector<Real> & x, const std::vector<Real> & y)
+{
+    CALL_STACK_MSG();
+    this->x = x;
+    this->y = y;
 }
 
 Real

--- a/src/MeshPartitioningOutput.cpp
+++ b/src/MeshPartitioningOutput.cpp
@@ -23,13 +23,6 @@ MeshPartitioningOutput::MeshPartitioningOutput(const Parameters & params) : File
 {
     CALL_STACK_MSG();
     set_file_base("part");
-}
-
-void
-MeshPartitioningOutput::check()
-{
-    CALL_STACK_MSG();
-    FileOutput::check();
     auto dm = get_problem()->get_dm();
     if (dm == nullptr)
         log_error("Mesh partitioning output works only with problems that provide DM.");

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -96,7 +96,10 @@ NonlinearProblem::NonlinearProblem(const Parameters & parameters) :
 {
     CALL_STACK_MSG();
     set_default_output_on(ExecuteOn::FINAL);
-    line_search_type = utils::to_lower(line_search_type);
+    this->line_search_type = utils::to_lower(line_search_type);
+    if (!validation::in(this->line_search_type, { "bt", "basic", "l2", "cp", "nleqerr", "shell" }))
+        log_error("The 'line_search' parameter can be either 'bt', 'basic', 'l2', 'cp', 'nleqerr' "
+                  "or 'shell'.");
 }
 
 NonlinearProblem::~NonlinearProblem()
@@ -132,16 +135,6 @@ NonlinearProblem::create()
     set_up_solve_type();
 
     Problem::create();
-}
-
-void
-NonlinearProblem::check()
-{
-    CALL_STACK_MSG();
-    Problem::check();
-    if (!validation::in(this->line_search_type, { "bt", "basic", "l2", "cp", "nleqerr", "shell" }))
-        log_error("The 'line_search' parameter can be either 'bt', 'basic', 'l2', 'cp', 'nleqerr' "
-                  "or 'shell'.");
 }
 
 SNES

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -88,10 +88,4 @@ Object::create()
     CALL_STACK_MSG();
 }
 
-void
-Object::check()
-{
-    CALL_STACK_MSG();
-}
-
 } // namespace godzilla

--- a/src/PiecewiseConstant.cpp
+++ b/src/PiecewiseConstant.cpp
@@ -37,6 +37,20 @@ PiecewiseConstant::PiecewiseConstant(const Parameters & params) :
     y(get_param<std::vector<Real>>("y"))
 {
     CALL_STACK_MSG();
+    if (this->x.size() + 1 != this->y.size())
+        log_error("Size of 'x' ({}) does not match size of 'y' ({}).",
+                  this->x.size(),
+                  this->y.size());
+
+    if (this->x.size() == 0)
+        log_error("Size of 'x' is {}. It must be 1 or more.", this->x.size());
+    else {
+        // check monotonicity
+        for (std::size_t i = 0; i < this->x.size() - 1; i++) {
+            if (this->x[i] >= this->x[i + 1])
+                log_error("Values in 'x' must be increasing. Failed at index '{}'.", i + 1);
+        }
+    }
 }
 
 void
@@ -60,28 +74,6 @@ PiecewiseConstant::create()
     }
     else
         log_error("The 'continuity' parameter can be either 'left' or 'right'.");
-}
-
-void
-PiecewiseConstant::check()
-{
-    CALL_STACK_MSG();
-    Function::check();
-
-    if (this->x.size() + 1 != this->y.size())
-        log_error("Size of 'x' ({}) does not match size of 'y' ({}).",
-                  this->x.size(),
-                  this->y.size());
-
-    if (this->x.size() == 0)
-        log_error("Size of 'x' is {}. It must be 1 or more.", this->x.size());
-    else {
-        // check monotonicity
-        for (std::size_t i = 0; i < this->x.size() - 1; i++) {
-            if (this->x[i] >= this->x[i + 1])
-                log_error("Values in 'x' must be increasing. Failed at index '{}'.", i + 1);
-        }
-    }
 }
 
 Real

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -70,19 +70,6 @@ Problem::get_solution_vector()
 }
 
 void
-Problem::check()
-{
-    CALL_STACK_MSG();
-    for (auto & f : this->functions)
-        f->check();
-    for (auto & pp : this->pps)
-        pp.second->check();
-    for (auto & out : this->outputs) {
-        out->check();
-    }
-}
-
-void
 Problem::create()
 {
     CALL_STACK_MSG();

--- a/src/TecplotOutput.cpp
+++ b/src/TecplotOutput.cpp
@@ -93,6 +93,10 @@ TecplotOutput::TecplotOutput(const Parameters & params) :
     element_id_var_index(-1)
 {
     CALL_STACK_MSG();
+    if (this->dpi == nullptr)
+        log_error("Tecplot output can be only used with finite element problems.");
+    if (this->mesh == nullptr)
+        log_error("Tecplot output can be only used with unstructured meshes.");
 }
 
 TecplotOutput::~TecplotOutput()
@@ -177,17 +181,6 @@ TecplotOutput::create()
         else
             this->nodal_aux_var_fids.push_back(fid);
     }
-}
-
-void
-TecplotOutput::check()
-{
-    CALL_STACK_MSG();
-    FileOutput::check();
-    if (this->dpi == nullptr)
-        log_error("Tecplot output can be only used with finite element problems.");
-    if (this->mesh == nullptr)
-        log_error("Tecplot output can be only used with unstructured meshes.");
 }
 
 void

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -71,6 +71,12 @@ TransientProblemInterface::TransientProblemInterface(Problem * problem, const Pa
 {
     CALL_STACK_MSG();
     PETSC_CHECK(TSCreate(this->problem->get_comm(), &this->ts));
+    if (this->tpi_params.is_param_valid("end_time") && this->tpi_params.is_param_valid("num_steps"))
+        this->problem->log_error(
+            "Cannot provide 'end_time' and 'num_steps' together. Specify one or the other.");
+    if (!this->tpi_params.is_param_valid("end_time") &&
+        !this->tpi_params.is_param_valid("num_steps"))
+        this->problem->log_error("You must provide either 'end_time' or 'num_steps' parameter.");
 }
 
 TransientProblemInterface::~TransientProblemInterface()
@@ -195,18 +201,6 @@ TransientProblemInterface::create()
     PETSC_CHECK(TSSetExactFinalTime(this->ts, TS_EXACTFINALTIME_MATCHSTEP));
     if (this->ts_adaptor)
         this->ts_adaptor->create();
-}
-
-void
-TransientProblemInterface::check()
-{
-    CALL_STACK_MSG();
-    if (this->tpi_params.is_param_valid("end_time") && this->tpi_params.is_param_valid("num_steps"))
-        this->problem->log_error(
-            "Cannot provide 'end_time' and 'num_steps' together. Specify one or the other.");
-    if (!this->tpi_params.is_param_valid("end_time") &&
-        !this->tpi_params.is_param_valid("num_steps"))
-        this->problem->log_error("You must provide either 'end_time' or 'num_steps' parameter.");
 }
 
 void

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -23,6 +23,9 @@ VTKOutput::parameters()
 VTKOutput::VTKOutput(const Parameters & params) : FileOutput(params), viewer(nullptr)
 {
     CALL_STACK_MSG();
+    const auto * mesh = dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh());
+    if (mesh == nullptr)
+        log_error("VTK output works only with unstructured meshes.");
 }
 
 VTKOutput::~VTKOutput()
@@ -47,16 +50,6 @@ VTKOutput::create()
     PETSC_CHECK(PetscViewerCreate(get_comm(), &this->viewer));
     PETSC_CHECK(PetscViewerSetType(this->viewer, PETSCVIEWERVTK));
     PETSC_CHECK(PetscViewerFileSetMode(this->viewer, FILE_MODE_WRITE));
-}
-
-void
-VTKOutput::check()
-{
-    CALL_STACK_MSG();
-    FileOutput::check();
-    const auto * mesh = dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh());
-    if (mesh == nullptr)
-        log_error("VTK output works only with unstructured meshes.");
 }
 
 void

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -80,34 +80,11 @@ TEST(ExodusIIOutputTest, non_existent_var)
     mesh.create();
     prob.create();
 
-    out.check();
     app.check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
                 testing::HasSubstr(
                     "Variable 'asdf' specified in 'variables' parameter does not exist. Typo?"));
-}
-
-TEST(ExodusIIOutputTest, check)
-{
-    TestApp app;
-
-    auto mesh_pars = LineMesh::parameters();
-    mesh_pars.set<App *>("_app") = &app;
-    mesh_pars.set<Int>("nx") = 2;
-    LineMesh mesh(mesh_pars);
-
-    auto prob_pars = GTestFENonlinearProblem::parameters();
-    prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
-    GTestFENonlinearProblem prob(prob_pars);
-
-    Parameters params = ExodusIIOutput::parameters();
-    params.set<App *>("_app") = &app;
-    params.set<Problem *>("_problem") = &prob;
-    ExodusIIOutput out(params);
-
-    out.check();
 }
 
 TEST(ExodusIIOutputTest, fe_check)
@@ -171,7 +148,6 @@ TEST(ExodusIIOutputTest, fe_check)
     mesh.create();
     prob.create();
 
-    out.check();
     app.check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
@@ -201,7 +177,6 @@ TEST(ExodusIIOutputTest, output)
     mesh.create();
     prob.create();
 
-    out.check();
     app.check_integrity();
 
     out.output_step();

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -210,7 +210,6 @@ TEST(ExplicitFELinearProblemTest, solve)
 
     mesh.create();
     prob.create();
-    prob.check();
 
     prob.run();
 
@@ -271,7 +270,6 @@ TEST(ExplicitFELinearProblemTest, solve_w_lumped_mass_matrix)
 
     mesh.create();
     prob.create_w_lumped_mass_matrix();
-    prob.check();
 
     prob.run();
 
@@ -357,7 +355,6 @@ TEST(ExplicitFELinearProblemTest, wrong_scheme)
 
     mesh->create();
     prob->create();
-    prob->check();
 
     app.check_integrity();
 

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -348,7 +348,6 @@ TEST(ExplicitFVLinearProblemTest, solve)
 
     mesh.create();
     prob.create();
-    prob.check();
 
     prob.run();
 
@@ -427,8 +426,6 @@ TEST(ExplicitFVLinearProblemTest, wrong_schemes)
 
     mesh.create();
     prob.create();
-
-    prob.check();
 
     app.check_integrity();
 

--- a/test/src/FileMesh_test.cpp
+++ b/test/src/FileMesh_test.cpp
@@ -5,7 +5,7 @@
 using namespace godzilla;
 using namespace testing;
 
-TEST(FileMesh, check)
+TEST(FileMesh, unknown_mesh_format)
 {
     testing::internal::CaptureStderr();
 

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -74,7 +74,6 @@ TEST_F(ImplicitFENonlinearProblemTest, wrong_scheme)
 
     mesh->create();
     prob->create();
-    prob->check();
 
     this->app->check_integrity();
 
@@ -101,7 +100,6 @@ TEST_F(ImplicitFENonlinearProblemTest, wrong_time_stepping_params)
 
     mesh->create();
     prob->create();
-    prob->check();
 
     this->app->check_integrity();
 
@@ -128,7 +126,6 @@ TEST_F(ImplicitFENonlinearProblemTest, no_time_stepping_params)
 
     mesh->create();
     prob->create();
-    prob->check();
 
     this->app->check_integrity();
 
@@ -167,7 +164,10 @@ TEST_F(ImplicitFENonlinearProblemTest, set_schemes)
 
     TS ts = prob->get_ts();
     TSType type;
-    std::vector<std::string> schemes = { "beuler", "cn", };
+    std::vector<std::string> schemes = {
+        "beuler",
+        "cn",
+    };
     std::vector<TSType> types = { TSBEULER, TSCN };
     for (std::size_t i = 0; i < schemes.size(); i++) {
         prob->set_scheme(types[i]);

--- a/test/src/LinearInterpolation_test.cpp
+++ b/test/src/LinearInterpolation_test.cpp
@@ -53,10 +53,7 @@ TEST(LinearInterpolationTest, single_interval)
 TEST(LinearInterpolationTest, single_point)
 {
     EXPECT_THAT(
-        []() {
-            LinearInterpolation ipol({ 1 }, { 0 });
-            ipol.check();
-        },
+        []() { LinearInterpolation ipol({ 1 }, { 0 }); },
         testing::ThrowsMessage<std::domain_error>("Size of 'x' is 1. It must be 2 or more."));
 }
 
@@ -65,7 +62,6 @@ TEST(LinearInterpolationTest, unequal_sizes)
     EXPECT_THAT(
         []() {
             LinearInterpolation ipol({ 1, 2 }, { 0, 2, 3 });
-            ipol.check();
         },
         testing::ThrowsMessage<std::domain_error>(
             "Size of 'x' (2) does not match size of 'y' (3)."));
@@ -76,7 +72,6 @@ TEST(LinearInterpolationTest, non_increasing)
     EXPECT_THAT(
         []() {
             LinearInterpolation ipol({ 1, 2, 1 }, { 0, 2, 3 });
-            ipol.check();
         },
         testing::ThrowsMessage<std::domain_error>(
             "Values in 'x' must be increasing. Failed at index '2'."));

--- a/test/src/MeshPartitioningOutput_test.cpp
+++ b/test/src/MeshPartitioningOutput_test.cpp
@@ -105,8 +105,6 @@ TEST(MeshPartitioningOutputTest, no_dm)
     params.set<Problem *>("_problem") = &prob;
     MeshPartitioningOutput out(params);
 
-    out.check();
-
     app.check_integrity();
 
     EXPECT_THAT(

--- a/test/src/NonlinearProblem_test.cpp
+++ b/test/src/NonlinearProblem_test.cpp
@@ -271,8 +271,6 @@ TEST(NonlinearProblemTest, invalid_line_search_type)
     MockNonlinearProblem prob(prob_pars);
     prob.create();
 
-    prob.check();
-
     app.check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),

--- a/test/src/Output_test.cpp
+++ b/test/src/Output_test.cpp
@@ -119,7 +119,6 @@ TEST_F(OutputTest, interval_with_no_timestep_output)
     MockOutput out(pars);
 
     out.create();
-    out.check();
 
     app->check_integrity();
 

--- a/test/src/PiecewiseConstant_test.cpp
+++ b/test/src/PiecewiseConstant_test.cpp
@@ -35,7 +35,6 @@ TEST(PiecewiseConstantTest, left_cont_eval)
     params.set<std::vector<Real>>("y") = { 3., 0., -1., 2. };
     PiecewiseConstant obj(params);
     obj.create();
-    obj.check();
 
     EXPECT_EQ(obj.evaluate(0.), 3.);
     EXPECT_EQ(obj.evaluate(1.), 3.);
@@ -58,7 +57,6 @@ TEST(PiecewiseConstantTest, right_cont_eval)
     params.set<std::vector<Real>>("y") = { 3., 0., -1., 2. };
     PiecewiseConstant obj(params);
     obj.create();
-    obj.check();
 
     EXPECT_EQ(obj.evaluate(0.), 3.);
     EXPECT_EQ(obj.evaluate(1.), 0.);
@@ -82,7 +80,6 @@ TEST(PiecewiseConstantTest, err_incorrect_point_count)
     params.set<std::vector<Real>>("y") = { 3., 1. };
     PiecewiseConstant obj(params);
     obj.create();
-    obj.check();
 
     app.check_integrity();
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
@@ -102,7 +99,6 @@ TEST(PiecewiseConstantTest, err_no_points)
     params.set<std::vector<Real>>("y") = { 1. };
     PiecewiseConstant obj(params);
     obj.create();
-    obj.check();
 
     app.check_integrity();
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
@@ -122,7 +118,6 @@ TEST(PiecewiseConstantTest, err_not_monotonic)
     params.set<std::vector<Real>>("y") = { 1., 2., 3. };
     PiecewiseConstant obj(params);
     obj.create();
-    obj.check();
 
     app.check_integrity();
     EXPECT_THAT(
@@ -144,7 +139,6 @@ TEST(PiecewiseConstantTest, err_cont)
     params.set<std::vector<Real>>("y") = { 1., 2. };
     PiecewiseConstant obj(params);
     obj.create();
-    obj.check();
 
     app.check_integrity();
     EXPECT_THAT(testing::internal::GetCapturedStderr(),

--- a/test/src/PiecewiseLinear_test.cpp
+++ b/test/src/PiecewiseLinear_test.cpp
@@ -23,7 +23,7 @@ TEST(PiecewiseLinearTest, eval)
     EXPECT_EQ(parser.Eval(), 3.);
 }
 
-TEST(PiecewiseLinearTest, check)
+TEST(PiecewiseLinearTest, inconsistent_data_sizes)
 {
     testing::internal::CaptureStderr();
 
@@ -35,7 +35,6 @@ TEST(PiecewiseLinearTest, check)
     params.set<std::vector<Real>>("x") = { 1., 2. };
     params.set<std::vector<Real>>("y") = { 3., 1., 2. };
     PiecewiseLinear obj(params);
-    obj.check();
 
     app.check_integrity();
     EXPECT_THAT(

--- a/test/src/Problem_test.cpp
+++ b/test/src/Problem_test.cpp
@@ -49,8 +49,6 @@ TEST(ProblemTest, add_pp)
         {
             return 0;
         }
-
-        MOCK_METHOD(void, check, ());
     };
 
     class TestFunction : public Function {
@@ -61,8 +59,6 @@ TEST(ProblemTest, add_pp)
         register_callback(mu::Parser & parser) override
         {
         }
-
-        MOCK_METHOD(void, check, ());
     };
 
     class TestOutput : public Output {
@@ -105,10 +101,6 @@ TEST(ProblemTest, add_pp)
     TestOutput out(out_params);
     out.create();
     problem.add_output(&out);
-
-    EXPECT_CALL(fn, check);
-    EXPECT_CALL(pp, check);
-    problem.check();
 
     EXPECT_EQ(problem.get_postprocessor("pp"), &pp);
     EXPECT_EQ(problem.get_postprocessor("asdf"), nullptr);

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -112,7 +112,6 @@ TEST_F(VTKOutputTest, wrong_mesh_type)
     mesh.create();
     prob.create();
 
-    out.check();
     this->app->check_integrity();
 
     EXPECT_THAT(testing::internal::GetCapturedStderr(),
@@ -124,7 +123,6 @@ TEST_F(VTKOutputTest, output_1d_step)
     auto out = build_output("out");
     create();
 
-    out->check();
     this->app->check_integrity();
 
     this->prob->solve();


### PR DESCRIPTION
Checks should be done as early as possible, typically in the c-tor and create().
