### PR TITLE
Improving Terminal API

### DIFF
--- a/include/godzilla/Terminal.h
+++ b/include/godzilla/Terminal.h
@@ -43,6 +43,10 @@ public:
     /// @return true if terminal supports colors
     static bool has_colors();
 
+    /// Set the terminal to use colors
+    static void set_colors(bool state);
+
+private:
     /// Number of colors supported by the terminal
     static unsigned int num_colors;
 };

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -177,7 +177,7 @@ App::process_command_line(const cxxopts::ParseResult & result)
         fmt::print("{}, version {}\n", get_name(), get_version());
     else {
         if (result.count("no-colors"))
-            Terminal::num_colors = 1;
+            Terminal::set_colors(false);
 
         if (result.count("verbose"))
             set_verbosity_level(result["verbose"].as<unsigned int>());

--- a/src/Terminal.cpp
+++ b/src/Terminal.cpp
@@ -15,11 +15,7 @@ Terminal::Color Terminal::Color::cyan("\33[36m");
 Terminal::Color Terminal::Color::white("\33[37m");
 Terminal::Color Terminal::Color::normal("\33[39m");
 
-Terminal::Color::Color(const char * aclr)
-{
-    if (has_colors())
-        this->str = std::string(aclr);
-}
+Terminal::Color::Color(const char * aclr) : str(aclr) {}
 
 Terminal::Color::operator const std::string &() const
 {
@@ -37,6 +33,15 @@ Terminal::has_colors()
     return num_colors > 1;
 }
 
+void
+Terminal::set_colors(bool state)
+{
+    if (state)
+        num_colors = 256;
+    else
+        num_colors = 1;
+}
+
 unsigned int Terminal::num_colors = 256;
 
 } // namespace godzilla
@@ -44,6 +49,7 @@ unsigned int Terminal::num_colors = 256;
 std::ostream &
 operator<<(std::ostream & os, const godzilla::Terminal::Color & clr)
 {
-    os << static_cast<const char *>(clr);
+    if (godzilla::Terminal::has_colors())
+        os << static_cast<const char *>(clr);
     return os;
 }

--- a/test/src/GodzillaApp_test.cpp
+++ b/test/src/GodzillaApp_test.cpp
@@ -64,7 +64,7 @@ TEST_F(GodzillaAppTest, no_colors)
     App app(comm, "godzilla", argc, argv);
 
     app.run();
-    EXPECT_EQ(Terminal::num_colors, 1);
+    EXPECT_FALSE(Terminal::has_colors());
 }
 
 TEST_F(GodzillaAppTest, verbose)

--- a/test/src/Terminal_test.cpp
+++ b/test/src/Terminal_test.cpp
@@ -5,26 +5,27 @@ using namespace godzilla;
 
 TEST(TerminalTest, colors)
 {
-    unsigned int nc = Terminal::num_colors;
+    Terminal::set_colors(true);
+    EXPECT_TRUE(Terminal::has_colors());
 
-    Terminal::num_colors = 256;
-    EXPECT_EQ(Terminal::has_colors(), true);
-
-    Terminal::num_colors = 1;
-    EXPECT_EQ(Terminal::has_colors(), false);
-
-    Terminal::Color blk("\33[30m");
-    EXPECT_STREQ(blk, "");
-
-    // restore
-    Terminal::num_colors = nc;
+    Terminal::set_colors(false);
+    EXPECT_FALSE(Terminal::has_colors());
 }
 
-TEST(TerminalTest, ostream_operator)
+TEST(TerminalTest, ostream_operator_w_colors)
 {
+    Terminal::set_colors(true);
     std::ostringstream oss;
     oss << Terminal::Color::red;
     EXPECT_STREQ(oss.str().c_str(), Terminal::Color::red);
+}
+
+TEST(TerminalTest, ostream_operator_wo_colors)
+{
+    Terminal::set_colors(false);
+    std::ostringstream oss;
+    oss << Terminal::Color::red;
+    EXPECT_STREQ(oss.str().c_str(), "");
 }
 
 TEST(TerminalTest, string_operator)


### PR DESCRIPTION
- removing public data
- adding API to set color
- when Terminal::Color is put on the output stream it checks the support
  for colors
