### PR TITLE
Renaming set_{fe|aux_fe} to set_{field|aux_field}

### DIFF
--- a/examples/burgers-eqn/src/BurgersEquation.cpp
+++ b/examples/burgers-eqn/src/BurgersEquation.cpp
@@ -69,7 +69,7 @@ void
 BurgersEquation::set_up_fields()
 {
     CALL_STACK_MSG();
-    u_id = add_fe("u", 1, 1);
+    u_id = add_field("u", 1, 1);
 }
 
 void

--- a/examples/heat-eqn/src/HeatEquationExplicit.cpp
+++ b/examples/heat-eqn/src/HeatEquationExplicit.cpp
@@ -78,7 +78,7 @@ void
 HeatEquationExplicit::set_up_fields()
 {
     CALL_STACK_MSG();
-    temp_id = add_fe("temp", 1, this->order);
+    temp_id = add_field("temp", 1, this->order);
     ffn_aux_id = add_aux_fe("forcing_fn", 1, this->order);
 }
 

--- a/examples/heat-eqn/src/HeatEquationExplicit.cpp
+++ b/examples/heat-eqn/src/HeatEquationExplicit.cpp
@@ -79,7 +79,7 @@ HeatEquationExplicit::set_up_fields()
 {
     CALL_STACK_MSG();
     temp_id = add_field("temp", 1, this->order);
-    ffn_aux_id = add_aux_fe("forcing_fn", 1, this->order);
+    ffn_aux_id = add_aux_field("forcing_fn", 1, this->order);
 }
 
 void

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -108,7 +108,7 @@ void
 HeatEquationProblem::set_up_fields()
 {
     CALL_STACK_MSG();
-    temp_id = add_fe("temp", 1, this->p_order);
+    temp_id = add_field("temp", 1, this->p_order);
 
     q_ppp_id = add_aux_fe("q_ppp", 1, 0);
     htc_aux_id = add_aux_fe("htc", 1, this->p_order);

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -110,9 +110,9 @@ HeatEquationProblem::set_up_fields()
     CALL_STACK_MSG();
     temp_id = add_field("temp", 1, this->p_order);
 
-    q_ppp_id = add_aux_fe("q_ppp", 1, 0);
-    htc_aux_id = add_aux_fe("htc", 1, this->p_order);
-    T_ambient_aux_id = add_aux_fe("T_ambient", 1, this->p_order);
+    q_ppp_id = add_aux_field("q_ppp", 1, 0);
+    htc_aux_id = add_aux_field("htc", 1, this->p_order);
+    T_ambient_aux_id = add_aux_field("T_ambient", 1, this->p_order);
 }
 
 void

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -296,7 +296,7 @@ NSIncompressibleProblem::set_up_fields()
         set_field_component_name(velocity_id, i, comp_name[i]);
     pressure_id = add_field("pressure", 1, 1);
 
-    ffn_aid = add_aux_fe("ffn", dim, 2);
+    ffn_aid = add_aux_field("ffn", dim, 2);
 }
 
 void

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -291,10 +291,10 @@ NSIncompressibleProblem::set_up_fields()
     const char * comp_name[] = { "velocity_x", "velocity_y", "velocity_z" };
 
     PetscInt dim = this->get_dimension();
-    velocity_id = add_fe("velocity", dim, 2);
+    velocity_id = add_field("velocity", dim, 2);
     for (unsigned int i = 0; i < dim; i++)
         set_field_component_name(velocity_id, i, comp_name[i]);
-    pressure_id = add_fe("pressure", 1, 1);
+    pressure_id = add_field("pressure", 1, 1);
 
     ffn_aid = add_aux_fe("ffn", dim, 2);
 }

--- a/examples/poisson/src/PoissonEquation.cpp
+++ b/examples/poisson/src/PoissonEquation.cpp
@@ -29,7 +29,7 @@ PoissonEquation::set_up_fields()
 {
     CALL_STACK_MSG();
     this->iu = add_field("u", 1, this->p_order);
-    this->affn = add_aux_fe("forcing_fn", 1, this->p_order);
+    this->affn = add_aux_field("forcing_fn", 1, this->p_order);
 }
 
 void

--- a/examples/poisson/src/PoissonEquation.cpp
+++ b/examples/poisson/src/PoissonEquation.cpp
@@ -28,7 +28,7 @@ void
 PoissonEquation::set_up_fields()
 {
     CALL_STACK_MSG();
-    this->iu = add_fe("u", 1, this->p_order);
+    this->iu = add_field("u", 1, this->p_order);
     this->affn = add_aux_fe("forcing_fn", 1, this->p_order);
 }
 

--- a/include/godzilla/DGProblemInterface.h
+++ b/include/godzilla/DGProblemInterface.h
@@ -44,7 +44,7 @@ public:
     /// @param nc The number of components
     /// @param k The degree k of the space
     /// @return ID of the new field
-    Int add_fe(const std::string & name, Int nc, Int k, const Label & block = Label());
+    Int add_field(const std::string & name, Int nc, Int k, const Label & block = Label());
 
     /// Set a volumetric field
     ///

--- a/include/godzilla/DGProblemInterface.h
+++ b/include/godzilla/DGProblemInterface.h
@@ -68,7 +68,8 @@ public:
     /// @param name The name of the field
     /// @param nc The number of components
     /// @param k The degree k of the space
-    void set_aux_fe(Int id, const std::string & name, Int nc, Int k, const Label & block = Label());
+    void
+    set_aux_field(Int id, const std::string & name, Int nc, Int k, const Label & block = Label());
 
     /// Get field degree of freedom
     ///

--- a/include/godzilla/DGProblemInterface.h
+++ b/include/godzilla/DGProblemInterface.h
@@ -60,7 +60,7 @@ public:
     /// @param nc The number of components
     /// @param k The degree k of the space
     /// @return ID of the new field
-    Int add_aux_fe(const std::string & name, Int nc, Int k, const Label & block = Label());
+    Int add_aux_field(const std::string & name, Int nc, Int k, const Label & block = Label());
 
     /// Set a volumetric auxiliary field
     ///

--- a/include/godzilla/DGProblemInterface.h
+++ b/include/godzilla/DGProblemInterface.h
@@ -52,7 +52,7 @@ public:
     /// @param name The name of the field
     /// @param nc The number of components
     /// @param k The degree k of the space
-    void set_fe(Int id, const std::string & name, Int nc, Int k, const Label & block = Label());
+    void set_field(Int id, const std::string & name, Int nc, Int k, const Label & block = Label());
 
     /// Adds a volumetric auxiliary field
     ///

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -73,7 +73,7 @@ public:
     /// @param nc The number of components
     /// @param k The degree k of the space
     /// @param block The mesh region this field is restricted to
-    void set_fe(Int id, const std::string & name, Int nc, Int k, const Label & block = Label());
+    void set_field(Int id, const std::string & name, Int nc, Int k, const Label & block = Label());
 
     /// Adds a volumetric auxiliary field
     ///

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -64,7 +64,7 @@ public:
     /// @param k The degree k of the space
     /// @param block The mesh region this field is restricted to
     /// @return ID of the new field
-    Int add_fe(const std::string & name, Int nc, Int k, const Label & block = Label());
+    Int add_field(const std::string & name, Int nc, Int k, const Label & block = Label());
 
     /// Set a volumetric field
     ///

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -82,7 +82,7 @@ public:
     /// @param k The degree k of the space
     /// @param block The mesh region this field is restricted to
     /// @return ID of the new field
-    Int add_aux_fe(const std::string & name, Int nc, Int k, const Label & block = Label());
+    Int add_aux_field(const std::string & name, Int nc, Int k, const Label & block = Label());
 
     /// Set a volumetric auxiliary field
     ///

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -91,7 +91,8 @@ public:
     /// @param nc The number of components
     /// @param k The degree k of the space
     /// @param block The mesh region this field is restricted to
-    void set_aux_fe(Int id, const std::string & name, Int nc, Int k, const Label & block = Label());
+    void
+    set_aux_field(Int id, const std::string & name, Int nc, Int k, const Label & block = Label());
 
     const Int & get_spatial_dimension() const;
 

--- a/include/godzilla/FVProblemInterface.h
+++ b/include/godzilla/FVProblemInterface.h
@@ -65,7 +65,8 @@ public:
     /// @param nc The number of components
     /// @param k The degree k of the space
     /// @param block The label this field is restricted to
-    void set_aux_fe(Int id, const std::string & name, Int nc, Int k, const Label & block = Label());
+    void
+    set_aux_field(Int id, const std::string & name, Int nc, Int k, const Label & block = Label());
 
 protected:
     void init() override;

--- a/include/godzilla/FVProblemInterface.h
+++ b/include/godzilla/FVProblemInterface.h
@@ -56,7 +56,7 @@ public:
     /// @param k The degree k of the space
     /// @param block The label this field is restricted to
     /// @return ID of the new field
-    Int add_aux_fe(const std::string & name, Int nc, Int k, const Label & block = Label());
+    Int add_aux_field(const std::string & name, Int nc, Int k, const Label & block = Label());
 
     /// Set a volumetric auxiliary field
     ///

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -275,7 +275,7 @@ DGProblemInterface::set_aux_field_component_name(Int fid, Int component, const s
 }
 
 Int
-DGProblemInterface::add_fe(const std::string & name, Int nc, Int k, const Label & block)
+DGProblemInterface::add_field(const std::string & name, Int nc, Int k, const Label & block)
 {
     CALL_STACK_MSG();
     std::vector<Int> keys = utils::map_keys(this->fields);

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -307,7 +307,7 @@ DGProblemInterface::set_field(Int id, const std::string & name, Int nc, Int k, c
 }
 
 Int
-DGProblemInterface::add_aux_fe(const std::string & name, Int nc, Int k, const Label & block)
+DGProblemInterface::add_aux_field(const std::string & name, Int nc, Int k, const Label & block)
 {
     CALL_STACK_MSG();
     std::vector<Int> keys = utils::map_keys(this->aux_fields);

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -280,12 +280,12 @@ DGProblemInterface::add_field(const std::string & name, Int nc, Int k, const Lab
     CALL_STACK_MSG();
     std::vector<Int> keys = utils::map_keys(this->fields);
     Int id = get_next_id(keys);
-    set_fe(id, name, nc, k, block);
+    set_field(id, name, nc, k, block);
     return id;
 }
 
 void
-DGProblemInterface::set_fe(Int id, const std::string & name, Int nc, Int k, const Label & block)
+DGProblemInterface::set_field(Int id, const std::string & name, Int nc, Int k, const Label & block)
 {
     CALL_STACK_MSG();
     if (k != 1)

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -312,12 +312,16 @@ DGProblemInterface::add_aux_field(const std::string & name, Int nc, Int k, const
     CALL_STACK_MSG();
     std::vector<Int> keys = utils::map_keys(this->aux_fields);
     Int id = get_next_id(keys);
-    set_aux_fe(id, name, nc, k, block);
+    set_aux_field(id, name, nc, k, block);
     return id;
 }
 
 void
-DGProblemInterface::set_aux_fe(Int id, const std::string & name, Int nc, Int k, const Label & block)
+DGProblemInterface::set_aux_field(Int id,
+                                  const std::string & name,
+                                  Int nc,
+                                  Int k,
+                                  const Label & block)
 {
     CALL_STACK_MSG();
     auto it = this->aux_fields.find(id);

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -397,12 +397,16 @@ FEProblemInterface::add_aux_field(const std::string & name, Int nc, Int k, const
     CALL_STACK_MSG();
     std::vector<Int> keys = utils::map_keys(this->aux_fields);
     Int id = get_next_id(keys);
-    set_aux_fe(id, name, nc, k, block);
+    set_aux_field(id, name, nc, k, block);
     return id;
 }
 
 void
-FEProblemInterface::set_aux_fe(Int id, const std::string & name, Int nc, Int k, const Label & block)
+FEProblemInterface::set_aux_field(Int id,
+                                  const std::string & name,
+                                  Int nc,
+                                  Int k,
+                                  const Label & block)
 {
     CALL_STACK_MSG();
     auto it = this->aux_fields.find(id);

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -392,7 +392,7 @@ FEProblemInterface::set_field(Int id, const std::string & name, Int nc, Int k, c
 }
 
 Int
-FEProblemInterface::add_aux_fe(const std::string & name, Int nc, Int k, const Label & block)
+FEProblemInterface::add_aux_field(const std::string & name, Int nc, Int k, const Label & block)
 {
     CALL_STACK_MSG();
     std::vector<Int> keys = utils::map_keys(this->aux_fields);

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -367,12 +367,12 @@ FEProblemInterface::add_field(const std::string & name, Int nc, Int k, const Lab
     CALL_STACK_MSG();
     std::vector<Int> keys = utils::map_keys(this->fields);
     Int id = get_next_id(keys);
-    set_fe(id, name, nc, k, block);
+    set_field(id, name, nc, k, block);
     return id;
 }
 
 void
-FEProblemInterface::set_fe(Int id, const std::string & name, Int nc, Int k, const Label & block)
+FEProblemInterface::set_field(Int id, const std::string & name, Int nc, Int k, const Label & block)
 {
     CALL_STACK_MSG();
     auto it = this->fields.find(id);

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -362,7 +362,7 @@ FEProblemInterface::set_aux_field_component_name(Int fid, Int component, const s
 }
 
 Int
-FEProblemInterface::add_fe(const std::string & name, Int nc, Int k, const Label & block)
+FEProblemInterface::add_field(const std::string & name, Int nc, Int k, const Label & block)
 {
     CALL_STACK_MSG();
     std::vector<Int> keys = utils::map_keys(this->fields);

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -327,12 +327,16 @@ FVProblemInterface::add_aux_field(const std::string & name, Int nc, Int k, const
     CALL_STACK_MSG();
     std::vector<Int> keys = utils::map_keys(this->aux_fields);
     Int id = get_next_id(keys);
-    set_aux_fe(id, name, nc, k, block);
+    set_aux_field(id, name, nc, k, block);
     return id;
 }
 
 void
-FVProblemInterface::set_aux_fe(Int id, const std::string & name, Int nc, Int k, const Label & block)
+FVProblemInterface::set_aux_field(Int id,
+                                  const std::string & name,
+                                  Int nc,
+                                  Int k,
+                                  const Label & block)
 {
     CALL_STACK_MSG();
     auto it = this->aux_fields.find(id);

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -322,7 +322,7 @@ FVProblemInterface::add_field(Int id, const std::string & name, Int nc, const La
 }
 
 Int
-FVProblemInterface::add_aux_fe(const std::string & name, Int nc, Int k, const Label & block)
+FVProblemInterface::add_aux_field(const std::string & name, Int nc, Int k, const Label & block)
 {
     CALL_STACK_MSG();
     std::vector<Int> keys = utils::map_keys(this->aux_fields);

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -51,7 +51,7 @@ TEST_F(AuxiliaryFieldTest, api)
 
     mesh->create();
 
-    prob->set_aux_fe(0, "fld", 1, 1);
+    prob->set_aux_field(0, "fld", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
     params.set<App *>("_app") = app;
@@ -105,7 +105,7 @@ TEST_F(AuxiliaryFieldTest, non_existent_field)
 
     testing::internal::CaptureStderr();
 
-    prob->set_aux_fe(0, "aux1", 1, 1);
+    prob->set_aux_field(0, "aux1", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
     params.set<App *>("_app") = app;
@@ -147,7 +147,7 @@ TEST_F(AuxiliaryFieldTest, inconsistent_comp_number)
 
     testing::internal::CaptureStderr();
 
-    prob->set_aux_fe(0, "aux", 1, 1);
+    prob->set_aux_field(0, "aux", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
     params.set<App *>("_app") = app;
@@ -190,7 +190,7 @@ TEST_F(AuxiliaryFieldTest, non_existent_region)
 
     testing::internal::CaptureStderr();
 
-    prob->set_aux_fe(0, "aux", 1, 1);
+    prob->set_aux_field(0, "aux", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
     params.set<App *>("_app") = app;
@@ -212,7 +212,7 @@ TEST_F(AuxiliaryFieldTest, name_already_taken)
 {
     mesh->create();
 
-    prob->set_aux_fe(0, "fld", 1, 1);
+    prob->set_aux_field(0, "fld", 1, 1);
 
     Parameters params = ConstantAuxiliaryField::parameters();
     params.set<App *>("_app") = app;
@@ -250,7 +250,7 @@ TEST_F(AuxiliaryFieldTest, get_value)
 
     mesh->create();
 
-    prob->set_aux_fe(0, "aux", 1, 1);
+    prob->set_aux_field(0, "aux", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
     params.set<App *>("_app") = app;
@@ -293,7 +293,7 @@ TEST_F(AuxiliaryFieldTest, get_vector_value)
 
     mesh->create();
 
-    prob->set_aux_fe(0, "aux", 1, 1);
+    prob->set_aux_field(0, "aux", 1, 1);
 
     Parameters params = AuxiliaryField::parameters();
     params.set<App *>("_app") = app;

--- a/test/src/BndJacobianFunc_test.cpp
+++ b/test/src/BndJacobianFunc_test.cpp
@@ -37,7 +37,7 @@ protected:
     void
     set_up_fields() override
     {
-        set_fe(0, "u", 1, 1);
+        set_field(0, "u", 1, 1);
     }
 
     void

--- a/test/src/BndResidualFunc_test.cpp
+++ b/test/src/BndResidualFunc_test.cpp
@@ -37,7 +37,7 @@ protected:
     void
     set_up_fields() override
     {
-        set_fe(0, "u", 1, 1);
+        set_field(0, "u", 1, 1);
     }
 
     void

--- a/test/src/ConstantAuxiliaryField_test.cpp
+++ b/test/src/ConstantAuxiliaryField_test.cpp
@@ -29,7 +29,7 @@ TEST(ConstantAuxiliaryFieldTest, create)
 
     mesh.create();
     prob.create();
-    prob.set_aux_fe(0, "aux1", 1, 1);
+    prob.set_aux_field(0, "aux1", 1, 1);
     prob.add_auxiliary_field(&aux);
 
     EXPECT_EQ(aux.get_field_id(), 0);
@@ -68,7 +68,7 @@ TEST(ConstantAuxiliaryFieldTest, evaluate)
 
     mesh.create();
     prob.create();
-    prob.set_aux_fe(0, "aux1", 1, 1);
+    prob.set_aux_field(0, "aux1", 1, 1);
     prob.add_auxiliary_field(&aux);
 
     PetscFunc * fn = aux.get_func();

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -56,7 +56,7 @@ protected:
     void
     set_up_fields() override
     {
-        set_fe(0, "u", 1, 1);
+        set_field(0, "u", 1, 1);
     }
 
     void set_up_weak_form() override;

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -130,8 +130,8 @@ protected:
     {
         add_field(0, "u", 1);
 
-        add_aux_fe("a0", 1, 0);
-        add_aux_fe("a1", 2, 0);
+        add_aux_field("a0", 1, 0);
+        add_aux_field("a1", 2, 0);
     }
 
     void

--- a/test/src/FENonlinearProblemJFNK_test.cpp
+++ b/test/src/FENonlinearProblemJFNK_test.cpp
@@ -89,7 +89,7 @@ GTestFENonlinearProblemJFNK::GTestFENonlinearProblemJFNK(const Parameters & para
 void
 GTestFENonlinearProblemJFNK::set_up_fields()
 {
-    set_fe(this->iu, "u", 1, 1);
+    set_field(this->iu, "u", 1, 1);
 }
 
 void

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -43,7 +43,7 @@ TEST_F(FENonlinearProblemTest, fields)
 {
     mesh->create();
 
-    prob->set_fe(1, "vec", 3, 1);
+    prob->set_field(1, "vec", 3, 1);
 
     Int aux_fld1_idx = prob->add_aux_fe("aux_fld1", 2, 1);
 
@@ -94,8 +94,8 @@ TEST_F(FENonlinearProblemTest, fields)
 TEST_F(FENonlinearProblemTest, add_duplicate_field_id)
 {
     mesh->create();
-    prob->set_fe(0, "first", 1, 1);
-    EXPECT_THROW_MSG(prob->set_fe(0, "second", 1, 1),
+    prob->set_field(0, "first", 1, 1);
+    EXPECT_THROW_MSG(prob->set_field(0, "second", 1, 1),
                      "Cannot add field 'second' with ID = 0. ID already exists.");
 }
 

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -45,7 +45,7 @@ TEST_F(FENonlinearProblemTest, fields)
 
     prob->set_field(1, "vec", 3, 1);
 
-    Int aux_fld1_idx = prob->add_aux_fe("aux_fld1", 2, 1);
+    Int aux_fld1_idx = prob->add_aux_field("aux_fld1", 2, 1);
 
     prob->create();
 
@@ -103,7 +103,7 @@ TEST_F(FENonlinearProblemTest, get_aux_fields)
 {
     mesh->create();
     prob->set_aux_fe(0, "aux_one", 1, 1);
-    prob->add_aux_fe("aux_two", 2, 1);
+    prob->add_aux_field("aux_two", 2, 1);
     prob->create();
 
     EXPECT_EQ(prob->get_aux_field_name(0), "aux_one");

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -102,7 +102,7 @@ TEST_F(FENonlinearProblemTest, add_duplicate_field_id)
 TEST_F(FENonlinearProblemTest, get_aux_fields)
 {
     mesh->create();
-    prob->set_aux_fe(0, "aux_one", 1, 1);
+    prob->set_aux_field(0, "aux_one", 1, 1);
     prob->add_aux_field("aux_two", 2, 1);
     prob->create();
 
@@ -138,8 +138,8 @@ TEST_F(FENonlinearProblemTest, get_aux_fields)
 TEST_F(FENonlinearProblemTest, add_duplicate_aux_field_id)
 {
     mesh->create();
-    prob->set_aux_fe(0, "first", 1, 1);
-    EXPECT_THROW_MSG(prob->set_aux_fe(0, "second", 1, 1),
+    prob->set_aux_field(0, "first", 1, 1);
+    EXPECT_THROW_MSG(prob->set_aux_field(0, "second", 1, 1),
                      "Cannot add auxiliary field 'second' with ID = 0. ID is already taken.");
 }
 

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -79,7 +79,7 @@ TEST_F(FENonlinearProblemTest, fields)
     EXPECT_THROW_MSG(prob->set_field_component_name(65536, 0, "x"),
                      "Field with ID = '65536' does not exist.");
 
-    Int fld2_idx = prob->add_fe("fld2", 3, 1);
+    Int fld2_idx = prob->add_field("fld2", 3, 1);
     EXPECT_EQ(fld2_idx, 2);
 
     EXPECT_EQ(prob->get_field_dof(4, 0), 8);

--- a/test/src/FunctionAuxiliaryField_test.cpp
+++ b/test/src/FunctionAuxiliaryField_test.cpp
@@ -28,7 +28,7 @@ TEST(FunctionAuxiliaryFieldTest, create)
     FunctionAuxiliaryField aux(aux_params);
 
     mesh.create();
-    prob.set_aux_fe(0, "aux1", 1, 1);
+    prob.set_aux_field(0, "aux1", 1, 1);
     prob.add_auxiliary_field(&aux);
     prob.create();
 
@@ -67,7 +67,7 @@ TEST(FunctionAuxiliaryFieldTest, evaluate)
     FunctionAuxiliaryField aux(aux_params);
 
     mesh.create();
-    prob.set_aux_fe(0, "aux1", 1, 1);
+    prob.set_aux_field(0, "aux1", 1, 1);
     prob.add_auxiliary_field(&aux);
     prob.create();
 

--- a/test/src/GTest2FieldsFENonlinearProblem.cpp
+++ b/test/src/GTest2FieldsFENonlinearProblem.cpp
@@ -11,5 +11,5 @@ void
 GTest2FieldsFENonlinearProblem::set_up_fields()
 {
     GTestFENonlinearProblem::set_up_fields();
-    set_fe(this->iv, "v", 1, 1);
+    set_field(this->iv, "v", 1, 1);
 }

--- a/test/src/GTestFENonlinearProblem.cpp
+++ b/test/src/GTestFENonlinearProblem.cpp
@@ -90,7 +90,7 @@ void
 GTestFENonlinearProblem::set_up_fields()
 {
     Int order = 1;
-    set_fe(this->iu, "u", 1, order);
+    set_field(this->iu, "u", 1, order);
 }
 
 void

--- a/test/src/GTestImplicitFENonlinearProblem.cpp
+++ b/test/src/GTestImplicitFENonlinearProblem.cpp
@@ -102,7 +102,7 @@ GTestImplicitFENonlinearProblem::set_up_fields()
 {
     CALL_STACK_MSG();
     Int order = 1;
-    set_fe(this->iu, "u", 1, order);
+    set_field(this->iu, "u", 1, order);
 }
 
 void

--- a/test/src/InitialCondition_test.cpp
+++ b/test/src/InitialCondition_test.cpp
@@ -87,7 +87,7 @@ TEST_F(InitialConditionTest, test)
 {
     this->mesh->create();
 
-    this->prob->add_aux_fe("a", 1, 1);
+    this->prob->add_aux_field("a", 1, 1);
 
     Parameters params = InitialCondition::parameters();
     params.set<App *>("_app") = this->app;

--- a/test/src/JacobianFunc_test.cpp
+++ b/test/src/JacobianFunc_test.cpp
@@ -17,7 +17,7 @@ protected:
     void
     set_up_fields() override
     {
-        set_fe(0, "u", 1, 1);
+        set_field(0, "u", 1, 1);
     }
 
     void

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -134,7 +134,7 @@ TEST(NaturalBCTest, fe)
     TestNaturalBC bc(bc_params);
 
     mesh.create();
-    prob.set_aux_fe(0, "aux1", 1, 1);
+    prob.set_aux_field(0, "aux1", 1, 1);
     prob.add_boundary_condition(&bc);
     prob.create();
 

--- a/test/src/NeumannProblem_test.cpp
+++ b/test/src/NeumannProblem_test.cpp
@@ -108,7 +108,7 @@ void
 TestNeumannProblem::set_up_fields()
 {
     Int order = 2;
-    set_fe(this->iu, "u", 1, order);
+    set_field(this->iu, "u", 1, order);
 }
 
 void

--- a/test/src/ResidualFunc_test.cpp
+++ b/test/src/ResidualFunc_test.cpp
@@ -17,7 +17,7 @@ TEST(ResidualFuncTest, test)
         void
         set_up_fields() override
         {
-            set_fe(0, "u", 1, 1);
+            set_field(0, "u", 1, 1);
         }
 
         void
@@ -83,7 +83,7 @@ TEST(ResidualFuncTest, test_vals)
         void
         set_up_fields() override
         {
-            set_fe(0, "u", 1, 1);
+            set_field(0, "u", 1, 1);
         }
 
         void


### PR DESCRIPTION
- Renaming `FVProblemInterface::add_aux_fe` to `FVProblemInterface::add_aux_field`
- Renaming `FVProblemInterface::set_aux_fe` to `FVProblemInterface::set_aux_field`
- Renaming `DGProblemInterface::add_fe` to `DGProblemInterface::add_field`
- Renaming `DGProblemInterface::set_fe` to `DGProblemInterface::set_field`
- Renaming `DGProblemInterface::add_aux_fe` to `DGProblemInterface::add_aux_field`
- Renaming `DGProblemInterface::set_aux_fe` to `DGProblemInterface::set_aux_field`
- Renaming `FEProblemInterface::add_fe` to `FEProblemInterface::add_field`
- Renaming `FEProblemInterface::set_fe` to `FEProblemInterface::set_field`
- Renaming `FEProblemInterface::add_aux_fe` to `FEProblemInterface::add_aux_field`
- Renaming `FEProblemInterface::set_aux_fe` to `FEProblemInterface::set_aux_field`
