### PR TITLE
`AuxiliaryField` API changes

### DIFF
--- a/include/godzilla/AuxiliaryField.h
+++ b/include/godzilla/AuxiliaryField.h
@@ -58,11 +58,7 @@ public:
     /// @return The number of constrained components
     [[nodiscard]] virtual Int get_num_components() const = 0;
 
-    [[nodiscard]] virtual PetscFunc * get_func() const = 0;
-
-    virtual const void * get_context() const;
-
-    virtual void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) = 0;
+    virtual void evaluate(Real time, const Real x[], Scalar u[]) = 0;
 
     template <Int DIM>
     Real get_value(Real time, const DenseVector<Real, DIM> & x);
@@ -112,7 +108,7 @@ inline Real
 AuxiliaryField::get_value(Real time, const DenseVector<Real, DIM> & x)
 {
     Real val;
-    evaluate(DIM, time, x.data(), 1, &val);
+    evaluate(time, x.data(), &val);
     return val;
 }
 
@@ -121,7 +117,7 @@ inline DenseVector<Real, N>
 AuxiliaryField::get_vector_value(Real time, const DenseVector<Real, DIM> & x)
 {
     DenseVector<Real, N> val;
-    evaluate(DIM, time, x.data(), N, val.data());
+    evaluate(time, x.data(), val.data());
     return val;
 }
 

--- a/include/godzilla/ConstantAuxiliaryField.h
+++ b/include/godzilla/ConstantAuxiliaryField.h
@@ -15,8 +15,7 @@ public:
     explicit ConstantAuxiliaryField(const Parameters & params);
 
     [[nodiscard]] Int get_num_components() const override;
-    [[nodiscard]] PetscFunc * get_func() const override;
-    void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override;
+    void evaluate(Real time, const Real x[], Scalar u[]) override;
 
 private:
     /// Values (one per component)

--- a/include/godzilla/FunctionAuxiliaryField.h
+++ b/include/godzilla/FunctionAuxiliaryField.h
@@ -17,8 +17,7 @@ public:
 
     void create() override;
     Int get_num_components() const override;
-    PetscFunc * get_func() const override;
-    void evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override;
+    void evaluate(Real time, const Real x[], Scalar u[]) override;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/FunctionDelegate.h
+++ b/include/godzilla/FunctionDelegate.h
@@ -35,4 +35,24 @@ private:
     void (T::*method)(Real, const Real[], Scalar[]);
 };
 
+template <typename T>
+struct AuxFunctionMethod : public FunctionMethodAbstract {
+    AuxFunctionMethod(T * instance, void (T::*method)(Real, const Real[], Scalar[])) :
+        instance(instance),
+        method(method)
+    {
+    }
+
+    ErrorCode
+    invoke(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+    {
+        ((*this->instance).*method)(time, x, u);
+        return 0;
+    }
+
+private:
+    T * instance;
+    void (T::*method)(Real, const Real[], Scalar[]);
+};
+
 } // namespace godzilla::internal

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -106,11 +106,4 @@ AuxiliaryField::get_field() const
     return this->field;
 }
 
-const void *
-AuxiliaryField::get_context() const
-{
-    CALL_STACK_MSG();
-    return this;
-}
-
 } // namespace godzilla

--- a/src/ConstantAuxiliaryField.cpp
+++ b/src/ConstantAuxiliaryField.cpp
@@ -9,14 +9,6 @@
 
 namespace godzilla {
 
-static ErrorCode
-constant_auxiliary_field(Int dim, Real time, const Real x[], Int nc, Scalar u[], void * ctx)
-{
-    auto * aux_fld = static_cast<ConstantAuxiliaryField *>(ctx);
-    aux_fld->evaluate(dim, time, x, nc, u);
-    return 0;
-}
-
 Parameters
 ConstantAuxiliaryField::parameters()
 {
@@ -41,18 +33,11 @@ ConstantAuxiliaryField::get_num_components() const
     return this->values.size();
 }
 
-PetscFunc *
-ConstantAuxiliaryField::get_func() const
-{
-    CALL_STACK_MSG();
-    return constant_auxiliary_field;
-}
-
 void
-ConstantAuxiliaryField::evaluate(Int, Real, const Real[], Int nc, Scalar u[])
+ConstantAuxiliaryField::evaluate(Real, const Real[], Scalar u[])
 {
     CALL_STACK_MSG();
-    for (Int c = 0; c < nc; c++)
+    for (Int c = 0; c < this->values.size(); c++)
         u[c] = this->values[c];
 }
 

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -408,8 +408,9 @@ DiscreteProblemInterface::compute_global_aux_fields(DM dm,
 
     for (const auto & aux : auxs) {
         Int fid = aux->get_field_id();
-        func[fid] = aux->get_func();
-        ctxs[fid] = const_cast<void *>(aux->get_context());
+        auto method = new internal::AuxFunctionMethod(aux, &AuxiliaryField::evaluate);
+        func[fid] = internal::function_delegate;
+        ctxs[fid] = method;
     }
 
     PETSC_CHECK(DMProjectFunctionLocal(dm,
@@ -418,6 +419,9 @@ DiscreteProblemInterface::compute_global_aux_fields(DM dm,
                                        ctxs.data(),
                                        INSERT_ALL_VALUES,
                                        a));
+
+    for (auto & ctx : ctxs)
+        delete static_cast<internal::FunctionMethodAbstract *>(ctx);
 }
 
 void
@@ -433,8 +437,9 @@ DiscreteProblemInterface::compute_label_aux_fields(DM dm,
 
     for (const auto & aux : auxs) {
         Int fid = aux->get_field_id();
-        func[fid] = aux->get_func();
-        ctxs[fid] = const_cast<void *>(aux->get_context());
+        auto method = new internal::AuxFunctionMethod(aux, &AuxiliaryField::evaluate);
+        func[fid] = internal::function_delegate;
+        ctxs[fid] = method;
     }
 
     auto ids = label.get_value_index_set();
@@ -452,6 +457,9 @@ DiscreteProblemInterface::compute_label_aux_fields(DM dm,
                                             a));
     ids.restore_indices();
     ids.destroy();
+
+    for (auto & ctx : ctxs)
+        delete static_cast<internal::FunctionMethodAbstract *>(ctx);
 }
 
 void

--- a/src/FunctionAuxiliaryField.cpp
+++ b/src/FunctionAuxiliaryField.cpp
@@ -8,14 +8,6 @@
 
 namespace godzilla {
 
-static ErrorCode
-function_auxiliary_field(Int dim, Real time, const Real x[], Int nc, Scalar u[], void * ctx)
-{
-    auto * func = static_cast<FunctionAuxiliaryField *>(ctx);
-    func->evaluate(dim, time, x, nc, u);
-    return 0;
-}
-
 Parameters
 FunctionAuxiliaryField::parameters()
 {
@@ -46,18 +38,11 @@ FunctionAuxiliaryField::get_num_components() const
     return FunctionInterface::get_num_components();
 }
 
-PetscFunc *
-FunctionAuxiliaryField::get_func() const
-{
-    CALL_STACK_MSG();
-    return function_auxiliary_field;
-}
-
 void
-FunctionAuxiliaryField::evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[])
+FunctionAuxiliaryField::evaluate(Real time, const Real x[], Scalar u[])
 {
     CALL_STACK_MSG();
-    evaluate_func(time, x, nc, u);
+    evaluate_func(time, x, get_num_components(), u);
 }
 
 } // namespace godzilla

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -26,13 +26,8 @@ TEST_F(AuxiliaryFieldTest, api)
         {
             return 1;
         }
-        PetscFunc *
-        get_func() const override
-        {
-            return nullptr;
-        }
         void
-        evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+        evaluate(Real time, const Real x[], Scalar u[]) override
         {
         }
 
@@ -68,8 +63,6 @@ TEST_F(AuxiliaryFieldTest, api)
     EXPECT_EQ(aux.get_block_id(), -1);
     EXPECT_EQ(aux.get_field(), "fld");
     EXPECT_EQ(aux.get_field_id(), 0);
-    EXPECT_EQ(aux.get_func(), nullptr);
-    EXPECT_EQ(aux.get_context(), &aux);
     EXPECT_EQ(aux.get_msh(), this->mesh->get_mesh<Mesh>());
     EXPECT_EQ(aux.get_prblm(), prob);
     EXPECT_EQ(aux.get_dimension(), 1);
@@ -90,13 +83,8 @@ TEST_F(AuxiliaryFieldTest, non_existent_field)
         {
             return 2;
         }
-        PetscFunc *
-        get_func() const override
-        {
-            return nullptr;
-        }
         void
-        evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+        evaluate(Real time, const Real x[], Scalar u[]) override
         {
         }
     };
@@ -132,13 +120,8 @@ TEST_F(AuxiliaryFieldTest, inconsistent_comp_number)
         {
             return 2;
         }
-        PetscFunc *
-        get_func() const override
-        {
-            return nullptr;
-        }
         void
-        evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+        evaluate(Real time, const Real x[], Scalar u[]) override
         {
         }
     };
@@ -175,13 +158,8 @@ TEST_F(AuxiliaryFieldTest, non_existent_region)
         {
             return 1;
         }
-        PetscFunc *
-        get_func() const override
-        {
-            return nullptr;
-        }
         void
-        evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+        evaluate(Real time, const Real x[], Scalar u[]) override
         {
         }
     };
@@ -236,13 +214,8 @@ TEST_F(AuxiliaryFieldTest, get_value)
         {
             return 1;
         }
-        PetscFunc *
-        get_func() const override
-        {
-            return nullptr;
-        }
         void
-        evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+        evaluate(Real time, const Real x[], Scalar u[]) override
         {
             u[0] = time * (x[0] + 1234);
         }
@@ -277,13 +250,8 @@ TEST_F(AuxiliaryFieldTest, get_vector_value)
         {
             return 3;
         }
-        PetscFunc *
-        get_func() const override
-        {
-            return nullptr;
-        }
         void
-        evaluate(Int dim, Real time, const Real x[], Int nc, Scalar u[]) override
+        evaluate(Real time, const Real x[], Scalar u[]) override
         {
             u[0] = x[0] + 2;
             u[1] = time;

--- a/test/src/ConstantAuxiliaryField_test.cpp
+++ b/test/src/ConstantAuxiliaryField_test.cpp
@@ -36,47 +36,9 @@ TEST(ConstantAuxiliaryFieldTest, create)
 
     EXPECT_EQ(aux.get_num_components(), 1);
 
-    Int dim = 1;
     Real time = 0;
     Real x[1] = { 1. };
-    Int nc = 1;
     Real u[1] = { 0 };
-    aux.evaluate(dim, time, x, nc, u);
-    EXPECT_EQ(u[0], 1234.);
-}
-
-TEST(ConstantAuxiliaryFieldTest, evaluate)
-{
-    TestApp app;
-
-    Parameters mesh_params = LineMesh::parameters();
-    mesh_params.set<App *>("_app") = &app;
-    mesh_params.set<Int>("nx") = 2;
-    LineMesh mesh(mesh_params);
-
-    Parameters prob_params = GTestFENonlinearProblem::parameters();
-    prob_params.set<App *>("_app") = &app;
-    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
-    GTestFENonlinearProblem prob(prob_params);
-
-    Parameters aux_params = ConstantAuxiliaryField::parameters();
-    aux_params.set<App *>("_app") = &app;
-    aux_params.set<std::string>("_name") = "aux1";
-    aux_params.set<DiscreteProblemInterface *>("_dpi") = &prob;
-    aux_params.set<std::vector<Real>>("value") = { 1234 };
-    ConstantAuxiliaryField aux(aux_params);
-
-    mesh.create();
-    prob.create();
-    prob.set_aux_field(0, "aux1", 1, 1);
-    prob.add_auxiliary_field(&aux);
-
-    PetscFunc * fn = aux.get_func();
-    Int dim = 1;
-    Real time = 0;
-    Real x[1] = { 1. };
-    Int nc = 1;
-    Real u[1] = { 0 };
-    (*fn)(dim, time, x, nc, u, &aux);
+    aux.evaluate(time, x, u);
     EXPECT_EQ(u[0], 1234.);
 }

--- a/test/src/FunctionAuxiliaryField_test.cpp
+++ b/test/src/FunctionAuxiliaryField_test.cpp
@@ -37,48 +37,9 @@ TEST(FunctionAuxiliaryFieldTest, create)
 
     EXPECT_EQ(aux.get_num_components(), 1);
 
-    Int dim = 1;
     Real time = 0;
     Real x[1] = { 1. };
-    Int nc = 1;
     Real u[1] = { 0 };
-    aux.evaluate(dim, time, x, nc, u);
-    EXPECT_EQ(u[0], 1234.);
-}
-
-TEST(FunctionAuxiliaryFieldTest, evaluate)
-{
-    TestApp app;
-
-    Parameters mesh_params = LineMesh::parameters();
-    mesh_params.set<App *>("_app") = &app;
-    mesh_params.set<Int>("nx") = 2;
-    LineMesh mesh(mesh_params);
-
-    Parameters prob_params = GTestFENonlinearProblem::parameters();
-    prob_params.set<App *>("_app") = &app;
-    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
-    GTestFENonlinearProblem prob(prob_params);
-    app.set_problem(&prob);
-
-    Parameters aux_params = FunctionAuxiliaryField::parameters();
-    aux_params.set<App *>("_app") = &app;
-    aux_params.set<std::string>("_name") = "aux1";
-    aux_params.set<DiscreteProblemInterface *>("_dpi") = &prob;
-    aux_params.set<std::vector<std::string>>("value") = { "1234" };
-    FunctionAuxiliaryField aux(aux_params);
-
-    mesh.create();
-    prob.set_aux_field(0, "aux1", 1, 1);
-    prob.add_auxiliary_field(&aux);
-    prob.create();
-
-    PetscFunc * fn = aux.get_func();
-    Int dim = 1;
-    Real time = 0;
-    Real x[1] = { 1. };
-    Int nc = 1;
-    Real u[1] = { 0 };
-    (*fn)(dim, time, x, nc, u, &aux);
+    aux.evaluate(time, x, u);
     EXPECT_EQ(u[0], 1234.);
 }


### PR DESCRIPTION
- removed `get_func` and `get_context` from AuxiliaryField API
- calls to `AuxiliaryField::evaluate` are done via delegates
- `AuxiliaryField::evaluate` does not pass dim as a function argument
