### PR TITLE
Mesh refactoring

### DIFF
--- a/include/godzilla/BoxMesh.h
+++ b/include/godzilla/BoxMesh.h
@@ -3,18 +3,17 @@
 
 #pragma once
 
-#include "godzilla/UnstructuredMesh.h"
+#include "godzilla/MeshObject.h"
+#include "godzilla/Types.h"
 
 namespace godzilla {
 
 /// 3D box mesh
 ///
-class BoxMesh : public UnstructuredMesh {
+class BoxMesh : public MeshObject {
 public:
     /// Constructor for building the object via Factory
     explicit BoxMesh(const Parameters & parameters);
-
-    void create() override;
 
     /// Get lower limit in x-direction
     Real get_x_min() const;
@@ -42,6 +41,9 @@ public:
 
     /// Get the number of mesh points in z direction
     Int get_nz() const;
+
+protected:
+    Mesh * create_mesh() override;
 
 private:
     /// Minimum in the x direction

--- a/include/godzilla/FileMesh.h
+++ b/include/godzilla/FileMesh.h
@@ -3,20 +3,20 @@
 
 #pragma once
 
-#include "godzilla/UnstructuredMesh.h"
+#include "godzilla/MeshObject.h"
 
 namespace godzilla {
 
+class UnstructuredMesh;
+
 /// Mesh loaded from a file
 ///
-class FileMesh : public UnstructuredMesh {
+class FileMesh : public MeshObject {
 protected:
     enum FileFormat { UNKNOWN, EXODUSII, GMSH } file_format;
 
 public:
     explicit FileMesh(const Parameters & parameters);
-
-    void create() override;
 
     /// Return file name
     ///
@@ -25,11 +25,12 @@ public:
 
 protected:
     void set_file_format(FileFormat fmt);
+    Mesh * create_mesh() override;
 
 private:
     void detect_file_format();
-    void create_from_exodus();
-    void create_from_gmsh();
+    UnstructuredMesh * create_from_exodus();
+    UnstructuredMesh * create_from_gmsh();
 
     /// File name with the mesh
     std::string file_name;

--- a/include/godzilla/InputFile.h
+++ b/include/godzilla/InputFile.h
@@ -14,6 +14,7 @@ namespace godzilla {
 class App;
 class Factory;
 class Object;
+class MeshObject;
 class Mesh;
 class Problem;
 class Function;
@@ -144,7 +145,7 @@ private:
     /// Root node of the YML file
     Block root;
     /// Mesh object
-    Mesh * mesh;
+    MeshObject * mesh;
     /// Problem object
     Problem * problem;
     /// List of all objects built from the input file

--- a/include/godzilla/LineMesh.h
+++ b/include/godzilla/LineMesh.h
@@ -3,17 +3,16 @@
 
 #pragma once
 
-#include "godzilla/UnstructuredMesh.h"
+#include "godzilla/MeshObject.h"
+#include "godzilla/Types.h"
 
 namespace godzilla {
 
 /// 1D line
 ///
-class LineMesh : public UnstructuredMesh {
+class LineMesh : public MeshObject {
 public:
     explicit LineMesh(const Parameters & parameters);
-
-    void create() override;
 
     /// Get the lower bound in x-direction
     ///
@@ -29,6 +28,9 @@ public:
     ///
     /// @return Number of divisions in the x-direction
     [[nodiscard]] Int get_nx() const;
+
+protected:
+    Mesh * create_mesh() override;
 
 private:
     /// Minimum in the x direction

--- a/include/godzilla/Mesh.h
+++ b/include/godzilla/Mesh.h
@@ -4,21 +4,26 @@
 #pragma once
 
 #include "godzilla/Types.h"
-#include "godzilla/Object.h"
-#include "godzilla/PrintInterface.h"
 #include "godzilla/Label.h"
 #include "godzilla/Vector.h"
 #include "godzilla/Section.h"
+#include "mpicpp-lite/mpicpp-lite.h"
 #include "petscdm.h"
+
+namespace mpi = mpicpp_lite;
 
 namespace godzilla {
 
 /// Base class for meshes
 ///
-class Mesh : public Object, public PrintInterface {
+class Mesh {
 public:
-    explicit Mesh(const Parameters & parameters);
+    Mesh();
+    explicit Mesh(DM dm);
     virtual ~Mesh();
+
+    /// Get the MPI comm this object works on
+    mpi::Communicator get_comm() const;
 
     /// Get the underlying DM object
     ///
@@ -101,9 +106,6 @@ protected:
 private:
     /// DM object
     DM dm;
-
-public:
-    static Parameters parameters();
 };
 
 } // namespace godzilla

--- a/include/godzilla/Mesh.h
+++ b/include/godzilla/Mesh.h
@@ -92,6 +92,11 @@ public:
     /// @param dim The embedding dimension
     void set_coordinate_dim(Int dim);
 
+    /// Sets a local vector, including ghost points, that holds the coordinates
+    ///
+    /// @param c coordinate vector
+    void set_coordinates_local(const Vector & c);
+
     /// Sets up the data structures inside the `DM` object
     void set_up();
 

--- a/include/godzilla/Mesh.h
+++ b/include/godzilla/Mesh.h
@@ -87,6 +87,11 @@ public:
     /// @return Local section from the coordinate `DM`
     Section get_coordinate_section() const;
 
+    /// Set the dimension of the embedding space for coordinate values
+    ///
+    /// @param dim The embedding dimension
+    void set_coordinate_dim(Int dim);
+
     /// Sets up the data structures inside the `DM` object
     void set_up();
 

--- a/include/godzilla/Mesh.h
+++ b/include/godzilla/Mesh.h
@@ -35,6 +35,11 @@ public:
     /// @return Mesh spatial dimension
     [[nodiscard]] Int get_dimension() const;
 
+    /// Set the topological dimension of the mesh
+    ///
+    /// @param dim The topological dimension
+    void set_dimension(Int dim);
+
     /// Distribute mesh over processes
     virtual void distribute() = 0;
 

--- a/include/godzilla/MeshObject.h
+++ b/include/godzilla/MeshObject.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2024 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "godzilla/Object.h"
+#include "godzilla/PrintInterface.h"
+
+namespace godzilla {
+
+class Mesh;
+
+/// Base class for objects that create `Mesh`es. These are user-facing objects.
+///
+/// TODO: This needs a better name
+class MeshObject : public Object, public PrintInterface {
+public:
+    explicit MeshObject(const Parameters & parameters);
+    ~MeshObject() override;
+
+    void create() override;
+
+    /// Get the mesh object
+    ///
+    /// @return Mesh object
+    template <class T>
+    T * get_mesh() const
+    {
+        CALL_STACK_MSG();
+        return dynamic_cast<T *>(this->mesh);
+    }
+
+protected:
+    virtual Mesh * create_mesh() = 0;
+    void lprint_mesh_info();
+
+private:
+    /// Mesh object build by us
+    Mesh * mesh;
+
+public:
+    static Parameters parameters();
+};
+
+} // namespace godzilla

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -15,6 +15,7 @@
 
 namespace godzilla {
 
+class MeshObject;
 class Mesh;
 class Function;
 class Postprocessor;
@@ -161,7 +162,7 @@ protected:
 
 private:
     /// Mesh
-    Mesh * mesh;
+    MeshObject * mesh;
 
     /// The solution vector
     Vector x;

--- a/include/godzilla/RectangleMesh.h
+++ b/include/godzilla/RectangleMesh.h
@@ -3,17 +3,17 @@
 
 #pragma once
 
-#include "godzilla/UnstructuredMesh.h"
+#include "godzilla/MeshObject.h"
+#include "godzilla/Types.h"
 
 namespace godzilla {
 
 /// 2D rectangular mesh
 ///
-class RectangleMesh : public UnstructuredMesh {
+class RectangleMesh : public MeshObject {
 public:
     explicit RectangleMesh(const Parameters & parameters);
 
-    void create() override;
     ///
     [[nodiscard]] Real get_x_min() const;
     [[nodiscard]] Real get_x_max() const;
@@ -24,6 +24,9 @@ public:
     [[nodiscard]] Real get_y_max() const;
     /// Get the number of mesh points in y direction
     [[nodiscard]] Int get_ny() const;
+
+protected:
+    Mesh * create_mesh() override;
 
 private:
     /// Minimum in the x direction

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -207,6 +207,12 @@ public:
     /// @return Range of mesh points
     Range get_chart() const;
 
+    /// Set the interval for all mesh points `[start, end)`
+    ///
+    /// @param start The first mesh point
+    /// @param end The upper bound for mesh points
+    void set_chart(Int start, Int end);
+
     /// Get cell type
     ///
     /// @param cell Cell index

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -396,6 +396,8 @@ public:
     void symmetrize();
 
     /// Computes the strata for all points in the mesh
+    void stratify();
+
 private:
     /// Mesh partitioner
     Partitioner partitioner;

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -250,6 +250,13 @@ public:
     /// @param size The cone size for point `p`
     void set_cone_size(Int point, Int size);
 
+    /// Set the points on the in-edges for this point in the DAG; that is these are the points that
+    /// cover the specific point
+    ///
+    /// @param point The point, which must lie in the chart set with `set_chart`
+    /// @param cone An array of points which are on the in-edges for point `p`
+    void set_cone(Int point, const std::vector<Int> & cone);
+
     /// Set partitioner type
     ///
     /// @param type Type of the partitioner

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -398,6 +398,12 @@ public:
     /// Computes the strata for all points in the mesh
     void stratify();
 
+    /// Get an array for the join of the set of points
+    ///
+    /// @param points The input points
+    /// @return The points in the join
+    std::vector<Int> get_full_join(const std::vector<Int> & points);
+
 private:
     /// Mesh partitioner
     Partitioner partitioner;

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -244,6 +244,12 @@ public:
     /// @return Vertices recursively expanded from input points
     IndexSet get_cone_recursive_vertices(IndexSet points) const;
 
+    /// Set the number of in-edges for this point in the DAG
+    ///
+    /// @param point The point, which must lie in the chart set with `set_chart`
+    /// @param size The cone size for point `p`
+    void set_cone_size(Int point, Int size);
+
     /// Set partitioner type
     ///
     /// @param type Type of the partitioner

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -311,6 +311,12 @@ public:
     /// @param name Cell set name
     void set_cell_set_name(Int id, const std::string & name);
 
+    /// Set the polytope type of a given cell
+    ///
+    /// @param cell The cell
+    /// @param cell_type The polytope type of the cell
+    void set_cell_type(Int cell, DMPolytopeType cell_type);
+
     /// Get face set name
     ///
     /// @param id The ID of the face set

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -392,6 +392,10 @@ public:
     /// Take in a cell-vertex mesh and return one with all intermediate faces, edges, etc.
     void interpolate();
 
+    /// Create support (out-edge) information from cone (in-edge) information
+    void symmetrize();
+
+    /// Computes the strata for all points in the mesh
 private:
     /// Mesh partitioner
     Partitioner partitioner;

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -96,6 +96,7 @@ public:
 
     void set(Scalar alpha);
     void set_sizes(Int n, Int N = PETSC_DECIDE);
+    void set_block_size(Int bs);
     void set_type(VecType method);
 
     void set_value(Int row, Scalar value, InsertMode mode = INSERT_VALUES);

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -25,7 +25,7 @@ AuxiliaryField::AuxiliaryField(const Parameters & params) :
     Object(params),
     PrintInterface(this),
     dpi(get_param<DiscreteProblemInterface *>("_dpi")),
-    mesh(dpi->get_unstr_mesh()),
+    mesh(nullptr),
     field(get_param<std::string>("field")),
     region(get_param<std::string>("region")),
     fid(-1),
@@ -61,6 +61,7 @@ void
 AuxiliaryField::create()
 {
     CALL_STACK_MSG();
+    this->mesh = this->dpi->get_unstr_mesh();
     if (this->region.length() > 0) {
         if (this->mesh->has_label(this->region)) {
             this->label = this->mesh->get_label(this->region);

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -20,7 +20,7 @@ namespace godzilla {
 
 DiscreteProblemInterface::DiscreteProblemInterface(Problem * problem, const Parameters & params) :
     problem(problem),
-    unstr_mesh(dynamic_cast<UnstructuredMesh *>(problem->get_mesh())),
+    unstr_mesh(nullptr),
     logger(params.get<App *>("_app")->get_logger()),
     ds(nullptr),
     dm_aux(nullptr),
@@ -192,6 +192,7 @@ DiscreteProblemInterface::create()
 {
     CALL_STACK_MSG();
     assert(this->problem != nullptr);
+    this->unstr_mesh = dynamic_cast<UnstructuredMesh *>(problem->get_mesh());
     assert(this->unstr_mesh != nullptr);
 
     for (auto & ic : this->all_ics)

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -99,7 +99,7 @@ Parameters
 ExodusIIOutput::parameters()
 {
     Parameters params = FileOutput::parameters();
-    params.add_private_param<UnstructuredMesh *>("_mesh", nullptr);
+    params.add_private_param<MeshObject *>("_mesh_obj", nullptr);
     params.add_param<std::vector<std::string>>(
         "variables",
         "List of variables to be stored. If not specified, all variables will be stored.");
@@ -113,8 +113,7 @@ ExodusIIOutput::ExodusIIOutput(const Parameters & params) :
     variable_names(get_param<std::vector<std::string>>("variables")),
     dpi(dynamic_cast<DiscreteProblemInterface *>(get_problem())),
     dgpi(dynamic_cast<DGProblemInterface *>(get_problem())),
-    mesh(get_problem() ? dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh())
-                       : get_param<UnstructuredMesh *>("_mesh")),
+    mesh(nullptr),
     exo(nullptr),
     step_num(1),
     mesh_stored(false)
@@ -125,8 +124,6 @@ ExodusIIOutput::ExodusIIOutput(const Parameters & params) :
     else
         this->cont = true;
 
-    if (this->mesh == nullptr)
-        log_error("ExodusII output can be only used with unstructured meshes.");
 }
 
 ExodusIIOutput::~ExodusIIOutput()
@@ -148,6 +145,11 @@ ExodusIIOutput::create()
 {
     CALL_STACK_MSG();
     FileOutput::create();
+
+    this->mesh = get_problem() ? dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh())
+                               : get_param<UnstructuredMesh *>("_mesh");
+    if (this->mesh == nullptr)
+        log_error("ExodusII output can be only used with unstructured meshes.");
 
     if (this->dpi) {
         auto flds = this->dpi->get_field_names();

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -362,9 +362,9 @@ void
 FVProblemInterface::create()
 {
     CALL_STACK_MSG();
-    get_unstr_mesh()->construct_ghost_cells();
     set_up_fields();
     DiscreteProblemInterface::create();
+    get_unstr_mesh()->construct_ghost_cells();
 }
 
 void

--- a/src/FileMeshExodusII.cpp
+++ b/src/FileMeshExodusII.cpp
@@ -43,10 +43,7 @@ FileMesh::create_from_exodus()
     auto comm = get_comm();
     auto rank = comm.rank();
 
-    DM dm = nullptr;
-    PETSC_CHECK(DMCreate(comm, &dm));
-    PETSC_CHECK(DMSetType(dm, DMPLEX));
-    auto m = new UnstructuredMesh(dm);
+    auto m = new UnstructuredMesh(comm);
 
     try {
         Int dim = 0;
@@ -63,9 +60,9 @@ FileMesh::create_from_exodus()
             n_cells = f.get_num_elements();
             n_vertices = f.get_num_nodes();
             n_side_sets = f.get_num_side_sets();
-            PETSC_CHECK(DMPlexSetChart(dm, 0, n_cells + n_vertices));
+            m->set_chart(0, n_cells + n_vertices);
             // We do not want this label automatically computed, instead we compute it here
-            PETSC_CHECK(DMCreateLabel(dm, "celltype"));
+            m->create_label("celltype");
 
             f.read_blocks();
             int n_elem_blocks = f.get_num_element_blocks();
@@ -91,18 +88,17 @@ FileMesh::create_from_exodus()
                 auto eb = f.get_element_block(blk_idx);
                 DMPolytopeType ct = ::get_cell_type(eb.get_element_type());
                 for (int j = 0; j < eb.get_num_elements(); ++j, ++cell) {
-                    PETSC_CHECK(DMPlexSetConeSize(dm, cell, eb.get_num_nodes_per_element()));
-                    PETSC_CHECK(DMPlexSetCellType(dm, cell, ct));
+                    m->set_cone_size(cell, eb.get_num_nodes_per_element());
+                    m->set_cell_type(cell, ct);
                 }
             }
             for (Int vertex = n_cells; vertex < n_cells + n_vertices; ++vertex)
-                PETSC_CHECK(DMPlexSetCellType(dm, vertex, DM_POLYTOPE_POINT));
-            PETSC_CHECK(DMSetUp(dm));
+                m->set_cell_type(vertex, DM_POLYTOPE_POINT);
+            m->set_up();
 
             // process element blocks
-            PETSC_CHECK(DMCreateLabel(dm, "Cell Sets"));
-            DMLabel cell_sets;
-            PETSC_CHECK(DMGetLabel(dm, "Cell Sets", &cell_sets));
+            m->create_label("Cell Sets");
+            auto cell_sets = m->get_label("Cell Sets");
 
             for (Int i = 0, cell = 0; i < n_elem_blocks; ++i) {
                 int blk_idx = cs_order[i];
@@ -112,9 +108,8 @@ FileMesh::create_from_exodus()
                 if (name.empty())
                     name = fmt::format("{}", id);
 
-                PETSC_CHECK(DMCreateLabel(dm, name.c_str()));
-                DMLabel block_label;
-                PETSC_CHECK(DMGetLabel(dm, name.c_str(), &block_label));
+                m->create_label(name);
+                auto block_label = m->get_label(name);
                 m->set_cell_set_name(id, name);
 
                 auto n_blk_elems = eb.get_num_elements();
@@ -126,12 +121,11 @@ FileMesh::create_from_exodus()
                 for (Int j = 0, vertex = 0; j < n_blk_elems; ++j, ++cell) {
                     for (Int k = 0; k < n_elem_nodes; ++k, ++vertex)
                         cone[k] = connect[vertex] + n_cells - 1;
-                    DMPolytopeType ct;
-                    PETSC_CHECK(DMPlexGetCellType(dm, cell, &ct));
+                    DMPolytopeType ct = m->get_cell_type(cell);
                     PETSC_CHECK(DMPlexInvertCell(ct, cone.data()));
-                    PETSC_CHECK(DMPlexSetCone(dm, cell, cone.data()));
-                    PETSC_CHECK(DMLabelSetValue(cell_sets, cell, id));
-                    PETSC_CHECK(DMLabelSetValue(block_label, cell, id));
+                    m->set_cone(cell, cone);
+                    cell_sets.set_value(cell, id);
+                    block_label.set_value(cell, id);
                 }
             }
         }
@@ -139,39 +133,36 @@ FileMesh::create_from_exodus()
         // broadcast dimensions to all ranks
         Int ints[] = { dim, dim_embed };
         comm.broadcast(ints, 2, 0);
-        PETSC_CHECK(DMSetDimension(dm, ints[0]));
-        PETSC_CHECK(DMSetCoordinateDim(dm, ints[1]));
+        m->set_dimension(ints[0]);
+        m->set_coordinate_dim(ints[1]);
         dim = ints[0];
         dim_embed = ints[1];
 
-        PETSC_CHECK(DMPlexSymmetrize(dm));
-        PETSC_CHECK(DMPlexStratify(dm));
+        m->symmetrize();
+        m->stratify();
         m->interpolate();
-        dm = m->get_dm();
 
         // TODO: create vertex sets
 
         // Read coordinates
-        PetscSection coord_section;
-        Vec coordinates;
-        Scalar * coords;
-        Int coord_size;
-        PETSC_CHECK(DMGetCoordinateSection(dm, &coord_section));
-        PETSC_CHECK(PetscSectionSetNumFields(coord_section, 1));
-        PETSC_CHECK(PetscSectionSetFieldComponents(coord_section, 0, dim_embed));
-        PETSC_CHECK(PetscSectionSetChart(coord_section, n_cells, n_cells + n_vertices));
+        auto coord_section = m->get_coordinate_section();
+        coord_section.set_num_fields(1);
+        coord_section.set_num_field_components(0, dim_embed);
+        coord_section.set_chart(n_cells, n_cells + n_vertices);
+
         for (Int vertex = n_cells; vertex < n_cells + n_vertices; ++vertex) {
-            PETSC_CHECK(PetscSectionSetDof(coord_section, vertex, dim_embed));
-            PETSC_CHECK(PetscSectionSetFieldDof(coord_section, vertex, 0, dim_embed));
+            coord_section.set_dof(vertex, dim_embed);
+            coord_section.set_field_dof(vertex, 0, dim_embed);
         }
-        PETSC_CHECK(PetscSectionSetUp(coord_section));
-        PETSC_CHECK(PetscSectionGetStorageSize(coord_section, &coord_size));
-        PETSC_CHECK(VecCreate(comm, &coordinates));
-        PETSC_CHECK(PetscObjectSetName((PetscObject) coordinates, "coordinates"));
-        PETSC_CHECK(VecSetSizes(coordinates, coord_size, PETSC_DETERMINE));
-        PETSC_CHECK(VecSetBlockSize(coordinates, dim_embed));
-        PETSC_CHECK(VecSetType(coordinates, VECSTANDARD));
-        PETSC_CHECK(VecGetArray(coordinates, &coords));
+        coord_section.set_up();
+        auto coord_size = coord_section.get_storage_size();
+
+        Vector coordinates(comm);
+        coordinates.set_name("coordinates");
+        coordinates.set_sizes(coord_size, PETSC_DETERMINE);
+        coordinates.set_block_size(dim_embed);
+        coordinates.set_type(VECSTANDARD);
+        Scalar * coords = coordinates.get_array();
         if (rank == 0) {
             f.read_coords();
             if (dim_embed > 0) {
@@ -190,15 +181,14 @@ FileMesh::create_from_exodus()
                     coords[i * dim_embed + 2] = z[i];
             }
         }
-        PETSC_CHECK(VecRestoreArray(coordinates, &coords));
-        PETSC_CHECK(DMSetCoordinatesLocal(dm, coordinates));
-        PETSC_CHECK(VecDestroy(&coordinates));
+        coordinates.restore_array(coords);
+        m->set_coordinates_local(coordinates);
+        coordinates.destroy();
 
         // Create side set labels
         if ((rank == 0) && (n_side_sets > 0)) {
-            PETSC_CHECK(DMCreateLabel(dm, "Face Sets"));
-            DMLabel face_sets;
-            PETSC_CHECK(DMGetLabel(dm, "Face Sets", &face_sets));
+            m->create_label("Face Sets");
+            auto face_sets = m->get_label("Face Sets");
 
             f.read_side_sets();
             auto & side_sets = f.get_side_sets();
@@ -209,9 +199,8 @@ FileMesh::create_from_exodus()
                 if (name.empty())
                     name = fmt::format("{}", id);
 
-                PETSC_CHECK(DMCreateLabel(dm, name.c_str()));
-                DMLabel face_set_label;
-                PETSC_CHECK(DMGetLabel(dm, name.c_str(), &face_set_label));
+                m->create_label(name);
+                auto face_set_label = m->get_label(name);
                 m->set_face_set_name(id, name);
 
                 std::vector<int> node_count_list;
@@ -228,22 +217,20 @@ FileMesh::create_from_exodus()
                             fmt::format("ExodusII side cannot have more than {} vertices.",
                                         MAX_FACE_VERTICES));
 
-                    Int face_nodes[MAX_FACE_VERTICES];
+                    std::vector<Int> face_nodes(MAX_FACE_VERTICES);
                     for (Int l = 0; l < face_size; ++l, ++k)
                         face_nodes[l] = node_list[k] + n_cells - 1;
 
-                    Int n_faces;
-                    const Int * faces = nullptr;
-                    PETSC_CHECK(DMPlexGetFullJoin(dm, face_size, face_nodes, &n_faces, &faces));
-                    if (n_faces != 1)
+                    auto faces = m->get_full_join(face_nodes);
+                    if (faces.size() != 1)
                         throw Exception(
                             fmt::format("Invalid ExodusII side {} in set {} maps to {} faces.",
                                         j,
                                         i,
-                                        n_faces));
-                    PETSC_CHECK(DMLabelSetValue(face_sets, faces[0], id));
-                    PETSC_CHECK(DMLabelSetValue(face_set_label, faces[0], id));
-                    PETSC_CHECK(DMPlexRestoreJoin(dm, face_size, face_nodes, &n_faces, &faces));
+                                        faces.size()));
+
+                    face_sets.set_value(faces[0], id);
+                    face_set_label.set_value(faces[0], id);
                 }
             }
         }

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -4,6 +4,7 @@
 #include "godzilla/InputFile.h"
 #include "godzilla/App.h"
 #include "godzilla/Factory.h"
+#include "godzilla/MeshObject.h"
 #include "godzilla/Mesh.h"
 #include "godzilla/Problem.h"
 #include "godzilla/Output.h"
@@ -96,7 +97,10 @@ Mesh *
 InputFile::get_mesh() const
 {
     CALL_STACK_MSG();
-    return this->mesh;
+    if (this->mesh)
+        return this->mesh->get_mesh<Mesh>();
+    else
+        return nullptr;
 }
 
 Problem *
@@ -152,7 +156,7 @@ InputFile::build_mesh()
     auto node = get_block(this->root, "mesh");
     Parameters * params = build_params(node);
     const auto & class_name = params->get<std::string>("_type");
-    this->mesh = this->app->build_object<Mesh>(class_name, "mesh", params);
+    this->mesh = this->app->build_object<MeshObject>(class_name, "mesh", params);
     add_object(this->mesh);
 }
 
@@ -164,7 +168,7 @@ InputFile::build_problem()
     auto node = get_block(this->root, "problem");
     Parameters * params = build_params(node);
     const auto & class_name = params->get<std::string>("_type");
-    params->set<Mesh *>("_mesh") = this->mesh;
+    params->set<MeshObject *>("_mesh_obj") = this->mesh;
     this->problem = this->app->build_object<Problem>(class_name, "problem", params);
     add_object(this->problem);
 }

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -46,7 +46,10 @@ void
 LinearProblem::create()
 {
     CALL_STACK_MSG();
-    get_mesh()->distribute();
+    {
+        TIMED_EVENT(9, "MeshDistribution", "Distributing");
+        get_mesh()->distribute();
+    }
     init();
     allocate_objects();
     set_up_matrix_properties();

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -43,6 +43,13 @@ Mesh::get_dimension() const
     return dim;
 }
 
+void
+Mesh::set_dimension(Int dim)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMSetDimension(this->dm, dim));
+}
+
 bool
 Mesh::has_label(const std::string & name) const
 {

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -122,6 +122,13 @@ Mesh::get_coordinate_section() const
 }
 
 void
+Mesh::set_coordinate_dim(Int dim)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMSetCoordinateDim(this->dm, dim));
+}
+
+void
 Mesh::set_up()
 {
     CALL_STACK_MSG();

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -7,20 +7,24 @@
 
 namespace godzilla {
 
-Parameters
-Mesh::parameters()
-{
-    Parameters params = Object::parameters();
-    return params;
-}
+Mesh::Mesh() : dm(nullptr) {}
 
-Mesh::Mesh(const Parameters & parameters) : Object(parameters), PrintInterface(this), dm(nullptr) {}
+Mesh::Mesh(DM dm) : dm(dm) {}
 
 Mesh::~Mesh()
 {
     CALL_STACK_MSG();
     if (this->dm)
         PETSC_CHECK(DMDestroy(&this->dm));
+}
+
+mpi::Communicator
+Mesh::get_comm() const
+{
+    CALL_STACK_MSG();
+    MPI_Comm comm;
+    PETSC_CHECK(PetscObjectGetComm((PetscObject) this->dm, &comm));
+    return { comm };
 }
 
 DM

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -129,6 +129,13 @@ Mesh::set_coordinate_dim(Int dim)
 }
 
 void
+Mesh::set_coordinates_local(const Vector & c)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMSetCoordinatesLocal(this->dm, c));
+}
+
+void
 Mesh::set_up()
 {
     CALL_STACK_MSG();

--- a/src/MeshObject.cpp
+++ b/src/MeshObject.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2024 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "godzilla/MeshObject.h"
+#include "godzilla/App.h"
+#include "godzilla/Mesh.h"
+#include "godzilla/UnstructuredMesh.h"
+#include "godzilla/CallStack.h"
+
+namespace godzilla {
+
+Parameters
+MeshObject::parameters()
+{
+    Parameters params = Object::parameters();
+    return params;
+}
+
+MeshObject::MeshObject(const Parameters & parameters) :
+    Object(parameters),
+    PrintInterface(this),
+    mesh(nullptr)
+{
+}
+
+MeshObject::~MeshObject()
+{
+    delete this->mesh;
+}
+
+void
+MeshObject::create()
+{
+    CALL_STACK_MSG();
+    this->mesh = create_mesh();
+    if (this->mesh) {
+        this->mesh->set_up();
+        lprint_mesh_info();
+    }
+}
+
+void
+MeshObject::lprint_mesh_info()
+{
+    CALL_STACK_MSG();
+    if (get_mesh<UnstructuredMesh>()) {
+        auto um = get_mesh<UnstructuredMesh>();
+        lprint(9, "Information:");
+        lprint(9, "- vertices: {}", um->get_num_vertices());
+        lprint(9, "- elements: {}", um->get_num_cells());
+    }
+}
+
+} // namespace godzilla

--- a/src/MeshPartitioningOutput.cpp
+++ b/src/MeshPartitioningOutput.cpp
@@ -23,9 +23,6 @@ MeshPartitioningOutput::MeshPartitioningOutput(const Parameters & params) : File
 {
     CALL_STACK_MSG();
     set_file_base("part");
-    auto dm = get_problem()->get_dm();
-    if (dm == nullptr)
-        log_error("Mesh partitioning output works only with problems that provide DM.");
 }
 
 std::string
@@ -42,6 +39,7 @@ MeshPartitioningOutput::output_step()
     PetscViewer viewer;
     PETSC_CHECK(PetscViewerHDF5Open(get_comm(), get_file_name().c_str(), FILE_MODE_WRITE, &viewer));
 
+    assert(get_problem()->get_dm() != nullptr);
     DM dmp;
     PETSC_CHECK(DMClone(get_problem()->get_dm(), &dmp));
 

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -122,7 +122,10 @@ void
 NonlinearProblem::create()
 {
     CALL_STACK_MSG();
-    get_mesh()->distribute();
+    {
+        TIMED_EVENT(9, "MeshDistribution", "Distributing");
+        get_mesh()->distribute();
+    }
     init();
     allocate_objects();
     set_up_matrix_properties();

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -3,6 +3,7 @@
 
 #include "godzilla/Problem.h"
 #include "godzilla/CallStack.h"
+#include "godzilla/MeshObject.h"
 #include "godzilla/Mesh.h"
 #include "godzilla/Function.h"
 #include "godzilla/Postprocessor.h"
@@ -32,14 +33,14 @@ Parameters
 Problem::parameters()
 {
     Parameters params = Object::parameters();
-    params.add_private_param<Mesh *>("_mesh", nullptr);
+    params.add_private_param<MeshObject *>("_mesh_obj", nullptr);
     return params;
 }
 
 Problem::Problem(const Parameters & parameters) :
     Object(parameters),
     PrintInterface(this),
-    mesh(get_param<Mesh *>("_mesh")),
+    mesh(get_param<MeshObject *>("_mesh_obj")),
     default_output_on()
 {
 }
@@ -53,7 +54,7 @@ DM
 Problem::get_dm() const
 {
     CALL_STACK_MSG();
-    return this->mesh->get_dm();
+    return get_mesh()->get_dm();
 }
 
 const Vector &
@@ -92,14 +93,14 @@ Mesh *
 Problem::get_mesh() const
 {
     CALL_STACK_MSG();
-    return this->mesh;
+    return this->mesh->get_mesh<Mesh>();
 }
 
 Int
 Problem::get_dimension() const
 {
     CALL_STACK_MSG();
-    return this->mesh->get_dimension();
+    return get_mesh()->get_dimension();
 }
 
 Real

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -414,6 +414,13 @@ UnstructuredMesh::set_cell_set_name(Int id, const std::string & name)
     this->cell_set_ids[name] = id;
 }
 
+void
+UnstructuredMesh::set_cell_type(Int cell, DMPolytopeType cell_type)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMPlexSetCellType(get_dm(), cell, cell_type));
+}
+
 const std::string &
 UnstructuredMesh::get_cell_set_name(Int id) const
 {

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -646,5 +646,12 @@ UnstructuredMesh::symmetrize()
     PETSC_CHECK(DMPlexSymmetrize(get_dm()));
 }
 
+void
+UnstructuredMesh::stratify()
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMPlexStratify(get_dm()));
+}
+
 
 } // namespace godzilla

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -274,6 +274,12 @@ UnstructuredMesh::set_cone_size(Int point, Int size)
     PETSC_CHECK(DMPlexSetConeSize(get_dm(), point, size));
 }
 
+void
+UnstructuredMesh::set_cone(Int point, const std::vector<Int> & cone)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMPlexSetCone(get_dm(), point, cone.data()));
+}
 
 void
 UnstructuredMesh::set_partitioner_type(const std::string & type)

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -639,4 +639,12 @@ UnstructuredMesh::interpolate()
     set_dm(idm);
 }
 
+void
+UnstructuredMesh::symmetrize()
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMPlexSymmetrize(get_dm()));
+}
+
+
 } // namespace godzilla

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -268,6 +268,14 @@ UnstructuredMesh::get_cone_recursive_vertices(IndexSet points) const
 }
 
 void
+UnstructuredMesh::set_cone_size(Int point, Int size)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMPlexSetConeSize(get_dm(), point, size));
+}
+
+
+void
 UnstructuredMesh::set_partitioner_type(const std::string & type)
 {
     CALL_STACK_MSG();

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -653,5 +653,28 @@ UnstructuredMesh::stratify()
     PETSC_CHECK(DMPlexStratify(get_dm()));
 }
 
+std::vector<Int>
+UnstructuredMesh::get_full_join(const std::vector<Int> & points)
+{
+    PetscInt n_covered_points;
+    const PetscInt * covered_points;
+    PETSC_CHECK(DMPlexGetFullJoin(get_dm(),
+                                  points.size(),
+                                  points.data(),
+                                  &n_covered_points,
+                                  &covered_points));
+
+    std::vector<Int> out_points(n_covered_points);
+    for (Int i = 0; i < n_covered_points; i++)
+        out_points[i] = covered_points[i];
+
+    PETSC_CHECK(DMPlexRestoreJoin(get_dm(),
+                                  points.size(),
+                                  points.data(),
+                                  &n_covered_points,
+                                  &covered_points));
+
+    return out_points;
+}
 
 } // namespace godzilla

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -189,6 +189,13 @@ UnstructuredMesh::get_chart() const
     return Range(start, end);
 }
 
+void
+UnstructuredMesh::set_chart(Int start, Int end)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMPlexSetChart(get_dm(), start, end));
+}
+
 DMPolytopeType
 UnstructuredMesh::get_cell_type(Int el) const
 {

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -23,9 +23,6 @@ VTKOutput::parameters()
 VTKOutput::VTKOutput(const Parameters & params) : FileOutput(params), viewer(nullptr)
 {
     CALL_STACK_MSG();
-    const auto * mesh = dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh());
-    if (mesh == nullptr)
-        log_error("VTK output works only with unstructured meshes.");
 }
 
 VTKOutput::~VTKOutput()
@@ -45,6 +42,10 @@ void
 VTKOutput::create()
 {
     CALL_STACK_MSG();
+    const auto * mesh = dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh());
+    if (mesh == nullptr)
+        log_error("VTK output works only with unstructured meshes.");
+
     FileOutput::create();
 
     PETSC_CHECK(PetscViewerCreate(get_comm(), &this->viewer));

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -251,6 +251,13 @@ Vector::set_sizes(Int n, Int N)
 }
 
 void
+Vector::set_block_size(Int bs)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecSetBlockSize(this->vec, bs));
+}
+
+void
 Vector::set_type(VecType method)
 {
     CALL_STACK_MSG();

--- a/test/include/FENonlinearProblem_test.h
+++ b/test/include/FENonlinearProblem_test.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "gmock/gmock.h"
+#include "godzilla/MeshObject.h"
 #include "godzilla/UnstructuredMesh.h"
 #include "godzilla/FENonlinearProblem.h"
 #include "godzilla/InitialCondition.h"
@@ -20,12 +21,12 @@ public:
             const std::string class_name = "LineMesh";
             Parameters * params = this->app->get_parameters(class_name);
             params->set<Int>("nx") = 2;
-            this->mesh = this->app->build_object<UnstructuredMesh>(class_name, "mesh", params);
+            this->mesh = this->app->build_object<MeshObject>(class_name, "mesh", params);
         }
         {
             const std::string class_name = "GTestFENonlinearProblem";
             Parameters * params = this->app->get_parameters(class_name);
-            params->set<Mesh *>("_mesh") = this->mesh;
+            params->set<MeshObject *>("_mesh_obj") = this->mesh;
             this->prob =
                 this->app->build_object<GTestFENonlinearProblem>(class_name, "prob", params);
         }
@@ -38,7 +39,7 @@ public:
         GodzillaAppTest::TearDown();
     }
 
-    UnstructuredMesh * mesh;
+    MeshObject * mesh;
     GTestFENonlinearProblem * prob;
 };
 
@@ -53,12 +54,12 @@ public:
             const std::string class_name = "LineMesh";
             Parameters * params = this->app->get_parameters(class_name);
             params->set<Int>("nx") = 2;
-            this->mesh = this->app->build_object<Mesh>(class_name, "mesh", params);
+            this->mesh = this->app->build_object<MeshObject>(class_name, "mesh", params);
         }
         {
             const std::string class_name = "GTest2FieldsFENonlinearProblem";
             Parameters * params = this->app->get_parameters(class_name);
-            params->set<Mesh *>("_mesh") = this->mesh;
+            params->set<MeshObject *>("_mesh_obj") = this->mesh;
             this->prob =
                 this->app->build_object<GTest2FieldsFENonlinearProblem>(class_name, "prob", params);
         }
@@ -71,6 +72,6 @@ public:
         GodzillaAppTest::TearDown();
     }
 
-    Mesh * mesh;
+    MeshObject * mesh;
     GTest2FieldsFENonlinearProblem * prob;
 };

--- a/test/include/ImplicitFENonlinearProblem_test.h
+++ b/test/include/ImplicitFENonlinearProblem_test.h
@@ -1,28 +1,28 @@
 #pragma once
 
 #include "godzilla/ImplicitFENonlinearProblem.h"
-#include "godzilla/Mesh.h"
+#include "godzilla/MeshObject.h"
 #include "godzilla/InitialCondition.h"
 #include "GodzillaApp_test.h"
 #include "GTestImplicitFENonlinearProblem.h"
 
 class ImplicitFENonlinearProblemTest : public GodzillaAppTest {
 public:
-    Mesh *
+    MeshObject *
     gMesh1d()
     {
         const std::string class_name = "LineMesh";
         Parameters * params = this->app->get_parameters(class_name);
         params->set<Int>("nx") = 2;
-        return this->app->build_object<Mesh>(class_name, "mesh", params);
+        return this->app->build_object<MeshObject>(class_name, "mesh", params);
     }
 
     GTestImplicitFENonlinearProblem *
-    gProblem1d(Mesh * mesh)
+    gProblem1d(MeshObject * mesh)
     {
         const std::string class_name = "GTestImplicitFENonlinearProblem";
         Parameters * params = this->app->get_parameters(class_name);
-        params->set<Mesh *>("_mesh") = mesh;
+        params->set<MeshObject *>("_mesh_obj") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 20;
         params->set<Real>("dt") = 5;

--- a/test/include/LinearProblem_test.h
+++ b/test/include/LinearProblem_test.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "godzilla/Mesh.h"
+#include "godzilla/MeshObject.h"
 #include "godzilla/LinearProblem.h"
 #include "godzilla/Section.h"
 #include "GodzillaApp_test.h"
@@ -54,26 +54,26 @@ protected:
 
 class LinearProblemTest : public GodzillaAppTest {
 protected:
-    Mesh *
+    MeshObject *
     gMesh1d()
     {
         const std::string class_name = "LineMesh";
         Parameters * params = this->app->get_parameters(class_name);
         params->set<Int>("nx") = 1;
-        return this->app->build_object<Mesh>(class_name, "mesh", params);
+        return this->app->build_object<MeshObject>(class_name, "mesh", params);
     }
 
-    Mesh *
+    MeshObject *
     gMesh2d()
     {
         const std::string class_name = "RectangleMesh";
         Parameters * params = this->app->get_parameters(class_name);
         params->set<Int>("nx") = 1;
         params->set<Int>("ny") = 1;
-        return this->app->build_object<Mesh>(class_name, "mesh", params);
+        return this->app->build_object<MeshObject>(class_name, "mesh", params);
     }
 
-    Mesh *
+    MeshObject *
     gMesh3d()
     {
         const std::string class_name = "BoxMesh";
@@ -81,33 +81,33 @@ protected:
         params->set<Int>("nx") = 1;
         params->set<Int>("ny") = 1;
         params->set<Int>("nz") = 1;
-        return this->app->build_object<Mesh>(class_name, "mesh", params);
+        return this->app->build_object<MeshObject>(class_name, "mesh", params);
     }
 
     G1DTestLinearProblem *
-    gProblem1d(Mesh * mesh)
+    gProblem1d(MeshObject * mesh)
     {
         const std::string class_name = "G1DTestLinearProblem";
         Parameters * params = this->app->get_parameters(class_name);
-        params->set<Mesh *>("_mesh") = mesh;
+        params->set<MeshObject *>("_mesh_obj") = mesh;
         return this->app->build_object<G1DTestLinearProblem>(class_name, "problem", params);
     }
 
     G2DTestLinearProblem *
-    gProblem2d(Mesh * mesh)
+    gProblem2d(MeshObject * mesh)
     {
         const std::string class_name = "G2DTestLinearProblem";
         Parameters * params = this->app->get_parameters(class_name);
-        params->set<Mesh *>("_mesh") = mesh;
+        params->set<MeshObject *>("_mesh_obj") = mesh;
         return this->app->build_object<G2DTestLinearProblem>(class_name, "problem", params);
     }
 
     G3DTestLinearProblem *
-    gProblem3d(Mesh * mesh)
+    gProblem3d(MeshObject * mesh)
     {
         const std::string class_name = "G3DTestLinearProblem";
         Parameters * params = this->app->get_parameters(class_name);
-        params->set<Mesh *>("_mesh") = mesh;
+        params->set<MeshObject *>("_mesh_obj") = mesh;
         return this->app->build_object<G3DTestLinearProblem>(class_name, "problem", params);
     }
 };

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -21,10 +21,6 @@ TEST_F(AuxiliaryFieldTest, api)
     class TestAuxFld : public AuxiliaryField {
     public:
         explicit TestAuxFld(const Parameters & params) : AuxiliaryField(params) {}
-        void
-        create() override
-        {
-        }
         Int
         get_num_components() const override
         {
@@ -65,6 +61,7 @@ TEST_F(AuxiliaryFieldTest, api)
     params.set<std::string>("region") = "rgn";
     TestAuxFld aux(params);
     prob->add_auxiliary_field(&aux);
+    prob->create();
 
     EXPECT_EQ(aux.get_label(), nullptr);
     EXPECT_EQ(aux.get_region(), "rgn");
@@ -73,7 +70,7 @@ TEST_F(AuxiliaryFieldTest, api)
     EXPECT_EQ(aux.get_field_id(), 0);
     EXPECT_EQ(aux.get_func(), nullptr);
     EXPECT_EQ(aux.get_context(), &aux);
-    EXPECT_EQ(aux.get_msh(), this->mesh);
+    EXPECT_EQ(aux.get_msh(), this->mesh->get_mesh<Mesh>());
     EXPECT_EQ(aux.get_prblm(), prob);
     EXPECT_EQ(aux.get_dimension(), 1);
 

--- a/test/src/BasicTSAdapt_test.cpp
+++ b/test/src/BasicTSAdapt_test.cpp
@@ -23,7 +23,7 @@ TEST(BasicTSAdapt, api)
     {
         const std::string class_name = "GTestImplicitFENonlinearProblem";
         Parameters * params = app.get_parameters(class_name);
-        params->set<Mesh *>("_mesh") = mesh;
+        params->set<MeshObject *>("_mesh_obj") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 1;
         params->set<Real>("dt") = 0.1;

--- a/test/src/BndJacobianFunc_test.cpp
+++ b/test/src/BndJacobianFunc_test.cpp
@@ -101,7 +101,7 @@ TEST(BndJacobianFuncTest, test)
 
     Parameters prob_pars = GTestProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 20;
     prob_pars.set<Real>("dt") = 5;

--- a/test/src/BndResidualFunc_test.cpp
+++ b/test/src/BndResidualFunc_test.cpp
@@ -101,7 +101,7 @@ TEST(BndResidualFuncTest, test)
 
     Parameters prob_pars = GTestProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 20;
     prob_pars.set<Real>("dt") = 5;

--- a/test/src/BoxMesh_test.cpp
+++ b/test/src/BoxMesh_test.cpp
@@ -1,5 +1,6 @@
 #include "gmock/gmock.h"
 #include "GodzillaApp_test.h"
+#include "godzilla/Mesh.h"
 #include "godzilla/BoxMesh.h"
 #include "godzilla/Parameters.h"
 #include "petsc.h"
@@ -37,10 +38,11 @@ TEST(BoxMeshTest, api)
     EXPECT_EQ(mesh.get_nz(), 7);
 
     mesh.create();
-    auto dm = mesh.get_dm();
 
-    EXPECT_EQ(mesh.get_dimension(), 3);
+    auto m = mesh.get_mesh<Mesh>();
+    EXPECT_EQ(m->get_dimension(), 3);
 
+    auto dm = m->get_dm();
     Real gmin[4], gmax[4];
     DMGetBoundingBox(dm, gmin, gmax);
     EXPECT_EQ(gmin[0], 1);

--- a/test/src/ConstantAuxiliaryField_test.cpp
+++ b/test/src/ConstantAuxiliaryField_test.cpp
@@ -17,7 +17,7 @@ TEST(ConstantAuxiliaryFieldTest, create)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
 
     Parameters aux_params = ConstantAuxiliaryField::parameters();
@@ -56,7 +56,7 @@ TEST(ConstantAuxiliaryFieldTest, evaluate)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
 
     Parameters aux_params = ConstantAuxiliaryField::parameters();

--- a/test/src/DependencyEvaluator_test.cpp
+++ b/test/src/DependencyEvaluator_test.cpp
@@ -82,7 +82,7 @@ TEST(DependencyEvaluator, create_functional)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -107,7 +107,7 @@ TEST(DependencyEvaluator, create_existing_functional)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -132,7 +132,7 @@ TEST(DependencyEvaluator, get_non_existent_functional)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -152,7 +152,7 @@ TEST(DependencyEvaluator, eval)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -196,7 +196,7 @@ TEST(DependencyEvaluator, redeclare_a_value)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -220,7 +220,7 @@ TEST(DependencyEvaluator, get_suppliers)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();
@@ -254,7 +254,7 @@ TEST(DependencyEvaluator, build_dep_graph)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();

--- a/test/src/DirichletBC_test.cpp
+++ b/test/src/DirichletBC_test.cpp
@@ -19,7 +19,7 @@ TEST(DirichletBCTest, api)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem problem(prob_pars);
     app.set_problem(&problem);
 
@@ -61,7 +61,7 @@ TEST(DirichletBCTest, with_user_defined_fn)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem problem(prob_pars);
     app.set_problem(&problem);
 

--- a/test/src/EssentialBC_test.cpp
+++ b/test/src/EssentialBC_test.cpp
@@ -42,7 +42,7 @@ TEST(EssentialBCTest, api)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem problem(prob_pars);
     app.set_problem(&problem);
 
@@ -87,7 +87,7 @@ TEST(EssentialBCTest, non_existing_field)
 
     Parameters prob_pars = GTest2FieldsFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTest2FieldsFENonlinearProblem problem(prob_pars);
     app.set_problem(&problem);
 
@@ -120,7 +120,7 @@ TEST(EssentialBCTest, field_param_not_specified)
 
     Parameters prob_pars = GTest2FieldsFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTest2FieldsFENonlinearProblem problem(prob_pars);
     app.set_problem(&problem);
 

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -104,7 +104,7 @@ TEST(ExplicitFELinearProblemTest, test_mass_matrix)
 
     Parameters prob_pars = TestExplicitFELinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -155,7 +155,7 @@ TEST(ExplicitFELinearProblemTest, test_lumped_mass_matrix)
 
     Parameters prob_pars = TestExplicitFELinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -184,7 +184,7 @@ TEST(ExplicitFELinearProblemTest, solve)
 
     Parameters prob_pars = TestExplicitFELinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -244,7 +244,7 @@ TEST(ExplicitFELinearProblemTest, solve_w_lumped_mass_matrix)
 
     Parameters prob_pars = TestExplicitFELinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -304,7 +304,7 @@ TEST(ExplicitFELinearProblemTest, set_schemes)
 
     Parameters prob_pars = TestExplicitFELinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -345,7 +345,7 @@ TEST(ExplicitFELinearProblemTest, wrong_scheme)
     {
         const std::string class_name = "TestExplicitFELinearProblem";
         Parameters * params = app.get_parameters(class_name);
-        params->set<Mesh *>("_mesh") = mesh;
+        params->set<MeshObject *>("_mesh_obj") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 20;
         params->set<Real>("dt") = 5;
@@ -374,7 +374,7 @@ TEST(ExplicitFELinearProblemTest, allocate_mass_matrix)
 
     Parameters prob_pars = TestExplicitFELinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -401,7 +401,7 @@ TEST(ExplicitFELinearProblemTest, allocate_lumped_mass_matrix)
 
     Parameters prob_pars = TestExplicitFELinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -154,7 +154,7 @@ TEST(ExplicitFVLinearProblemTest, api)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -247,7 +247,7 @@ TEST(ExplicitFVLinearProblemTest, fields)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -290,7 +290,7 @@ TEST(ExplicitFVLinearProblemTest, test_mass_matrix)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -322,7 +322,7 @@ TEST(ExplicitFVLinearProblemTest, solve)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -382,7 +382,7 @@ TEST(ExplicitFVLinearProblemTest, set_schemes)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;
@@ -417,7 +417,7 @@ TEST(ExplicitFVLinearProblemTest, wrong_schemes)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;

--- a/test/src/FEBoundary1D_test.cpp
+++ b/test/src/FEBoundary1D_test.cpp
@@ -1,5 +1,6 @@
 #include "gmock/gmock.h"
 #include "TestApp.h"
+#include "godzilla/MeshObject.h"
 #include "godzilla/FEGeometry.h"
 #include "godzilla/FEVolumes.h"
 #include "godzilla/FEShapeFns.h"
@@ -22,41 +23,47 @@ points_from_label(const Label & label)
 
 namespace {
 
-class TestMesh1D : public godzilla::UnstructuredMesh {
+class TestMesh1D : public MeshObject {
 public:
-    explicit TestMesh1D(const godzilla::Parameters & parameters) : UnstructuredMesh(parameters) {}
+    explicit TestMesh1D(const godzilla::Parameters & parameters) : MeshObject(parameters) {}
 
-    void
-    create() override
+    Mesh *
+    create_mesh() override
     {
-        const PetscInt DIM = 1;
-        const PetscInt N_ELEM_NODES = 2;
+        const Int DIM = 1;
+        const Int N_ELEM_NODES = 2;
         std::vector<Int> cells = { 0, 1, 1, 2 };
         std::vector<Real> coords = { 0, 0.4, 1 };
-        build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
+        auto m = UnstructuredMesh::build_from_cell_list(get_comm(),
+                                                            DIM,
+                                                            N_ELEM_NODES,
+                                                            cells,
+                                                            DIM,
+                                                            coords,
+                                                            true);
 
         // create "side sets"
-        auto face_sets = create_label("Face Sets");
+        auto face_sets = m->create_label("Face Sets");
 
-        create_side_set(face_sets, 1, { 2 }, "left");
-        create_side_set(face_sets, 2, { 4 }, "right");
+        create_side_set(m, face_sets, 1, { 2 }, "left");
+        create_side_set(m, face_sets, 2, { 4 }, "right");
 
         std::map<Int, std::string> face_set_names;
         face_set_names[1] = "left";
         face_set_names[2] = "right";
-        create_face_set_labels(face_set_names);
+        m->create_face_set_labels(face_set_names);
         for (auto it : face_set_names)
-            set_face_set_name(it.first, it.second);
+            m->set_face_set_name(it.first, it.second);
 
-        set_up();
+        return m;
     }
 
     void
-    create_side_set(Label & face_sets, Int id, const std::vector<Int> & faces, const char * name)
+    create_side_set(UnstructuredMesh * mesh, Label & face_sets, Int id, const std::vector<Int> & faces, const char * name)
     {
         for (auto & f : faces) {
             face_sets.set_value(f, id);
-            PETSC_CHECK(DMSetLabelValue(get_dm(), name, f, id));
+            PETSC_CHECK(DMSetLabelValue(mesh->get_dm(), name, f, id));
         }
     }
 
@@ -92,7 +99,7 @@ public:
 Parameters
 TestMesh1D::parameters()
 {
-    Parameters params = UnstructuredMesh::parameters();
+    Parameters params = MeshObject::parameters();
     return params;
 }
 
@@ -107,14 +114,16 @@ TEST(FEBoundaryTest, nodal_normals_1d)
     TestMesh1D mesh(mesh_pars);
     mesh.create();
 
-    auto coords = fe::coordinates<1>(mesh);
-    auto connect = fe::connectivity<1, 2>(mesh);
+    auto m = mesh.get_mesh<UnstructuredMesh>();
+
+    auto coords = fe::coordinates<1>(*m);
+    auto connect = fe::connectivity<1, 2>(*m);
     auto fe_volume = fe::calc_volumes<EDGE2, 1>(coords, connect);
     auto grad_phi = fe::calc_grad_shape<EDGE2, 1>(coords, connect, fe_volume);
 
     {
-        IndexSet bnd_facets = points_from_label(mesh.get_label("left"));
-        TestBoundary1D bnd(&mesh, &grad_phi, bnd_facets);
+        IndexSet bnd_facets = points_from_label(m->get_label("left"));
+        TestBoundary1D bnd(m, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), -1);
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(0)(0), -1);
@@ -123,8 +132,8 @@ TEST(FEBoundaryTest, nodal_normals_1d)
     }
 
     {
-        IndexSet bnd_facets = points_from_label(mesh.get_label("right"));
-        TestBoundary1D bnd(&mesh, &grad_phi, bnd_facets);
+        IndexSet bnd_facets = points_from_label(m->get_label("right"));
+        TestBoundary1D bnd(m, &grad_phi, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 1);
         EXPECT_DOUBLE_EQ(bnd.nodal_normal(0)(0), 1);

--- a/test/src/FEBoundary3D_test.cpp
+++ b/test/src/FEBoundary3D_test.cpp
@@ -1,5 +1,6 @@
 #include "gmock/gmock.h"
 #include "TestApp.h"
+#include "godzilla/MeshObject.h"
 #include "godzilla/FEGeometry.h"
 #include "godzilla/FEVolumes.h"
 #include "godzilla/FEShapeFns.h"
@@ -22,45 +23,55 @@ points_from_label(const Label & label)
 
 namespace {
 
-class TestMesh3D : public godzilla::UnstructuredMesh {
+class TestMesh3D : public MeshObject {
 public:
-    explicit TestMesh3D(const godzilla::Parameters & parameters) : UnstructuredMesh(parameters) {}
+    explicit TestMesh3D(const godzilla::Parameters & parameters) : MeshObject(parameters) {}
 
-    void
-    create() override
+    Mesh *
+    create_mesh() override
     {
-        const PetscInt DIM = 3;
-        const PetscInt N_ELEM_NODES = 4;
+        const Int DIM = 3;
+        const Int N_ELEM_NODES = 4;
         std::vector<Int> cells = { 0, 1, 2, 3 };
         std::vector<Real> coords = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1 };
-        build_from_cell_list(DIM, N_ELEM_NODES, cells, DIM, coords, true);
+        auto m = UnstructuredMesh::build_from_cell_list(get_comm(),
+                                                        DIM,
+                                                        N_ELEM_NODES,
+                                                        cells,
+                                                        DIM,
+                                                        coords,
+                                                        true);
 
         // create "side sets"
-        auto face_sets = create_label("Face Sets");
+        auto face_sets = m->create_label("Face Sets");
 
-        create_side_set(face_sets, 1, { 6 }, "front");
-        create_side_set(face_sets, 2, { 5 }, "bottom");
-        create_side_set(face_sets, 3, { 7 }, "left");
-        create_side_set(face_sets, 4, { 8 }, "slanted");
+        create_side_set(m, face_sets, 1, { 6 }, "front");
+        create_side_set(m, face_sets, 2, { 5 }, "bottom");
+        create_side_set(m, face_sets, 3, { 7 }, "left");
+        create_side_set(m, face_sets, 4, { 8 }, "slanted");
 
         std::map<Int, std::string> face_set_names;
         face_set_names[1] = "front";
         face_set_names[2] = "bottom";
         face_set_names[3] = "left";
         face_set_names[4] = "slanted";
-        create_face_set_labels(face_set_names);
+        m->create_face_set_labels(face_set_names);
         for (auto it : face_set_names)
-            set_face_set_name(it.first, it.second);
+            m->set_face_set_name(it.first, it.second);
 
-        set_up();
+        return m;
     }
 
     void
-    create_side_set(Label & face_sets, Int id, const std::vector<Int> & faces, const char * name)
+    create_side_set(UnstructuredMesh * mesh,
+                    Label & face_sets,
+                    Int id,
+                    const std::vector<Int> & faces,
+                    const char * name)
     {
         for (auto & f : faces) {
             face_sets.set_value(f, id);
-            PETSC_CHECK(DMSetLabelValue(get_dm(), name, f, id));
+            PETSC_CHECK(DMSetLabelValue(mesh->get_dm(), name, f, id));
         }
     }
 
@@ -96,7 +107,7 @@ public:
 Parameters
 TestMesh3D::parameters()
 {
-    Parameters params = UnstructuredMesh::parameters();
+    Parameters params = MeshObject::parameters();
     return params;
 }
 

--- a/test/src/FENonlinearProblemJFNK_test.cpp
+++ b/test/src/FENonlinearProblemJFNK_test.cpp
@@ -134,7 +134,7 @@ TEST(FENonlinearProblemJFNKTest, solve)
 
     Parameters prob_params = GTestFENonlinearProblemJFNK::parameters();
     prob_params.set<godzilla::App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblemJFNK prob(prob_params);
     app.set_problem(&prob);
 

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -276,29 +276,22 @@ TEST(TwoFieldFENonlinearProblemTest, err_duplicate_ics)
         TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla") {}
     } app;
 
-    Mesh * mesh;
-    {
-        const std::string class_name = "LineMesh";
-        Parameters * params = app.get_parameters(class_name);
-        params->set<Int>("nx") = 2;
-        mesh = app.build_object<Mesh>(class_name, "mesh", params);
-    }
-    FENonlinearProblem * prob;
-    {
-        const std::string class_name = "GTest2FieldsFENonlinearProblem";
-        Parameters * params = app.get_parameters(class_name);
-        params->set<Mesh *>("_mesh") = mesh;
-        prob = app.build_object<FENonlinearProblem>(class_name, "prob", params);
-    }
-    {
-        const std::string class_name = "ConstantInitialCondition";
-        Parameters * params = app.get_parameters(class_name);
-        params->set<DiscreteProblemInterface *>("_dpi") = prob;
-        params->set<std::string>("field") = "u";
-        params->set<std::vector<Real>>("value") = { 0.1 };
-        auto ic = app.build_object<InitialCondition>(class_name, "ic1", params);
-        prob->add_initial_condition(ic);
-    }
+    Parameters * mesh_params = app.get_parameters("LineMesh");
+    mesh_params->set<Int>("nx") = 2;
+    auto mesh = app.build_object<MeshObject>("LineMesh", "mesh", mesh_params);
+
+    Parameters * prob_params = app.get_parameters("GTest2FieldsFENonlinearProblem");
+    prob_params->set<MeshObject *>("_mesh_obj") = mesh;
+    auto prob =
+        app.build_object<FENonlinearProblem>("GTest2FieldsFENonlinearProblem", "prob", prob_params);
+
+    Parameters * ic1_params = app.get_parameters("ConstantInitialCondition");
+    ic1_params->set<DiscreteProblemInterface *>("_dpi") = prob;
+    ic1_params->set<std::string>("field") = "u";
+    ic1_params->set<std::vector<Real>>("value") = { 0.1 };
+    auto ic1 = app.build_object<InitialCondition>("ConstantInitialCondition", "ic1", ic1_params);
+    prob->add_initial_condition(ic1);
+
     const std::string class_name = "ConstantInitialCondition";
     Parameters * params = app.get_parameters(class_name);
     params->set<DiscreteProblemInterface *>("_dpi") = prob;
@@ -325,31 +318,21 @@ TEST(TwoFieldFENonlinearProblemTest, err_not_enough_ics)
         TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla") {}
     } app;
 
-    UnstructuredMesh * mesh;
-    FENonlinearProblem * prob;
+    Parameters * mesh_params = app.get_parameters("LineMesh");
+    mesh_params->set<Int>("nx") = 2;
+    auto mesh = app.build_object<LineMesh>("LineMesh", "mesh", mesh_params);
 
-    {
-        const std::string class_name = "LineMesh";
-        Parameters * params = app.get_parameters(class_name);
-        params->set<Int>("nx") = 2;
-        mesh = app.build_object<LineMesh>(class_name, "mesh", params);
-    }
-    {
-        const std::string class_name = "GTest2FieldsFENonlinearProblem";
-        Parameters * params = app.get_parameters(class_name);
-        params->set<Mesh *>("_mesh") = mesh;
-        prob = app.build_object<FENonlinearProblem>(class_name, "prob", params);
-    }
+    Parameters * prob_params = app.get_parameters("GTest2FieldsFENonlinearProblem");
+    prob_params->set<MeshObject *>("_mesh_obj") = mesh;
+    auto prob =
+        app.build_object<FENonlinearProblem>("GTest2FieldsFENonlinearProblem", "prob", prob_params);
 
-    {
-        const std::string class_name = "ConstantInitialCondition";
-        Parameters * params = app.get_parameters(class_name);
-        params->set<DiscreteProblemInterface *>("_dpi") = prob;
-        params->set<std::vector<Real>>("value") = { 0.1 };
-        params->set<std::string>("field") = "u";
-        auto ic = app.build_object<InitialCondition>(class_name, "ic1", params);
-        prob->add_initial_condition(ic);
-    }
+    Parameters * ic_params = app.get_parameters("ConstantInitialCondition");
+    ic_params->set<DiscreteProblemInterface *>("_dpi") = prob;
+    ic_params->set<std::vector<Real>>("value") = { 0.1 };
+    ic_params->set<std::string>("field") = "u";
+    auto ic = app.build_object<InitialCondition>("ConstantInitialCondition", "ic1", ic_params);
+    prob->add_initial_condition(ic);
 
     mesh->create();
     prob->create();
@@ -399,7 +382,7 @@ TEST(TwoFieldFENonlinearProblemTest, field_decomposition)
     auto mesh = app.build_object<LineMesh>("LineMesh", "mesh", mesh_pars);
 
     Parameters * prob_pars = app.get_parameters("GTest2FieldsFENonlinearProblem");
-    prob_pars->set<Mesh *>("_mesh") = mesh;
+    prob_pars->set<MeshObject *>("_mesh_obj") = mesh;
     auto prob =
         app.build_object<FENonlinearProblem>("GTest2FieldsFENonlinearProblem", "prob", prob_pars);
 

--- a/test/src/FunctionAuxiliaryField_test.cpp
+++ b/test/src/FunctionAuxiliaryField_test.cpp
@@ -17,7 +17,7 @@ TEST(FunctionAuxiliaryFieldTest, create)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
 
     Parameters aux_params = FunctionAuxiliaryField::parameters();
@@ -56,7 +56,7 @@ TEST(FunctionAuxiliaryFieldTest, evaluate)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
 
     Parameters aux_params = FunctionAuxiliaryField::parameters();

--- a/test/src/FunctionIC_test.cpp
+++ b/test/src/FunctionIC_test.cpp
@@ -18,7 +18,7 @@ TEST(FunctionICTest, api)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     Parameters params = FunctionInitialCondition::parameters();

--- a/test/src/GYMLFile_test.cpp
+++ b/test/src/GYMLFile_test.cpp
@@ -172,10 +172,10 @@ TEST_F(GYMLFileTest, mesh_partitioner)
 
     file.parse(file_name);
     file.build();
+    file.create_objects();
 
     auto mesh = file.get_mesh();
     EXPECT_NE(mesh, nullptr);
-    mesh->create();
 
     auto dm = mesh->get_dm();
     PetscBool distr;
@@ -195,9 +195,7 @@ TEST_F(GYMLFileTest, build)
 
     EXPECT_TRUE(file.parse(file_name));
     file.build();
-
-    auto mesh = dynamic_cast<LineMesh *>(file.get_mesh());
-    EXPECT_NE(mesh, nullptr);
+    file.create_objects();
 
     auto problem = file.get_problem();
     EXPECT_NE(problem, nullptr);
@@ -249,9 +247,6 @@ TEST_F(GYMLFileTest, build_vec_as_scalars)
     file.parse(file_name);
     file.build();
 
-    auto mesh = dynamic_cast<LineMesh *>(file.get_mesh());
-    EXPECT_NE(mesh, nullptr);
-
     auto problem = file.get_problem();
     EXPECT_NE(problem, nullptr);
 }
@@ -283,9 +278,6 @@ TEST_F(GYMLFileTest, build_fe)
     file.parse(file_name);
     file.build();
 
-    auto mesh = dynamic_cast<LineMesh *>(file.get_mesh());
-    EXPECT_NE(mesh, nullptr);
-
     auto problem = file.get_problem();
     EXPECT_NE(problem, nullptr);
 }
@@ -299,9 +291,6 @@ TEST_F(GYMLFileTest, simple_fe_pps)
 
     file.parse(file_name);
     file.build();
-
-    auto mesh = dynamic_cast<LineMesh *>(file.get_mesh());
-    EXPECT_NE(mesh, nullptr);
 
     auto problem = file.get_problem();
     EXPECT_NE(problem, nullptr);
@@ -320,9 +309,6 @@ TEST_F(GYMLFileTest, build_fe_w_aux)
 
     file.parse(file_name);
     file.build();
-
-    auto mesh = dynamic_cast<LineMesh *>(file.get_mesh());
-    EXPECT_NE(mesh, nullptr);
 
     auto problem = dynamic_cast<FEProblemInterface *>(file.get_problem());
     EXPECT_NE(problem, nullptr);

--- a/test/src/GmshMesh_test.cpp
+++ b/test/src/GmshMesh_test.cpp
@@ -1,5 +1,6 @@
 #include "gmock/gmock.h"
 #include "GodzillaApp_test.h"
+#include "godzilla/UnstructuredMesh.h"
 #include "godzilla/GmshMesh.h"
 #include "godzilla/Parameters.h"
 #include "petsc.h"
@@ -20,9 +21,10 @@ TEST(GmshMeshTest, api)
     EXPECT_EQ(mesh.get_file_name(), file_name);
 
     mesh.create();
-    auto dm = mesh.get_dm();
+    auto m = mesh.get_mesh<UnstructuredMesh>();
+    auto dm = m->get_dm();
 
-    EXPECT_EQ(mesh.get_dimension(), 2);
+    EXPECT_EQ(m->get_dimension(), 2);
 
     Real gmin[4], gmax[4];
     DMGetBoundingBox(dm, gmin, gmax);

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -64,7 +64,7 @@ TEST_F(ImplicitFENonlinearProblemTest, wrong_scheme)
     {
         const std::string class_name = "GTestImplicitFENonlinearProblem";
         Parameters * params = this->app->get_parameters(class_name);
-        params->set<Mesh *>("_mesh") = mesh;
+        params->set<MeshObject *>("_mesh_obj") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 20;
         params->set<Real>("dt") = 5;
@@ -89,7 +89,7 @@ TEST_F(ImplicitFENonlinearProblemTest, wrong_time_stepping_params)
 
     const std::string class_name = "GTestImplicitFENonlinearProblem";
     Parameters * params = this->app->get_parameters(class_name);
-    params->set<Mesh *>("_mesh") = mesh;
+    params->set<MeshObject *>("_mesh_obj") = mesh;
     params->set<Real>("start_time") = 0.;
     params->set<Int>("num_steps") = 2;
     params->set<Real>("end_time") = 20;
@@ -117,7 +117,7 @@ TEST_F(ImplicitFENonlinearProblemTest, no_time_stepping_params)
 
     const std::string class_name = "GTestImplicitFENonlinearProblem";
     Parameters * params = this->app->get_parameters(class_name);
-    params->set<Mesh *>("_mesh") = mesh;
+    params->set<MeshObject *>("_mesh_obj") = mesh;
     params->set<Real>("start_time") = 0.;
     params->set<Real>("dt") = 5;
     params->set<std::string>("scheme") = "asdf";
@@ -140,24 +140,19 @@ TEST_F(ImplicitFENonlinearProblemTest, set_schemes)
     auto prob = gProblem1d(mesh);
     this->app->set_problem(prob);
 
-    {
-        const std::string class_name = "ConstantInitialCondition";
-        Parameters * params = this->app->get_parameters(class_name);
-        params->set<DiscreteProblemInterface *>("_dpi") = prob;
-        params->set<std::vector<Real>>("value") = { 0 };
-        auto ic = this->app->build_object<InitialCondition>(class_name, "ic", params);
-        prob->add_initial_condition(ic);
-    }
+    Parameters * ic_params = this->app->get_parameters("ConstantInitialCondition");
+    ic_params->set<DiscreteProblemInterface *>("_dpi") = prob;
+    ic_params->set<std::vector<Real>>("value") = { 0 };
+    auto ic =
+        this->app->build_object<InitialCondition>("ConstantInitialCondition", "ic", ic_params);
+    prob->add_initial_condition(ic);
 
-    {
-        const std::string class_name = "DirichletBC";
-        Parameters * params = this->app->get_parameters(class_name);
-        params->set<std::vector<std::string>>("boundary") = { "left", "right" };
-        params->set<std::vector<std::string>>("value") = { "x*x" };
-        params->set<DiscreteProblemInterface *>("_dpi") = prob;
-        auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc", params);
-        prob->add_boundary_condition(bc);
-    }
+    Parameters * prob_params = this->app->get_parameters("DirichletBC");
+    prob_params->set<std::vector<std::string>>("boundary") = { "left", "right" };
+    prob_params->set<std::vector<std::string>>("value") = { "x*x" };
+    prob_params->set<DiscreteProblemInterface *>("_dpi") = prob;
+    auto bc = this->app->build_object<BoundaryCondition>("DirichletBC", "bc", prob_params);
+    prob->add_boundary_condition(bc);
 
     mesh->create();
     prob->create();
@@ -182,24 +177,19 @@ TEST_F(ImplicitFENonlinearProblemTest, converged_reason)
     auto prob = gProblem1d(mesh);
     this->app->set_problem(prob);
 
-    {
-        const std::string class_name = "ConstantInitialCondition";
-        Parameters * params = this->app->get_parameters(class_name);
-        params->set<DiscreteProblemInterface *>("_dpi") = prob;
-        params->set<std::vector<Real>>("value") = { 0 };
-        auto ic = this->app->build_object<InitialCondition>(class_name, "ic", params);
-        prob->add_initial_condition(ic);
-    }
+    Parameters * ic_params = this->app->get_parameters("ConstantInitialCondition");
+    ic_params->set<DiscreteProblemInterface *>("_dpi") = prob;
+    ic_params->set<std::vector<Real>>("value") = { 0 };
+    auto ic =
+        this->app->build_object<InitialCondition>("ConstantInitialCondition", "ic", ic_params);
+    prob->add_initial_condition(ic);
 
-    {
-        const std::string class_name = "DirichletBC";
-        Parameters * params = this->app->get_parameters(class_name);
-        params->set<std::vector<std::string>>("boundary") = { "left", "right" };
-        params->set<std::vector<std::string>>("value") = { "x*x" };
-        params->set<DiscreteProblemInterface *>("_dpi") = prob;
-        auto bc = this->app->build_object<BoundaryCondition>(class_name, "bc", params);
-        prob->add_boundary_condition(bc);
-    }
+    Parameters * bc_params = this->app->get_parameters("DirichletBC");
+    bc_params->set<std::vector<std::string>>("boundary") = { "left", "right" };
+    bc_params->set<std::vector<std::string>>("value") = { "x*x" };
+    bc_params->set<DiscreteProblemInterface *>("_dpi") = prob;
+    auto bc = this->app->build_object<BoundaryCondition>("DirichletBC", "bc", bc_params);
+    prob->add_boundary_condition(bc);
 
     mesh->create();
     prob->create();

--- a/test/src/InitialCondition_test.cpp
+++ b/test/src/InitialCondition_test.cpp
@@ -11,13 +11,6 @@ namespace {
 
 class InitialConditionTest : public FENonlinearProblemTest {
 public:
-    //    void
-    //    SetUp() override
-    //    {
-    //        FENonlinearProblemTest::SetUp();
-    //    }
-    //
-    //    const Int ia;
 };
 
 class InitialCondition2FieldTest : public FENonlinear2FieldProblemTest {

--- a/test/src/JacobianFunc_test.cpp
+++ b/test/src/JacobianFunc_test.cpp
@@ -74,16 +74,16 @@ TEST(JacobianFuncTest, test)
     mesh_pars.set<App *>("_app") = &app;
     mesh_pars.set<Int>("nx") = 2;
     LineMesh mesh(mesh_pars);
+    mesh.create();
 
     Parameters prob_pars = GTestProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 20;
     prob_pars.set<Real>("dt") = 5;
     GTestProblem prob(prob_pars);
 
-    mesh.create();
     prob.create();
 
     Int dim;

--- a/test/src/KrylovSolver_test.cpp
+++ b/test/src/KrylovSolver_test.cpp
@@ -2,6 +2,7 @@
 #include "godzilla/KrylovSolver.h"
 #include "godzilla/Matrix.h"
 #include "godzilla/Vector.h"
+#include "godzilla/UnstructuredMesh.h"
 #include "godzilla/LineMesh.h"
 #include "godzilla/PCHypre.h"
 #include "TestApp.h"
@@ -158,7 +159,8 @@ TEST(KrylovSolver, set_opers_rhs)
     LineMesh mesh(mesh_pars);
     mesh.create();
 
-    auto dm = mesh.get_dm();
+    auto m = mesh.get_mesh<UnstructuredMesh>();
+    auto dm = m->get_dm();
     DMSetNumFields(dm, 1);
     Int nc[1] = { 1 };
     Int n_dofs[2] = { 1, 0 };
@@ -226,7 +228,8 @@ TEST(KrylovSolver, set_opers_rhs_c_version)
     LineMesh mesh(mesh_pars);
     mesh.create();
 
-    auto dm = mesh.get_dm();
+    auto m = mesh.get_mesh<UnstructuredMesh>();
+    auto dm = m->get_dm();
     DMSetNumFields(dm, 1);
     Int nc[1] = { 1 };
     Int n_dofs[2] = { 1, 0 };

--- a/test/src/L2Diff_test.cpp
+++ b/test/src/L2Diff_test.cpp
@@ -16,7 +16,7 @@ TEST(L2DiffTest, compute)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
     app.set_problem(&prob);
 

--- a/test/src/LineMesh_test.cpp
+++ b/test/src/LineMesh_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "GodzillaApp_test.h"
+#include "godzilla/UnstructuredMesh.h"
 #include "godzilla/Parameters.h"
 #include "godzilla/LineMesh.h"
 #include "petsc.h"
@@ -24,9 +25,11 @@ TEST(LineMeshTest, api)
     EXPECT_EQ(mesh.get_nx(), 10);
 
     mesh.create();
-    auto dm = mesh.get_dm();
 
-    EXPECT_EQ(mesh.get_dimension(), 1);
+    auto m = mesh.get_mesh<UnstructuredMesh>();
+    auto dm = m->get_dm();
+
+    EXPECT_EQ(m->get_dimension(), 1);
 
     Real gmin[4], gmax[4];
     DMGetBoundingBox(dm, gmin, gmax);
@@ -76,8 +79,9 @@ TEST(LineMeshTest, distribute)
     LineMesh mesh(params);
     mesh.create();
 
+    auto m = mesh.get_mesh<Mesh>();
     PetscBool distr;
-    DMPlexIsDistributed(mesh.get_dm(), &distr);
+    DMPlexIsDistributed(m->get_dm(), &distr);
     if (sz > 1)
         EXPECT_EQ(distr, 1);
     else

--- a/test/src/LinearProblem_test.cpp
+++ b/test/src/LinearProblem_test.cpp
@@ -73,7 +73,7 @@ TEST_F(LinearProblemTest, run)
 
     Parameters prob_pars = LinearProblem::parameters();
     prob_pars.set<App *>("_app") = this->app;
-    prob_pars.set<Mesh *>("_mesh") = mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = mesh;
     MockLinearProblem prob(prob_pars);
 
     EXPECT_CALL(prob, solve);

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -22,7 +22,7 @@ TEST(NaturalBCTest, api)
 
     Parameters prob_params = GTestFENonlinearProblem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_params);
     app.set_problem(&prob);
 
@@ -121,7 +121,7 @@ TEST(NaturalBCTest, fe)
 
     Parameters prob_params = GTest2FieldsFENonlinearProblem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     GTest2FieldsFENonlinearProblem prob(prob_params);
     app.set_problem(&prob);
 
@@ -146,7 +146,8 @@ TEST(NaturalBCTest, fe)
     //
     Int field = bc.get_field_id();
     WeakForm * wf = prob.get_weak_form();
-    auto label = mesh.get_label("left");
+    auto m = mesh.get_mesh<UnstructuredMesh>();
+    auto label = m->get_label("left");
     auto ids = label.get_values();
 
     const auto & f0 = wf->get(WeakForm::BND_F0, label, ids[0], field, 0);
@@ -171,7 +172,7 @@ TEST(NaturalBCTest, non_existing_field)
 
     Parameters prob_pars = GTest2FieldsFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTest2FieldsFENonlinearProblem problem(prob_pars);
     app.set_problem(&problem);
 
@@ -204,7 +205,7 @@ TEST(NaturalBCTest, field_param_not_specified)
 
     Parameters prob_pars = GTest2FieldsFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTest2FieldsFENonlinearProblem problem(prob_pars);
     app.set_problem(&problem);
 

--- a/test/src/NaturalRiemannBC_test.cpp
+++ b/test/src/NaturalRiemannBC_test.cpp
@@ -77,7 +77,7 @@ TEST(NaturalRiemannBCTest, api)
 
     Parameters prob_pars = TestExplicitFVLinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 1e-3;
     prob_pars.set<Real>("dt") = 1e-3;

--- a/test/src/NeumannProblem_test.cpp
+++ b/test/src/NeumannProblem_test.cpp
@@ -179,7 +179,7 @@ TEST(NeumannProblemTest, solve)
 
     Parameters prob_params = TestNeumannProblem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     TestNeumannProblem prob(prob_params);
     app.set_problem(&prob);
 

--- a/test/src/NonlinearProblem_test.cpp
+++ b/test/src/NonlinearProblem_test.cpp
@@ -99,7 +99,7 @@ TEST(NonlinearProblemTest, initial_guess)
 
     Parameters prob_pars = G1DTestNonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     G1DTestNonlinearProblem prob(prob_pars);
     prob.create();
     prob.call_initial_guess();
@@ -122,7 +122,7 @@ TEST(NonlinearProblemTest, solve)
 
     Parameters prob_pars = G1DTestNonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     G1DTestNonlinearProblem prob(prob_pars);
 
     prob.create();
@@ -159,7 +159,7 @@ TEST(NonlinearProblemTest, compute_callbacks)
 
     Parameters prob_pars = NonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     NonlinearProblem prob(prob_pars);
 
     Vector x;
@@ -198,7 +198,7 @@ TEST(NonlinearProblemTest, run)
 
     Parameters prob_pars = NonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     MockNonlinearProblem prob(prob_pars);
 
     EXPECT_CALL(prob, set_up_initial_guess);
@@ -233,7 +233,7 @@ TEST(NonlinearProblemTest, line_search_type)
     for (auto & lst : ls_type) {
         Parameters prob_pars = NonlinearProblem::parameters();
         prob_pars.set<App *>("_app") = &app;
-        prob_pars.set<Mesh *>("_mesh") = &mesh;
+        prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
         prob_pars.set<std::string>("line_search") = lst;
         MockNonlinearProblem prob(prob_pars);
         prob.create();
@@ -266,7 +266,7 @@ TEST(NonlinearProblemTest, invalid_line_search_type)
 
     Parameters prob_pars = NonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<std::string>("line_search") = "asdf";
     MockNonlinearProblem prob(prob_pars);
     prob.create();

--- a/test/src/PCFieldSplit_test.cpp
+++ b/test/src/PCFieldSplit_test.cpp
@@ -171,7 +171,7 @@ TEST(PCFieldSplit, schur)
     auto mesh = app.build_object<LineMesh>("LineMesh", "mesh", mesh_pars);
 
     Parameters * prob_pars = app.get_parameters("GTest2FieldsFENonlinearProblem");
-    prob_pars->set<Mesh *>("_mesh") = mesh;
+    prob_pars->set<MeshObject *>("_mesh_obj") = mesh;
     auto prob =
         app.build_object<FENonlinearProblem>("GTest2FieldsFENonlinearProblem", "prob", prob_pars);
 

--- a/test/src/Problem_test.cpp
+++ b/test/src/Problem_test.cpp
@@ -1,10 +1,12 @@
 #include "gmock/gmock.h"
 #include "GodzillaApp_test.h"
+#include "godzilla/Mesh.h"
 #include "godzilla/LineMesh.h"
 #include "godzilla/Problem.h"
 #include "godzilla/Function.h"
 #include "godzilla/Output.h"
 #include "godzilla/Postprocessor.h"
+#include "godzilla/Section.h"
 
 using namespace godzilla;
 
@@ -75,7 +77,7 @@ TEST(ProblemTest, add_pp)
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     TestProblem problem(prob_params);
 
     Parameters pp_params = Postprocessor::parameters();
@@ -122,12 +124,13 @@ TEST(ProblemTest, local_vec)
     mesh_params.set<Int>("nx") = 2;
     LineMesh mesh(mesh_params);
     mesh.create();
+    auto m  = mesh.get_mesh<Mesh>();
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     TestProblem problem(prob_params);
-    problem.set_local_section(create_section(mesh.get_dm()));
+    problem.set_local_section(create_section(m->get_dm()));
 
     Vector loc_vec = problem.get_local_vector();
     EXPECT_EQ(loc_vec.get_size(), 3);
@@ -150,9 +153,11 @@ TEST(ProblemTest, global_vec)
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     TestProblem problem(prob_params);
-    problem.set_local_section(create_section(mesh.get_dm()));
+
+    auto m = mesh.get_mesh<Mesh>();
+    problem.set_local_section(create_section(m->get_dm()));
 
     Vector glob_vec = problem.get_global_vector();
     EXPECT_EQ(glob_vec.get_size(), 3);
@@ -175,10 +180,12 @@ TEST(ProblemTest, create_matrix)
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     TestProblem problem(prob_params);
     problem.create();
-    problem.set_local_section(create_section(mesh.get_dm()));
+
+    auto m = mesh.get_mesh<Mesh>();
+    problem.set_local_section(create_section(m->get_dm()));
 
     Matrix mat = problem.create_matrix();
     EXPECT_EQ(mat.get_n_rows(), 3);
@@ -198,11 +205,12 @@ TEST(UnstructuredMeshTest, get_local_section)
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     TestProblem problem(prob_params);
     problem.create();
 
-    auto dm = mesh.get_dm();
+    auto m = mesh.get_mesh<Mesh>();
+    auto dm = m->get_dm();
     Section s = create_section(dm);
     problem.set_local_section(s);
 
@@ -225,11 +233,12 @@ TEST(UnstructuredMeshTest, get_global_section)
 
     Parameters prob_params = Problem::parameters();
     prob_params.set<App *>("_app") = &app;
-    prob_params.set<Mesh *>("_mesh") = &mesh;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
     TestProblem problem(prob_params);
     problem.create();
 
-    auto dm = mesh.get_dm();
+    auto m = mesh.get_mesh<Mesh>();
+    auto dm = m->get_dm();
     Section s = create_section(dm);
     problem.set_local_section(s);
     problem.set_global_section(s);

--- a/test/src/RectangleMesh_test.cpp
+++ b/test/src/RectangleMesh_test.cpp
@@ -1,6 +1,7 @@
 #include "gmock/gmock.h"
 #include "GodzillaApp_test.h"
 #include "godzilla/RectangleMesh.h"
+#include "godzilla/UnstructuredMesh.h"
 #include "godzilla/Parameters.h"
 #include "petsc.h"
 
@@ -30,9 +31,10 @@ TEST(RectangleMeshTest, api)
     EXPECT_EQ(mesh.get_ny(), 8);
 
     mesh.create();
-    auto dm = mesh.get_dm();
+    auto m = mesh.get_mesh<UnstructuredMesh>();
+    auto dm = m->get_dm();
 
-    EXPECT_EQ(mesh.get_dimension(), 2);
+    EXPECT_EQ(m->get_dimension(), 2);
 
     Real gmin[4], gmax[4];
     DMGetBoundingBox(dm, gmin, gmax);

--- a/test/src/ResidualFunc_test.cpp
+++ b/test/src/ResidualFunc_test.cpp
@@ -73,7 +73,7 @@ TEST(ResidualFuncTest, test)
 
     Parameters prob_pars = GTestProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 0.;
     prob_pars.set<Real>("end_time") = 20;
     prob_pars.set<Real>("dt") = 5;
@@ -154,7 +154,7 @@ TEST(ResidualFuncTest, test_vals)
 
     Parameters prob_pars = GTestProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_pars.set<Real>("start_time") = 1.23;
     prob_pars.set<Real>("end_time") = 20;
     prob_pars.set<Real>("dt") = 5;

--- a/test/src/TimeStepAdapt_test.cpp
+++ b/test/src/TimeStepAdapt_test.cpp
@@ -17,7 +17,7 @@ TEST(TimeStepAdapt, test)
     LineMesh mesh(mesh_pars);
 
     auto prob_param = GTestImplicitFENonlinearProblem::parameters();
-    prob_param.set<Mesh *>("_mesh") = &mesh;
+    prob_param.set<MeshObject *>("_mesh_obj") = &mesh;
     prob_param.set<godzilla::App *>("_app") = &app;
     prob_param.set<Real>("start_time") = 0.;
     prob_param.set<Real>("end_time") = 20;

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -163,7 +163,7 @@ TEST(TimeSteppingAdaptor, api)
     {
         const std::string class_name = "TestTSProblem";
         Parameters * params = app.get_parameters(class_name);
-        params->set<Mesh *>("_mesh") = mesh;
+        params->set<MeshObject *>("_mesh_obj") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 1;
         params->set<Real>("dt") = 0.1;
@@ -203,7 +203,7 @@ TEST(TimeSteppingAdaptor, choose)
     {
         const std::string class_name = "TestTSProblem";
         Parameters * params = app.get_parameters(class_name);
-        params->set<Mesh *>("_mesh") = mesh;
+        params->set<MeshObject *>("_mesh_obj") = mesh;
         params->set<Real>("start_time") = 0.;
         params->set<Real>("end_time") = 1;
         params->set<Real>("dt") = 0.1;

--- a/test/src/ValueFunctional_test.cpp
+++ b/test/src/ValueFunctional_test.cpp
@@ -61,7 +61,7 @@ TEST(ValueFunctional, eval)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     mesh.create();

--- a/test/src/WeakForm_test.cpp
+++ b/test/src/WeakForm_test.cpp
@@ -88,7 +88,7 @@ TEST(WeakFormTest, test)
 
     Parameters prob_pars = GTestFENonlinearProblem::parameters();
     prob_pars.set<App *>("_app") = &app;
-    prob_pars.set<Mesh *>("_mesh") = &mesh;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
     GTestFENonlinearProblem prob(prob_pars);
 
     Parameters bc_pars = NaturalBC::parameters();

--- a/tools/mesh-part/main.cpp
+++ b/tools/mesh-part/main.cpp
@@ -5,6 +5,7 @@
 #include "fmt/printf.h"
 #include "godzilla/Init.h"
 #include "godzilla/App.h"
+#include "godzilla/UnstructuredMesh.h"
 #include "godzilla/ExodusIIMesh.h"
 #include "godzilla/ExodusIIOutput.h"
 
@@ -20,7 +21,7 @@ public:
 
 protected:
     void create_command_line_options() override;
-    UnstructuredMesh * load_mesh(const std::string & file_name);
+    MeshObject * load_mesh(const std::string & file_name);
     void partition_mesh_file(const std::string & mesh_file_name);
     void save_partition(UnstructuredMesh * mesh, const std::string & file_name);
 };
@@ -61,13 +62,13 @@ MeshPartApp::create_command_line_options()
     opts.positional_help("<mesh-file>");
 }
 
-UnstructuredMesh *
+MeshObject *
 MeshPartApp::load_mesh(const std::string & file_name)
 {
     auto pars = ExodusIIMesh::parameters();
     pars.set<App *>("_app") = this;
     pars.set<std::string>("file") = file_name;
-    UnstructuredMesh * mesh = new ExodusIIMesh(pars);
+    auto mesh = new ExodusIIMesh(pars);
     mesh->create();
     return mesh;
 }
@@ -75,7 +76,8 @@ MeshPartApp::load_mesh(const std::string & file_name)
 void
 MeshPartApp::partition_mesh_file(const std::string & mesh_file_name)
 {
-    auto mesh = load_mesh(mesh_file_name);
+    auto mesh_obj = load_mesh(mesh_file_name);
+    auto mesh = mesh_obj->get_mesh<UnstructuredMesh>();
     mesh->distribute();
 
     std::string out_file_name = fmt::format("out");


### PR DESCRIPTION
- Refactoring mesh creation
- Adding UnstructuredMesh::set_chart
- Adding UnstructuredMesh::set_cone_size
- Adding UnstructuredMesh::set_cone
- Adding UnstructuredMesh::set_cell_type
- Adding UnstructuredMesh::symmetrize
- Adding UnstructuredMesh::stratify
- Adding UnstructuredMesh::get_full_join
- Adding Vector::set_block_size
- Adding Mesh:set_dimension
- Adding Mesh:set_coordinate_dim
- Adding Mesh:set_coordinates_local
- FileMesh::create_from_exodus() uses godzilla calls
