### PR TITLE
Changing API for callback

### DIFF
--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -65,9 +65,9 @@ protected:
     /// Set up solver parameters
     virtual void set_up_solver_parameters();
     /// SNES monitor
-    void snes_monitor_callback(Int it, Real norm);
+    void snes_monitor(Int it, Real norm);
     /// KSP monitor
-    void ksp_monitor_callback(Int it, Real rnorm);
+    void ksp_monitor(Int it, Real rnorm);
     /// Method for setting matrix properties
     virtual void set_up_matrix_properties();
     /// Method for creating a preconditioner

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -108,8 +108,8 @@ protected:
     virtual void pre_step();
     /// Called after the time step is done solving
     virtual void post_step();
-    /// TS monitor callback
-    virtual void ts_monitor_callback(Int stepi, Real time, Vec x);
+    /// TS monitor
+    virtual void ts_monitor(Int stepi, Real time, Vec x);
     /// Check if problem converged
     ///
     /// @return `true` if solve converged, otherwise `false`

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -37,7 +37,7 @@ __ksp_monitor(KSP, Int it, Real rnorm, void * ctx)
 {
     CALL_STACK_MSG();
     auto * problem = static_cast<NonlinearProblem *>(ctx);
-    problem->ksp_monitor_callback(it, rnorm);
+    problem->ksp_monitor(it, rnorm);
     return 0;
 }
 
@@ -46,7 +46,7 @@ __snes_monitor(SNES, Int it, Real norm, void * ctx)
 {
     CALL_STACK_MSG();
     auto * problem = static_cast<NonlinearProblem *>(ctx);
-    problem->snes_monitor_callback(it, norm);
+    problem->snes_monitor(it, norm);
     return 0;
 }
 
@@ -273,14 +273,14 @@ NonlinearProblem::set_up_solver_parameters()
 }
 
 void
-NonlinearProblem::snes_monitor_callback(Int it, Real norm)
+NonlinearProblem::snes_monitor(Int it, Real norm)
 {
     CALL_STACK_MSG();
     lprint(7, "{} Non-linear residual: {:e}", it, norm);
 }
 
 void
-NonlinearProblem::ksp_monitor_callback(Int it, Real rnorm)
+NonlinearProblem::ksp_monitor(Int it, Real rnorm)
 {
     CALL_STACK_MSG();
     lprint(8, "    {} Linear residual: {:e}", it, rnorm);

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -40,7 +40,7 @@ __transient_monitor(TS, Int stepi, Real time, Vec x, void * ctx)
 {
     CALL_STACK_MSG();
     auto * tpi = static_cast<TransientProblemInterface *>(ctx);
-    tpi->ts_monitor_callback(stepi, time, x);
+    tpi->ts_monitor(stepi, time, x);
     return 0;
 }
 
@@ -229,11 +229,11 @@ TransientProblemInterface::post_step()
 }
 
 void
-TransientProblemInterface::ts_monitor_callback(Int stepi, Real t, Vec x)
+TransientProblemInterface::ts_monitor(Int stepi, Real time, Vec x)
 {
     CALL_STACK_MSG();
     Real dt = get_time_step();
-    this->problem->lprint(6, "{} Time {:f} dt = {:f}", stepi, t, dt);
+    this->problem->lprint(6, "{} Time {:f} dt = {:f}", stepi, time, dt);
 }
 
 void

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -128,7 +128,7 @@ public:
     std::vector<Real> dts;
 
 protected:
-    void ts_monitor_callback(Int stepi, Real time, Vec x) override;
+    void ts_monitor(Int stepi, Real time, Vec x) override;
 };
 
 REGISTER_OBJECT(TestTSProblem);
@@ -139,7 +139,7 @@ TestTSProblem::TestTSProblem(const Parameters & params) : GTestImplicitFENonline
 }
 
 void
-TestTSProblem::ts_monitor_callback(Int stepi, Real time, Vec x)
+TestTSProblem::ts_monitor(Int stepi, Real time, Vec x)
 {
     Real dt = get_time_step();
     this->dts[stepi] = dt;


### PR DESCRIPTION
No _callback suffix, only `ksp_monitor`, `snes_monitor` and `ts_monitor`.
