### PR TITLE
Adding `Vector::filter`, deprecating `Vector::chop`

### DIFF
--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -54,7 +54,19 @@ public:
     void shift(Scalar shift);
     Scalar min() const;
     Scalar max() const;
+#if PETSC_VERSION_LT(3, 20, 0)
     void chop(Real tol);
+#else
+    [[deprecated("Use filter() instead")]] void chop(Real tol);
+#endif
+
+#if PETSC_VERSION_GE(3, 20, 0)
+    /// Set all values in the vector with an absolute value less than or equal to the tolerance to
+    /// zero
+    ///
+    /// @param tol The zero tolerance
+    void filter(Real tol);
+#endif
 
     /// Computes `this[i] = alpha x[i] + this[i]`
     ///

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -178,6 +178,15 @@ Vector::chop(Real tol)
     PETSC_CHECK(VecChop(this->vec, tol));
 }
 
+#if PETSC_VERSION_GE(3, 20, 0)
+void
+Vector::filter(Real tol)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecFilter(this->vec, tol));
+}
+#endif
+
 void
 Vector::axpy(Scalar alpha, const Vector & x)
 {

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -256,6 +256,7 @@ TEST(VectorTest, max)
     v.destroy();
 }
 
+#if PETSC_VERSION_LT(3, 20, 0)
 TEST(VectorTest, chop)
 {
     Vector v = Vector::create_seq(MPI_COMM_WORLD, 2);
@@ -266,6 +267,20 @@ TEST(VectorTest, chop)
     EXPECT_DOUBLE_EQ(v(1), 4.);
     v.destroy();
 }
+#endif
+
+#if PETSC_VERSION_GE(3, 20, 0)
+TEST(VectorTest, filter)
+{
+    Vector v = Vector::create_seq(MPI_COMM_WORLD, 2);
+    v.set_value(0, 3.);
+    v.set_value(1, 4.);
+    v.filter(3.5);
+    EXPECT_DOUBLE_EQ(v(0), 0.);
+    EXPECT_DOUBLE_EQ(v(1), 4.);
+    v.destroy();
+}
+#endif
 
 TEST(VectorTest, axpy)
 {


### PR DESCRIPTION
Following development in PETSc.
