### PR TITLE
`compute_flux` for `FVProblemInterface` is a delegate

### DIFF
--- a/examples/advect-eqn/include/AdvectionEquation.h
+++ b/examples/advect-eqn/include/AdvectionEquation.h
@@ -11,18 +11,23 @@ public:
     AdvectionEquation(const Parameters & parameters);
     void create() override;
 
-    PetscErrorCode compute_flux(PetscInt dim,
-                                PetscInt nf,
-                                const PetscReal x[],
-                                const PetscReal n[],
-                                const PetscScalar uL[],
-                                const PetscScalar uR[],
-                                PetscInt n_consts,
-                                const PetscScalar constants[],
-                                PetscScalar flux[]) override;
-
 protected:
     void set_up_fields() override;
+    void set_up_weak_form() override;
+
+    /// Method to compute flux across an edge
+    ///
+    /// @param x[in] Edge centroid
+    /// @param n[in] Normal
+    /// @param u_l[in] Solution on the "left" side
+    /// @param u_r[in] Solution on the "right" side
+    /// @param flux[out] Computed flux
+    /// @return PETSc error code, zero means success
+    PetscErrorCode compute_flux(const Real x[],
+                                const Real n[],
+                                const Scalar u_l[],
+                                const Scalar u_r[],
+                                Scalar flux[]);
 
 public:
     static Parameters parameters();

--- a/examples/advect-eqn/src/AdvectionEquation.cpp
+++ b/examples/advect-eqn/src/AdvectionEquation.cpp
@@ -33,21 +33,24 @@ AdvectionEquation::set_up_fields()
     add_field(0, "u", 1);
 }
 
-PetscErrorCode
-AdvectionEquation::compute_flux(PetscInt,
-                                PetscInt,
-                                const PetscReal[],
-                                const PetscReal n[],
-                                const PetscScalar uL[],
-                                const PetscScalar uR[],
-                                PetscInt,
-                                const PetscScalar[],
-                                PetscScalar flux[])
+void
+AdvectionEquation::set_up_weak_form()
 {
     CALL_STACK_MSG();
-    PetscReal wind[] = { 0.5 };
-    PetscReal wn = 0;
+    set_riemann_solver(0, this, &AdvectionEquation::compute_flux);
+}
+
+PetscErrorCode
+AdvectionEquation::compute_flux(const Real[],
+                                const Real n[],
+                                const Scalar u_l[],
+                                const Scalar u_r[],
+                                Scalar flux[])
+{
+    CALL_STACK_MSG();
+    Real wind[] = { 0.5 };
+    Real wn = 0;
     wn += wind[0] * n[0];
-    flux[0] = (wn > 0 ? uL[0] : uR[0]) * wn;
+    flux[0] = (wn > 0 ? u_l[0] : u_r[0]) * wn;
     return 0;
 }

--- a/include/godzilla/FVDelegates.h
+++ b/include/godzilla/FVDelegates.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2024 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "godzilla/Types.h"
+
+namespace godzilla::internal {
+
+// Machinery for FVComputeFlux
+
+/// Abstract "method" for calling FVComputeFlux
+struct FVComputeFluxMethodAbstract {
+    virtual ~FVComputeFluxMethodAbstract() = default;
+    virtual PetscErrorCode invoke(const Real x[],
+                                  const Real n[],
+                                  const Scalar u_l[],
+                                  const Scalar u_r[],
+                                  Scalar flux[]) = 0;
+};
+
+template <typename T>
+struct FVComputeFluxMethod : public FVComputeFluxMethodAbstract {
+    FVComputeFluxMethod(T * instance,
+                        PetscErrorCode (T::*method)(const Real[],
+                                                    const Real[],
+                                                    const Scalar[],
+                                                    const Scalar[],
+                                                    Scalar[])) :
+        instance(instance),
+        method(method)
+    {
+    }
+
+    PetscErrorCode
+    invoke(const Real x[], const Real n[], const Scalar u_l[], const Scalar u_r[], Scalar flux[]) override
+    {
+        return ((*this->instance).*method)(x, n, u_l, u_r, flux);
+    }
+
+private:
+    T * instance;
+    PetscErrorCode (
+        T::*method)(const Real[], const Real[],
+                                const Scalar[],
+                                const Scalar[],
+                                Scalar[]);
+};
+
+} // namespace godzilla::internal

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -110,21 +110,17 @@ public:
     }
 
     PetscErrorCode
-    compute_flux(Int dim,
-                 Int nf,
-                 const Real x[],
+    compute_flux(const Real x[],
                  const Real n[],
-                 const Scalar uL[],
-                 const Scalar uR[],
-                 Int n_consts,
-                 const Scalar constants[],
-                 Scalar flux[]) override
+                 const Scalar u_l[],
+                 const Scalar u_r[],
+                 Scalar flux[])
     {
         CALL_STACK_MSG();
         Real wind[] = { 0.5 };
         Real wn = 0;
         wn += wind[0] * n[0];
-        flux[0] = (wn > 0 ? uL[0] : uR[0]) * wn;
+        flux[0] = (wn > 0 ? u_l[0] : u_r[0]) * wn;
         return 0;
     }
 
@@ -136,6 +132,12 @@ protected:
 
         add_aux_fe("a0", 1, 0);
         add_aux_fe("a1", 2, 0);
+    }
+
+    void
+    set_up_weak_form() override
+    {
+        set_riemann_solver(0, this, &TestExplicitFVLinearProblem::compute_flux);
     }
 };
 

--- a/test/src/NaturalRiemannBC_test.cpp
+++ b/test/src/NaturalRiemannBC_test.cpp
@@ -49,16 +49,18 @@ protected:
         add_field(0, "u", 1);
     }
 
+    void
+    set_up_weak_form() override
+    {
+        set_riemann_solver(0, this, &TestExplicitFVLinearProblem::compute_flux);
+    }
+
     PetscErrorCode
-    compute_flux(PetscInt dim,
-                 PetscInt nf,
-                 const PetscReal x[],
+    compute_flux(const PetscReal x[],
                  const PetscReal n[],
-                 const PetscScalar uL[],
-                 const PetscScalar uR[],
-                 PetscInt n_consts,
-                 const PetscScalar constants[],
-                 PetscScalar flux[]) override
+                 const PetscScalar u_l[],
+                 const PetscScalar u_r[],
+                 PetscScalar flux[])
     {
         return 0;
     }


### PR DESCRIPTION
Also, applications now setup the Riemann solver via `set_riemann_solver` API.
This work toward removing the limitation of having only single field in FV-solvers.
Riemann solvers are set in `set_up_weak_form` to match the setup done in FE solvers.
