### PR TITLE
Do not output the same timestep twice

### DIFF
--- a/include/godzilla/Output.h
+++ b/include/godzilla/Output.h
@@ -58,6 +58,9 @@ private:
     ///
     Int interval;
 
+    /// Last simulation time when output happened
+    Real last_output_time;
+
 public:
     static Parameters parameters();
 };

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -89,6 +89,11 @@ public:
     /// @return Converged reason
     TSConvergedReason get_converged_reason() const;
 
+    /// Set simulation time
+    ///
+    /// @param t New simulation time
+    void set_time(Real t);
+
 protected:
     /// Get underlying SNES object
     SNES get_snes() const;

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -253,6 +253,14 @@ TransientProblemInterface::get_converged_reason() const
 }
 
 void
+TransientProblemInterface::set_time(Real t)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(TSSetTime(this->ts, t));
+    this->time = t;
+}
+
+void
 TransientProblemInterface::set_converged_reason(TSConvergedReason reason)
 {
     CALL_STACK_MSG();

--- a/test/include/ImplicitFENonlinearProblem_test.h
+++ b/test/include/ImplicitFENonlinearProblem_test.h
@@ -8,24 +8,37 @@
 
 class ImplicitFENonlinearProblemTest : public GodzillaAppTest {
 public:
-    MeshObject *
-    gMesh1d()
+    void
+    SetUp() override
     {
-        const std::string class_name = "LineMesh";
-        Parameters * params = this->app->get_parameters(class_name);
-        params->set<Int>("nx") = 2;
-        return this->app->build_object<MeshObject>(class_name, "mesh", params);
+        GodzillaAppTest::SetUp();
+
+        {
+            const std::string class_name = "LineMesh";
+            Parameters * params = this->app->get_parameters(class_name);
+            params->set<Int>("nx") = 2;
+            this->mesh = this->app->build_object<MeshObject>(class_name, "mesh", params);
+        }
+        {
+            const std::string class_name = "GTestImplicitFENonlinearProblem";
+            Parameters * params = this->app->get_parameters(class_name);
+            params->set<MeshObject *>("_mesh_obj") = mesh;
+            params->set<Real>("start_time") = 0.;
+            params->set<Real>("end_time") = 20;
+            params->set<Real>("dt") = 5;
+            this->prob = this->app->build_object<GTestImplicitFENonlinearProblem>(class_name,
+                                                                                  "prob",
+                                                                                  params);
+        }
+        this->app->set_problem(this->prob);
     }
 
-    GTestImplicitFENonlinearProblem *
-    gProblem1d(MeshObject * mesh)
+    void
+    TearDown() override
     {
-        const std::string class_name = "GTestImplicitFENonlinearProblem";
-        Parameters * params = this->app->get_parameters(class_name);
-        params->set<MeshObject *>("_mesh_obj") = mesh;
-        params->set<Real>("start_time") = 0.;
-        params->set<Real>("end_time") = 20;
-        params->set<Real>("dt") = 5;
-        return this->app->build_object<GTestImplicitFENonlinearProblem>(class_name, "prob", params);
+        GodzillaAppTest::TearDown();
     }
+
+    MeshObject * mesh;
+    GTestImplicitFENonlinearProblem * prob;
 };

--- a/test/src/Output_test.cpp
+++ b/test/src/Output_test.cpp
@@ -1,13 +1,13 @@
-#include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "godzilla/App.h"
-#include "FENonlinearProblem_test.h"
+#include "ImplicitFENonlinearProblem_test.h"
 #include "godzilla/Output.h"
 
 using namespace godzilla;
 
 namespace {
 
-class OutputTest : public FENonlinearProblemTest {
+class OutputTest : public ImplicitFENonlinearProblemTest {
 public:
 };
 
@@ -26,8 +26,8 @@ public:
 TEST_F(OutputTest, exec_masks_1)
 {
     Parameters pars = Output::parameters();
-    pars.set<App *>("_app") = app;
-    pars.set<Problem *>("_problem") = prob;
+    pars.set<App *>("_app") = this->app;
+    pars.set<Problem *>("_problem") = this->prob;
     pars.set<std::vector<std::string>>("on") = { "none" };
     MockOutput out(pars);
     out.create();
@@ -40,8 +40,8 @@ TEST_F(OutputTest, exec_masks_1)
 TEST_F(OutputTest, exec_masks_2)
 {
     Parameters pars = Output::parameters();
-    pars.set<App *>("_app") = app;
-    pars.set<Problem *>("_problem") = prob;
+    pars.set<App *>("_app") = this->app;
+    pars.set<Problem *>("_problem") = this->prob;
     pars.set<std::vector<std::string>>("on") = { "final" };
     MockOutput out(pars);
     out.create();
@@ -55,8 +55,8 @@ TEST_F(OutputTest, exec_masks_2)
 TEST_F(OutputTest, exec_masks_3)
 {
     Parameters pars = Output::parameters();
-    pars.set<App *>("_app") = app;
-    pars.set<Problem *>("_problem") = prob;
+    pars.set<App *>("_app") = this->app;
+    pars.set<Problem *>("_problem") = this->prob;
     pars.set<std::vector<std::string>>("on") = { "final", "initial", "timestep" };
     MockOutput out(pars);
     out.create();
@@ -65,9 +65,13 @@ TEST_F(OutputTest, exec_masks_3)
     EXPECT_TRUE(out.get_exec_mask() & ExecuteOn::INITIAL);
     EXPECT_TRUE(out.get_exec_mask() & ExecuteOn::TIMESTEP);
 
-    EXPECT_TRUE(out.should_output(ExecuteOn::FINAL));
+    this->prob->set_time(0.);
     EXPECT_TRUE(out.should_output(ExecuteOn::INITIAL));
+    this->prob->set_time(0.1);
     EXPECT_TRUE(out.should_output(ExecuteOn::TIMESTEP));
+    EXPECT_FALSE(out.should_output(ExecuteOn::TIMESTEP));
+    this->prob->set_time(0.2);
+    EXPECT_TRUE(out.should_output(ExecuteOn::FINAL));
 }
 
 TEST_F(OutputTest, empty_on)


### PR DESCRIPTION
This could happen when TIMESTEP and FINAL output masks were on. At the end of
the simulation FINAL would cause an output of an already saved solution which
happened because of the TIMESTEP mask.
