### PR TITLE
Deprecating ExodusIIMesh and GmshMesh

### DIFF
--- a/include/godzilla/LoggingInterface.h
+++ b/include/godzilla/LoggingInterface.h
@@ -33,6 +33,14 @@ public:
         this->logger->warning(this->prefix, format, std::forward<T>(args)...);
     }
 
+    /// Log a deprecated message
+    template <typename... T>
+    void
+    deprecated(fmt::format_string<T...> message)
+    {
+        this->logger->warning(this->prefix, message);
+    }
+
 private:
     /// Logger object
     Logger * logger;

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -21,6 +21,7 @@ ExodusIIMesh::ExodusIIMesh(const Parameters & parameters) : FileMesh(parameters)
 {
     CALL_STACK_MSG();
     set_file_format(EXODUSII);
+    deprecated("Use `FileMesh` instead.");
 }
 
 } // namespace godzilla

--- a/src/GmshMesh.cpp
+++ b/src/GmshMesh.cpp
@@ -20,6 +20,7 @@ GmshMesh::GmshMesh(const Parameters & parameters) : FileMesh(parameters)
 {
     CALL_STACK_MSG();
     set_file_format(GMSH);
+    deprecated("Use `FileMesh` instead.");
 }
 
 } // namespace godzilla


### PR DESCRIPTION
- Adding deprecated API to LoggingInterface
- Deprecating ExodusIIMesh and GmshMesh
