### PR TITLE
TransientProblemInterface is using delegates

### DIFF
--- a/include/godzilla/ExplicitProblemInterface.h
+++ b/include/godzilla/ExplicitProblemInterface.h
@@ -28,8 +28,6 @@ public:
 
     Vector & get_lumped_mass_matrix();
 
-    ErrorCode compute_rhs(Real time, const Vector & x, Vector & F) override;
-
 protected:
     void set_up_callbacks();
     void set_up_time_scheme() override;
@@ -41,6 +39,8 @@ protected:
     virtual ErrorCode compute_rhs_local(Real time, const Vector & x, Vector & F) = 0;
 
 private:
+    ErrorCode compute_rhs(Real time, const Vector & x, Vector & F);
+
     /// Nonlinear problem
     NonlinearProblem * nl_problem;
     /// Mass matrix

--- a/include/godzilla/ImplicitFENonlinearProblem.h
+++ b/include/godzilla/ImplicitFENonlinearProblem.h
@@ -20,12 +20,6 @@ public:
     Int get_step_num() const override;
     void compute_solution_vector_local() override;
 
-    virtual ErrorCode compute_ijacobian(Real time,
-                                        const Vector & X,
-                                        const Vector & X_t,
-                                        Real x_t_shift,
-                                        Matrix & J,
-                                        Matrix & Jp);
     virtual ErrorCode compute_boundary(Real time, const Vector & X, const Vector & X_t);
 
 protected:
@@ -36,6 +30,12 @@ protected:
     void post_step() override;
 
     ErrorCode compute_ifunction(Real time, const Vector & X, const Vector & X_t, Vector & F);
+    ErrorCode compute_ijacobian(Real time,
+                                     const Vector & X,
+                                     const Vector & X_t,
+                                     Real x_t_shift,
+                                     Matrix & J,
+                                     Matrix & Jp);
 
 private:
     /// Time stepping scheme

--- a/include/godzilla/ImplicitFENonlinearProblem.h
+++ b/include/godzilla/ImplicitFENonlinearProblem.h
@@ -20,8 +20,6 @@ public:
     Int get_step_num() const override;
     void compute_solution_vector_local() override;
 
-    virtual ErrorCode compute_boundary(Real time, const Vector & X, const Vector & X_t);
-
 protected:
     void init() override;
     void set_up_callbacks() override;
@@ -29,6 +27,7 @@ protected:
     void set_up_monitors() override;
     void post_step() override;
 
+    ErrorCode compute_boundary(Real time, const Vector & X, const Vector & X_t);
     ErrorCode compute_ifunction(Real time, const Vector & X, const Vector & X_t, Vector & F);
     ErrorCode compute_ijacobian(Real time,
                                      const Vector & X,

--- a/include/godzilla/ImplicitFENonlinearProblem.h
+++ b/include/godzilla/ImplicitFENonlinearProblem.h
@@ -20,8 +20,6 @@ public:
     Int get_step_num() const override;
     void compute_solution_vector_local() override;
 
-    virtual ErrorCode
-    compute_ifunction(Real time, const Vector & X, const Vector & X_t, Vector & F);
     virtual ErrorCode compute_ijacobian(Real time,
                                         const Vector & X,
                                         const Vector & X_t,
@@ -36,6 +34,8 @@ protected:
     void set_up_time_scheme() override;
     void set_up_monitors() override;
     void post_step() override;
+
+    ErrorCode compute_ifunction(Real time, const Vector & X, const Vector & X_t, Vector & F);
 
 private:
     /// Time stepping scheme

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -182,13 +182,13 @@ protected:
     /// Get step number
     Int get_step_number() const;
     /// Initialize
-    virtual void init();
+    void init();
     /// Create
-    virtual void create();
+    void create();
     /// Set up callbacks
     void set_up_callbacks();
     /// Set up monitors
-    virtual void set_up_monitors();
+    void set_up_monitors();
     /// Set up time integration scheme
     virtual void set_up_time_scheme() = 0;
     /// Default TS monitor
@@ -196,9 +196,9 @@ protected:
     /// Check if problem converged
     ///
     /// @return `true` if solve converged, otherwise `false`
-    virtual bool converged() const;
+    bool converged() const;
     /// Solve
-    virtual void solve(Vector & x);
+    void solve(Vector & x);
     /// Set time-stepping scheme
     void set_scheme(TimeScheme scheme);
     /// Set time-stepping scheme

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -159,6 +159,8 @@ protected:
     virtual void init();
     /// Create
     virtual void create();
+    /// Set up callbacks
+    void set_up_callbacks();
     /// Set up monitors
     virtual void set_up_monitors();
     /// Set up time integration scheme
@@ -221,6 +223,8 @@ public:
     static Parameters parameters();
 
 private:
+    static ErrorCode pre_step(TS ts);
+    static ErrorCode post_step(TS ts);
     static ErrorCode monitor(TS ts, Int stepi, Real time, Vec x, void * ctx);
     static ErrorCode monitor_destroy(void ** ctx);
 };

--- a/src/ExplicitProblemInterface.cpp
+++ b/src/ExplicitProblemInterface.cpp
@@ -9,19 +9,6 @@
 
 namespace godzilla {
 
-namespace {
-ErrorCode
-compute_rhs(TS, Real time, Vec x, Vec F, void * ctx)
-{
-    CALL_STACK_MSG();
-    auto * epi = static_cast<ExplicitProblemInterface *>(ctx);
-    Vector vec_x(x);
-    Vector vec_F(F);
-    return epi->compute_rhs(time, vec_x, vec_F);
-}
-
-} // namespace
-
 Parameters
 ExplicitProblemInterface::parameters()
 {
@@ -89,8 +76,7 @@ ExplicitProblemInterface::set_up_callbacks()
 {
     CALL_STACK_MSG();
     TransientProblemInterface::set_up_callbacks();
-    auto dm = this->nl_problem->get_dm();
-    PETSC_CHECK(DMTSSetRHSFunction(dm, godzilla::compute_rhs, this));
+    set_rhs_function(this, &ExplicitProblemInterface::compute_rhs);
 }
 
 void

--- a/src/ExplicitProblemInterface.cpp
+++ b/src/ExplicitProblemInterface.cpp
@@ -88,6 +88,7 @@ void
 ExplicitProblemInterface::set_up_callbacks()
 {
     CALL_STACK_MSG();
+    TransientProblemInterface::set_up_callbacks();
     auto dm = this->nl_problem->get_dm();
     PETSC_CHECK(DMTSSetRHSFunction(dm, godzilla::compute_rhs, this));
 }

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -15,19 +15,6 @@
 
 namespace godzilla {
 
-static ErrorCode
-_tsfep_compute_boundary(DM, Real time, Vec x, Vec x_t, void * user)
-{
-    CALL_STACK_MSG();
-    auto * fep = static_cast<ImplicitFENonlinearProblem *>(user);
-    Vector vec_x(x);
-    Vector vec_x_t(x_t);
-    fep->compute_boundary(time, vec_x, vec_x_t);
-    return 0;
-}
-
-///
-
 Parameters
 ImplicitFENonlinearProblem::parameters()
 {
@@ -105,8 +92,7 @@ ImplicitFENonlinearProblem::set_up_callbacks()
 {
     CALL_STACK_MSG();
     TransientProblemInterface::set_up_callbacks();
-    auto dm = get_dm();
-    PETSC_CHECK(DMTSSetBoundaryLocal(dm, _tsfep_compute_boundary, this));
+    set_boundary_local(this, &ImplicitFENonlinearProblem::compute_boundary);
     set_ifunction_local(this, &ImplicitFENonlinearProblem::compute_ifunction);
     set_ijacobian_local(this, &ImplicitFENonlinearProblem::compute_ijacobian);
 }

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -16,19 +16,6 @@
 namespace godzilla {
 
 static ErrorCode
-__tsfep_compute_ijacobian(DM, Real time, Vec x, Vec x_t, Real x_t_shift, Mat J, Mat Jp, void * user)
-{
-    CALL_STACK_MSG();
-    auto * fep = static_cast<ImplicitFENonlinearProblem *>(user);
-    Vector vec_x(x);
-    Vector vec_x_t(x_t);
-    Matrix mat_J(J);
-    Matrix mat_Jp(Jp);
-    fep->compute_ijacobian(time, vec_x, vec_x_t, x_t_shift, mat_J, mat_Jp);
-    return 0;
-}
-
-static ErrorCode
 _tsfep_compute_boundary(DM, Real time, Vec x, Vec x_t, void * user)
 {
     CALL_STACK_MSG();
@@ -121,7 +108,7 @@ ImplicitFENonlinearProblem::set_up_callbacks()
     auto dm = get_dm();
     PETSC_CHECK(DMTSSetBoundaryLocal(dm, _tsfep_compute_boundary, this));
     set_ifunction_local(this, &ImplicitFENonlinearProblem::compute_ifunction);
-    PETSC_CHECK(DMTSSetIJacobianLocal(dm, __tsfep_compute_ijacobian, this));
+    set_ijacobian_local(this, &ImplicitFENonlinearProblem::compute_ijacobian);
 }
 
 void

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -129,6 +129,7 @@ void
 ImplicitFENonlinearProblem::set_up_callbacks()
 {
     CALL_STACK_MSG();
+    TransientProblemInterface::set_up_callbacks();
     auto dm = get_dm();
     PETSC_CHECK(DMTSSetBoundaryLocal(dm, _tsfep_compute_boundary, this));
     PETSC_CHECK(DMTSSetIFunctionLocal(dm, __tsfep_compute_ifunction, this));

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -16,18 +16,6 @@
 namespace godzilla {
 
 static ErrorCode
-__tsfep_compute_ifunction(DM, Real time, Vec x, Vec x_t, Vec F, void * user)
-{
-    CALL_STACK_MSG();
-    auto * fep = static_cast<ImplicitFENonlinearProblem *>(user);
-    Vector vec_x(x);
-    Vector vec_x_t(x_t);
-    Vector vec_F(F);
-    fep->compute_ifunction(time, vec_x, vec_x_t, vec_F);
-    return 0;
-}
-
-static ErrorCode
 __tsfep_compute_ijacobian(DM, Real time, Vec x, Vec x_t, Real x_t_shift, Mat J, Mat Jp, void * user)
 {
     CALL_STACK_MSG();
@@ -132,7 +120,7 @@ ImplicitFENonlinearProblem::set_up_callbacks()
     TransientProblemInterface::set_up_callbacks();
     auto dm = get_dm();
     PETSC_CHECK(DMTSSetBoundaryLocal(dm, _tsfep_compute_boundary, this));
-    PETSC_CHECK(DMTSSetIFunctionLocal(dm, __tsfep_compute_ifunction, this));
+    set_ifunction_local(this, &ImplicitFENonlinearProblem::compute_ifunction);
     PETSC_CHECK(DMTSSetIJacobianLocal(dm, __tsfep_compute_ijacobian, this));
 }
 

--- a/src/TSAbstract.cpp
+++ b/src/TSAbstract.cpp
@@ -78,7 +78,7 @@ void
 TSAbstract::compute_rhs_function(Real t, const Vector & U, Vector & y)
 {
     CALL_STACK_MSG();
-    this->tpi->compute_rhs(t, U, y);
+    this->tpi->compute_rhs_function(t, U, y);
 }
 
 //

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -74,6 +74,26 @@ TransientProblemInterface::compute_ifunction(DM, Real time, Vec x, Vec x_t, Vec 
     return method->invoke(time, vec_x, vec_x_t, vec_F);
 }
 
+ErrorCode
+TransientProblemInterface::compute_ijacobian(DM,
+                                             Real time,
+                                             Vec x,
+                                             Vec x_t,
+                                             Real x_t_shift,
+                                             Mat J,
+                                             Mat Jp,
+                                             void * contex)
+{
+    CALL_STACK_MSG();
+    auto * method = static_cast<internal::TSComputeIJacobianMethodAbstract *>(contex);
+    Vector vec_x(x);
+    Vector vec_x_t(x_t);
+    Matrix mat_J(J);
+    Matrix mat_Jp(Jp);
+    method->invoke(time, vec_x, vec_x_t, x_t_shift, mat_J, mat_Jp);
+    return 0;
+}
+
 Parameters
 TransientProblemInterface::parameters()
 {
@@ -90,6 +110,7 @@ TransientProblemInterface::TransientProblemInterface(Problem * problem, const Pa
     ts(nullptr),
     compute_rhs_method(nullptr),
     compute_ifunction_local_method(nullptr),
+    compute_ijacobian_local_method(nullptr),
     monitor_method(nullptr),
     problem(problem),
     tpi_params(params),

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -53,6 +53,16 @@ TransientProblemInterface::monitor_destroy(void ** ctx)
     return 0;
 }
 
+ErrorCode
+TransientProblemInterface::compute_rhs(TS, Real time, Vec x, Vec F, void * ctx)
+{
+    CALL_STACK_MSG();
+    auto * method = static_cast<internal::TSComputeRhsMethodAbstract *>(ctx);
+    Vector vec_x(x);
+    Vector vec_F(F);
+    return method->invoke(time, vec_x, vec_F);
+}
+
 Parameters
 TransientProblemInterface::parameters()
 {
@@ -67,6 +77,7 @@ TransientProblemInterface::parameters()
 
 TransientProblemInterface::TransientProblemInterface(Problem * problem, const Parameters & params) :
     ts(nullptr),
+    compute_rhs_method(nullptr),
     monitor_method(nullptr),
     problem(problem),
     tpi_params(params),
@@ -282,9 +293,13 @@ TransientProblemInterface::post_stage(Real stage_time,
 }
 
 ErrorCode
-TransientProblemInterface::compute_rhs(Real time, const Vector & x, Vector & F)
+TransientProblemInterface::compute_rhs_function(Real time, const Vector & x, Vector & F)
 {
-    return 0;
+    CALL_STACK_MSG();
+    if (this->compute_rhs_method)
+        return this->compute_rhs_method->invoke(time, x, F);
+    else
+        return 0;
 }
 
 void

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -9,7 +9,6 @@
 #include "godzilla/LoggingInterface.h"
 #include "godzilla/Output.h"
 #include "godzilla/SNESolver.h"
-#include "petsc/private/tsimpl.h"
 #include <cassert>
 
 namespace godzilla {
@@ -94,6 +93,19 @@ TransientProblemInterface::compute_ijacobian(DM,
     return 0;
 }
 
+ErrorCode
+TransientProblemInterface::compute_boundary(DM, Real time, Vec x, Vec x_t, void * context)
+{
+    CALL_STACK_MSG();
+    auto * method = static_cast<internal::TSComputeBoundaryMethodAbstract *>(context);
+    Vector vec_x(x);
+    Vector vec_x_t(x_t);
+    method->invoke(time, vec_x, vec_x_t);
+    return 0;
+}
+
+//
+
 Parameters
 TransientProblemInterface::parameters()
 {
@@ -111,6 +123,7 @@ TransientProblemInterface::TransientProblemInterface(Problem * problem, const Pa
     compute_rhs_method(nullptr),
     compute_ifunction_local_method(nullptr),
     compute_ijacobian_local_method(nullptr),
+    compute_boundary_local_method(nullptr),
     monitor_method(nullptr),
     problem(problem),
     tpi_params(params),

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -15,7 +15,7 @@
 namespace godzilla {
 
 ErrorCode
-__transient_pre_step(TS ts)
+TransientProblemInterface::pre_step(TS ts)
 {
     CALL_STACK_MSG();
     void * ctx;
@@ -26,7 +26,7 @@ __transient_pre_step(TS ts)
 }
 
 ErrorCode
-__transient_post_step(TS ts)
+TransientProblemInterface::post_step(TS ts)
 {
     CALL_STACK_MSG();
     void * ctx;
@@ -206,11 +206,17 @@ TransientProblemInterface::create()
 }
 
 void
+TransientProblemInterface::set_up_callbacks()
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(TSSetPreStep(this->ts, TransientProblemInterface::pre_step));
+    PETSC_CHECK(TSSetPostStep(this->ts, TransientProblemInterface::post_step));
+}
+
+void
 TransientProblemInterface::set_up_monitors()
 {
     CALL_STACK_MSG();
-    PETSC_CHECK(TSSetPreStep(this->ts, __transient_pre_step));
-    PETSC_CHECK(TSSetPostStep(this->ts, __transient_post_step));
     monitor_set(this, &TransientProblemInterface::default_monitor);
 }
 

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -63,6 +63,17 @@ TransientProblemInterface::compute_rhs(TS, Real time, Vec x, Vec F, void * ctx)
     return method->invoke(time, vec_x, vec_F);
 }
 
+ErrorCode
+TransientProblemInterface::compute_ifunction(DM, Real time, Vec x, Vec x_t, Vec F, void * contex)
+{
+    CALL_STACK_MSG();
+    auto * method = static_cast<internal::TSComputeIFunctionMethodAbstract *>(contex);
+    Vector vec_x(x);
+    Vector vec_x_t(x_t);
+    Vector vec_F(F);
+    return method->invoke(time, vec_x, vec_x_t, vec_F);
+}
+
 Parameters
 TransientProblemInterface::parameters()
 {
@@ -78,6 +89,7 @@ TransientProblemInterface::parameters()
 TransientProblemInterface::TransientProblemInterface(Problem * problem, const Parameters & params) :
     ts(nullptr),
     compute_rhs_method(nullptr),
+    compute_ifunction_local_method(nullptr),
     monitor_method(nullptr),
     problem(problem),
     tpi_params(params),

--- a/test/src/TSAbstract_test.cpp
+++ b/test/src/TSAbstract_test.cpp
@@ -53,6 +53,7 @@ public:
         Problem::create();
         TransientProblemInterface::init();
         set_up_time_scheme();
+        set_rhs_function(this, &GTestProblem::compute_rhs);
     }
 
     void
@@ -104,7 +105,7 @@ public:
     }
 
     ErrorCode
-    compute_rhs(Real time, const Vector & vec_x, Vector & vec_F) override
+    compute_rhs(Real time, const Vector & vec_x, Vector & vec_F)
     {
         compute_rhs_called = true;
         return 0;

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -127,19 +127,21 @@ public:
     std::vector<Real> dts;
 
 protected:
-    void ts_monitor(Int stepi, Real time, Vec x) override;
+    ErrorCode ts_monitor(Int stepi, Real time, const Vector & x);
 };
 
 TestTSProblem::TestTSProblem(const Parameters & params) : GTestImplicitFENonlinearProblem(params)
 {
     this->dts.resize(5);
+    monitor_set(this, &TestTSProblem::ts_monitor);
 }
 
-void
-TestTSProblem::ts_monitor(Int stepi, Real time, Vec x)
+ErrorCode
+TestTSProblem::ts_monitor(Int stepi, Real time, const Vector & x)
 {
     Real dt = get_time_step();
     this->dts[stepi] = dt;
+    return 0;
 }
 
 ///


### PR DESCRIPTION
- `TSMonitor` is now implemented as a delegate
- TransientProblemInterface: pre/post step is is done via static function
- TransientProblemInterface: compute_rhs is a delegate
- TransientProblemInterface: changing some virtual into normal methods
- TransientProblemInterface: moving compute_ifunction_local from ImplicitFENonlinearProblem
- TransientProblemInterface: moving compute_ijacobian_local from ImplicitFENonlinearProblem
- TransientProblemInterface: moving compute_boundary_local from ImplicitFENonlinearProblem
