### PR TITLE
`InitialCondition` API changes

### DIFF
--- a/include/godzilla/ConstantInitialCondition.h
+++ b/include/godzilla/ConstantInitialCondition.h
@@ -19,7 +19,7 @@ public:
 
     [[nodiscard]] Int get_num_components() const override;
 
-    void evaluate(Int dim, Real time, const Real x[], Int Nc, Scalar u[]) override;
+    void evaluate(Real time, const Real x[], Scalar u[]) override;
 
 private:
     /// Constant values -- one for each component

--- a/include/godzilla/FunctionDelegate.h
+++ b/include/godzilla/FunctionDelegate.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "godzilla/Types.h"
+
+namespace godzilla::internal {
+
+// Machinery for calling time-dependent spatial functions
+
+/// Abstract "method"
+struct FunctionMethodAbstract {
+    virtual ~FunctionMethodAbstract() = default;
+    virtual ErrorCode invoke(Int dim, Real time, const Real x[], Int nc, Scalar u[]) = 0;
+};
+
+template <typename T>
+struct ICFunctionMethod : public FunctionMethodAbstract {
+    ICFunctionMethod(T * instance, void (T::*method)(Real, const Real[], Scalar[])) :
+        instance(instance),
+        method(method)
+    {
+    }
+
+    ErrorCode
+    invoke(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+    {
+        ((*this->instance).*method)(time, x, u);
+        return 0;
+    }
+
+private:
+    T * instance;
+    void (T::*method)(Real, const Real[], Scalar[]);
+};
+
+} // namespace godzilla::internal

--- a/include/godzilla/FunctionInitialCondition.h
+++ b/include/godzilla/FunctionInitialCondition.h
@@ -17,7 +17,7 @@ public:
     void create() override;
     Int get_num_components() const override;
 
-    void evaluate(Int dim, Real time, const Real x[], Int Nc, Scalar u[]) override;
+    void evaluate(Real time, const Real x[], Scalar u[]) override;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/InitialCondition.h
+++ b/include/godzilla/InitialCondition.h
@@ -19,24 +19,34 @@ public:
     explicit InitialCondition(const Parameters & params);
 
     void create() override;
+
+    /// Get problem spatial dimension
+    ///
+    /// @return Spatial dimension
+    Int get_dimension() const;
+
+    /// Get field name
+    ///
+    /// @return The field name
     virtual const std::string & get_field_name() const;
+
+    /// Get the ID of the field this boundary condition operates on
+    ///
+    /// @return ID of the field
     [[nodiscard]] virtual Int get_field_id() const;
+
+    /// Get the number of constrained components
+    ///
+    /// @return The number of constrained components
     [[nodiscard]] virtual Int get_num_components() const = 0;
-
-    /// Get pointer to the C function that will be passed into PETSc API
-    virtual PetscFunc * get_function();
-
-    /// Get the pointer to the context that will be passed into PETSc API
-    virtual const void * get_context() const;
 
     /// Evaluate the initial condition
     ///
-    /// @param dim The spatial dimension
     /// @param time The time at which to sample
     /// @param x The coordinates
     /// @param nc The number of components
     /// @param u  The output field values
-    virtual void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) = 0;
+    virtual void evaluate(Real time, const Real x[], Scalar u[]) = 0;
 
 private:
     /// Discrete problem this object is part of

--- a/src/ConstantInitialCondition.cpp
+++ b/src/ConstantInitialCondition.cpp
@@ -31,10 +31,10 @@ ConstantInitialCondition::get_num_components() const
 }
 
 void
-ConstantInitialCondition::evaluate(Int dim, Real time, const Real x[], Int Nc, Scalar u[])
+ConstantInitialCondition::evaluate(Real time, const Real x[], Scalar u[])
 {
     CALL_STACK_MSG();
-    for (Int i = 0; i < Nc; i++)
+    for (Int i = 0; i < this->values.size(); i++)
         u[i] = this->values[i];
 }
 

--- a/src/FunctionInitialCondition.cpp
+++ b/src/FunctionInitialCondition.cpp
@@ -37,10 +37,10 @@ FunctionInitialCondition::get_num_components() const
 }
 
 void
-FunctionInitialCondition::evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[])
+FunctionInitialCondition::evaluate(Real time, const Real x[], Scalar u[])
 {
     CALL_STACK_MSG();
-    evaluate_func(time, x, nc, u);
+    evaluate_func(time, x, get_num_components(), u);
 }
 
 } // namespace godzilla

--- a/src/InitialCondition.cpp
+++ b/src/InitialCondition.cpp
@@ -9,16 +9,6 @@
 
 namespace godzilla {
 
-static ErrorCode
-initial_condition_function(Int dim, Real time, const Real x[], Int Nc, Scalar u[], void * ctx)
-{
-    CALL_STACK_MSG();
-    auto * ic = static_cast<InitialCondition *>(ctx);
-    assert(ic != nullptr);
-    ic->evaluate(dim, time, x, Nc, u);
-    return 0;
-}
-
 Parameters
 InitialCondition::parameters()
 {
@@ -79,18 +69,12 @@ InitialCondition::get_field_id() const
     return this->fid;
 }
 
-PetscFunc *
-InitialCondition::get_function()
+Int
+InitialCondition::get_dimension() const
 {
     CALL_STACK_MSG();
-    return initial_condition_function;
+    return this->dpi->get_problem()->get_dimension();
 }
 
-const void *
-InitialCondition::get_context() const
-{
-    CALL_STACK_MSG();
-    return this;
-}
 
 } // namespace godzilla

--- a/test/src/ConstantIC_test.cpp
+++ b/test/src/ConstantIC_test.cpp
@@ -7,7 +7,6 @@ using namespace godzilla;
 
 TEST(ConstantICTest, api)
 {
-    mpi::Communicator comm(MPI_COMM_WORLD);
     TestApp app;
 
     Parameters params = ConstantInitialCondition::parameters();
@@ -18,12 +17,10 @@ TEST(ConstantICTest, api)
     EXPECT_EQ(obj.get_field_id(), -1);
     EXPECT_EQ(obj.get_num_components(), 3);
 
-    Int dim = 2;
     Real time = 0.;
     Real x[] = { 0 };
-    Int Nc = 3;
     Scalar u[] = { 0, 0, 0 };
-    obj.evaluate(dim, time, x, Nc, u);
+    obj.evaluate(time, x, u);
 
     EXPECT_EQ(u[0], 3);
     EXPECT_EQ(u[1], 4);

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -30,7 +30,7 @@ public:
     }
 
     void
-    evaluate(Int dim, Real time, const Real x[], Int Nc, Scalar u[]) override
+    evaluate(Real time, const Real x[], Scalar u[]) override
     {
         u[0] = 0.;
         u[1] = 10.;

--- a/test/src/FunctionIC_test.cpp
+++ b/test/src/FunctionIC_test.cpp
@@ -39,9 +39,8 @@ TEST(FunctionICTest, api)
 
     Real time = 2.;
     Real x[] = { 1, 2, 3 };
-    Int Nc = 1;
     Scalar u[] = { 0 };
-    obj.evaluate(0, time, x, Nc, u);
+    obj.evaluate(time, x, u);
 
     EXPECT_EQ(u[0], 12);
 }

--- a/test/src/InitialCondition_test.cpp
+++ b/test/src/InitialCondition_test.cpp
@@ -26,7 +26,13 @@ public:
     {
         return 1.;
     }
-    MOCK_METHOD(void, evaluate, (Int, Real, const Real x[], Int Nc, Scalar u[]), ());
+    MOCK_METHOD(void, evaluate, (Real, const Real x[], Scalar u[]), ());
+
+    Int
+    get_dimension() const
+    {
+        return InitialCondition::get_dimension();
+    }
 };
 
 class TestInitialCondition : public InitialCondition {
@@ -40,7 +46,7 @@ public:
     }
 
     void
-    evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+    evaluate(Real time, const Real x[], Scalar u[]) override
     {
         u[0] = time * (x[0] + 10);
     }
@@ -57,7 +63,7 @@ public:
     }
 
     void
-    evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+    evaluate(Real time, const Real x[], Scalar u[]) override
     {
         u[0] = time * (x[0] + 5);
         u[1] = (x[0] + time);
@@ -75,12 +81,6 @@ TEST_F(InitialConditionTest, api)
     MockInitialCondition ic(params);
 
     EXPECT_EQ(ic.get_field_id(), -1);
-
-    Real x[1] = { 0. };
-    Real u[1] = { 0. };
-    EXPECT_CALL(ic, evaluate);
-    PetscFunc * fn = ic.get_function();
-    EXPECT_EQ((*fn)(1, 0., x, 1, u, &ic), 0);
 }
 
 TEST_F(InitialConditionTest, test)
@@ -110,6 +110,7 @@ TEST_F(InitialConditionTest, test)
     this->app->check_integrity();
 
     EXPECT_EQ(ic.get_field_id(), 0);
+    EXPECT_EQ(ic.get_dimension(), 1);
 
     EXPECT_TRUE(this->prob->has_initial_condition("obj"));
     EXPECT_EQ(this->prob->get_initial_condition("obj"), &ic);


### PR DESCRIPTION
- removed `get_function` and `get_context` from InitialCondition API
- calls to `InitialCondition::evaluate` are done via delegates
- `InitialCondition::evaluate` does not pass dim as a function argument,
  problem spatial dimension is obtained via `get_dimension` API
