### PR TITLE
Adding RZSymmetry object

### DIFF
--- a/include/godzilla/RZSymmetry.h
+++ b/include/godzilla/RZSymmetry.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "godzilla/Object.h"
+#include "godzilla/Types.h"
+#include "godzilla/DenseVector.h"
+
+namespace godzilla {
+
+class DiscreteProblemInterface;
+
+class RZSymmetry : public Object {
+public:
+    RZSymmetry(const Parameters & params);
+
+    void create() override;
+    Real get_value(Real time, const DenseVector<Real, 2> & x);
+
+private:
+    /// Discrete problem this object is part of
+    DiscreteProblemInterface * dpi;
+    /// Axis vector
+    const std::vector<Real> & axis;
+    /// Axis point
+    const std::vector<Real> & pt;
+
+public:
+    static Parameters parameters();
+};
+
+} // namespace godzilla

--- a/src/RZSymmetry.cpp
+++ b/src/RZSymmetry.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2024 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "godzilla/RZSymmetry.h"
+#include "godzilla/Factory.h"
+#include "godzilla/CallStack.h"
+#include "godzilla/DiscreteProblemInterface.h"
+
+namespace godzilla {
+
+REGISTER_OBJECT(RZSymmetry);
+
+Parameters
+RZSymmetry::parameters()
+{
+    auto params = Object::parameters();
+    params.add_private_param<DiscreteProblemInterface *>("_dpi", nullptr);
+    params.add_required_param<std::vector<Real>>("axis", "Axis vector");
+    params.add_param<std::vector<Real>>("point",
+                                        std::vector<Real>({ 0, 0 }),
+                                        "Axis point. Default value is the origin.");
+    return params;
+}
+
+RZSymmetry::RZSymmetry(const Parameters & params) :
+    Object(params),
+    dpi(get_param<DiscreteProblemInterface *>("_dpi")),
+    axis(get_param<std::vector<Real>>("axis")),
+    pt(get_param<std::vector<Real>>("point"))
+{
+    CALL_STACK_MSG();
+}
+
+void
+RZSymmetry::create()
+{
+    CALL_STACK_MSG();
+    Object::create();
+    auto problem = this->dpi->get_problem();
+    auto dim = problem->get_dimension();
+    if (dim != 2)
+        log_error("'RZSymmetry' can be used only with 2D problems.");
+    if (this->axis.size() != 2)
+        log_error("'axis' parameter must provide 2 components.");
+    if (this->pt.size() != 2)
+        log_error("'point' parameter must provide 2 components.");
+}
+
+Real
+RZSymmetry::get_value(Real time, const DenseVector<Real, 2> & x)
+{
+    CALL_STACK_MSG();
+
+    std::vector<Real> a({ x(0) - this->pt[0], x(1) - this->pt[1] });
+
+    const Int dim = 2;
+    Real a_sqr = 0.;
+    for (Int i = 0; i < dim; i++)
+        a_sqr += a[i] * a[i];
+
+    Real dot = 0.;
+    for (Int i = 0; i < dim; i++)
+        dot += a[i] * this->axis[i];
+
+    Real b_sqr = 0.;
+    for (Int i = 0; i < dim; i++)
+        b_sqr += this->axis[i] * this->axis[i];
+
+    return std::sqrt(a_sqr - dot * dot / b_sqr);
+}
+
+} // namespace amnis

--- a/test/src/RZSymmetry_test.cpp
+++ b/test/src/RZSymmetry_test.cpp
@@ -1,0 +1,71 @@
+#include "gmock/gmock.h"
+#include "TestApp.h"
+#include "GTestFENonlinearProblem.h"
+#include "godzilla/LineMesh.h"
+#include "godzilla/RZSymmetry.h"
+
+using namespace godzilla;
+
+TEST(RZSymmetryTest, check)
+{
+    TestApp app;
+
+    auto mesh_pars = LineMesh::parameters();
+    mesh_pars.set<App *>("_app") = &app;
+    mesh_pars.set<Int>("nx") = 2;
+    LineMesh mesh(mesh_pars);
+
+    Parameters prob_pars = GTestFENonlinearProblem::parameters();
+    prob_pars.set<App *>("_app") = &app;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
+    prob_pars.set<std::string>("scheme") = "rk-2";
+    GTestFENonlinearProblem prob(prob_pars);
+
+    auto params = RZSymmetry::parameters();
+    params.set<App *>("_app") = &app;
+    params.set<Problem *>("_dpi") = &prob;
+    params.set<DiscreteProblemInterface *>("_dpi") = &prob;
+    params.set<std::vector<Real>>("point") = { 0. };
+    params.set<std::vector<Real>>("axis") = { 1. };
+    RZSymmetry rz(params);
+
+    mesh.create();
+    rz.create();
+
+    testing::internal::CaptureStderr();
+    auto * logger = app.get_logger();
+    if (logger->get_num_entries() > 0)
+        logger->print();
+    auto stdout = testing::internal::GetCapturedStderr();
+    EXPECT_THAT(stdout, testing::HasSubstr("[ERROR] 'axis' parameter must provide 2 components."));
+    EXPECT_THAT(stdout, testing::HasSubstr("[ERROR] 'point' parameter must provide 2 components."));
+}
+
+TEST(RZSymmetryTest, evaluate)
+{
+    TestApp app;
+
+    auto mesh_pars = LineMesh::parameters();
+    mesh_pars.set<App *>("_app") = &app;
+    mesh_pars.set<Int>("nx") = 2;
+    LineMesh mesh(mesh_pars);
+
+    Parameters prob_pars = GTestFENonlinearProblem::parameters();
+    prob_pars.set<App *>("_app") = &app;
+    prob_pars.set<MeshObject *>("_mesh_obj") = &mesh;
+    GTestFENonlinearProblem prob(prob_pars);
+
+    auto params = RZSymmetry::parameters();
+    params.set<App *>("_app") = &app;
+    params.set<Problem *>("_dpi") = &prob;
+    params.set<DiscreteProblemInterface *>("_dpi") = &prob;
+    params.set<std::vector<Real>>("point") = { 1., 1. };
+    params.set<std::vector<Real>>("axis") = { 1., 0. };
+    RZSymmetry rz(params);
+
+    mesh.create();
+    rz.create();
+
+    DenseVector<Real, 2> coord({ 0., 2. });
+    EXPECT_DOUBLE_EQ(rz.get_value(0, coord), 1.);
+}


### PR DESCRIPTION
This is a user-facing object to setup axisymmetric problems. It is the application
responsibility to include this in the input file syntax and use this.
