### PR TITLE
Renaming `set_up_aux_fields` to `create_aux_fields`

### DIFF
--- a/include/godzilla/DGProblemInterface.h
+++ b/include/godzilla/DGProblemInterface.h
@@ -124,7 +124,7 @@ protected:
                                       PetscNaturalRiemannBCFunc * fn_t,
                                       void * context) override;
 
-    void set_up_aux_fields() override;
+    void create_aux_fields() override;
 
 private:
     /// Field information

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -353,7 +353,7 @@ protected:
 
     void set_local_section_aux(const Section & section);
 
-    virtual void set_up_aux_fields() = 0;
+    virtual void create_aux_fields() = 0;
 
     void set_up_auxiliary_dm(DM dm);
 

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -281,7 +281,7 @@ protected:
 
     virtual void set_up_field_null_space(DM dm);
 
-    void set_up_aux_fields() override;
+    void create_aux_fields() override;
 
     /// Setup volumetric weak form terms
     virtual void set_up_weak_form() = 0;

--- a/include/godzilla/FVProblemInterface.h
+++ b/include/godzilla/FVProblemInterface.h
@@ -84,7 +84,7 @@ protected:
                               const std::vector<Int> & components,
                               void * context) override;
 
-    void set_up_aux_fields() override;
+    void create_aux_fields() override;
 
     /// Set up field variables
     virtual void set_up_fields() = 0;

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -501,7 +501,7 @@ DGProblemInterface::set_up_section_constraint_indicies(Section & section)
 }
 
 void
-DGProblemInterface::set_up_aux_fields()
+DGProblemInterface::create_aux_fields()
 {
     CALL_STACK_MSG();
     auto comm = get_problem()->get_comm();

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -343,7 +343,7 @@ DiscreteProblemInterface::set_up_auxiliary_dm(DM dm)
 
     PETSC_CHECK(DMClone(dm, &this->dm_aux));
 
-    set_up_aux_fields();
+    create_aux_fields();
 
     PETSC_CHECK(DMCreateDS(this->dm_aux));
 

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -503,7 +503,7 @@ FEProblemInterface::set_up_quadrature()
 }
 
 void
-FEProblemInterface::set_up_aux_fields()
+FEProblemInterface::create_aux_fields()
 {
     CALL_STACK_MSG();
     auto dm_aux = get_dm_aux();

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -400,8 +400,9 @@ FVProblemInterface::set_up_ds()
 }
 
 void
-FVProblemInterface::set_up_aux_fields()
+FVProblemInterface::create_aux_fields()
 {
+    CALL_STACK_MSG();
     auto dm_aux = get_dm_aux();
     for (auto & it : this->aux_fields) {
         FieldInfo & fi = it.second;


### PR DESCRIPTION
There is a method called `set_up_fields` which is meant to set both primary
and auxiliary fields.  Thus, there could be a confusion about what
`set_up_aux_fields` was for. This method is really for internal use and should
not be used by the application code. Thus, the rename.
