### PR TITLE
Improving code coverage

### DIFF
--- a/include/godzilla/KrylovSolver.h
+++ b/include/godzilla/KrylovSolver.h
@@ -41,6 +41,7 @@ private:
 
 /// Abstract "method" for calling KSP compute RHS
 struct KSPComputeRhsMethodAbstract {
+    virtual ~KSPComputeRhsMethodAbstract() = default;
     virtual ErrorCode invoke(Vector & b) = 0;
 };
 
@@ -65,6 +66,7 @@ private:
 
 /// Abstract "method" for calling KSP compute operators
 struct KSPComputeOperatorsMethodAbstract {
+    virtual ~KSPComputeOperatorsMethodAbstract() = default;
     virtual ErrorCode invoke(Matrix & A, Matrix & B) = 0;
 };
 
@@ -110,6 +112,7 @@ public:
 
     /// Construct empty Krylov solver
     KrylovSolver();
+    ~KrylovSolver();
 
     /// Construct a Krylov solver from a PETSc KSP object
     explicit KrylovSolver(KSP ksp);

--- a/include/godzilla/SNESolver.h
+++ b/include/godzilla/SNESolver.h
@@ -40,6 +40,7 @@ private:
 
 /// Abstract "method" for calling compute residual
 struct SNESComputeResidualMethodAbstract {
+    virtual ~SNESComputeResidualMethodAbstract() = default;
     virtual ErrorCode invoke(const Vector & x, Vector & f) = 0;
 };
 
@@ -64,6 +65,7 @@ private:
 
 /// Abstract "method" for calling compute Jacobian
 struct SNESComputeJacobianMethodAbstract {
+    virtual ~SNESComputeJacobianMethodAbstract() = default;
     virtual ErrorCode invoke(const Vector & x, Matrix & J, Matrix & Jp) = 0;
 };
 
@@ -133,6 +135,7 @@ public:
 
     /// Construct empty non-linear solver
     SNESolver();
+    ~SNESolver();
 
     /// Construct a non-linear solver from a PETSc SNES object
     explicit SNESolver(SNES snes);

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -100,28 +100,10 @@ public:
         /// Get the first index in the range
         ///
         /// @return First index in the range
-        [[deprecated("Use first() instead")]] Int
-        get_first() const
-        {
-            return first_idx;
-        }
-
-        /// Get the first index in the range
-        ///
-        /// @return First index in the range
         Int
         first() const
         {
             return first_idx;
-        }
-
-        /// Get the last index (not included) in the range
-        ///
-        /// @return Last index (not included) in the range
-        [[deprecated("Use last() instead")]] Int
-        get_last() const
-        {
-            return last_idx;
         }
 
         /// Get the last index (not included) in the range

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -47,6 +47,8 @@ FVProblemInterface::~FVProblemInterface()
         auto & fe = kv.second;
         PetscFEDestroy(&fe);
     }
+    for (auto & [id, delegate] : this->compute_flux_methods)
+        delete delegate;
 }
 
 void

--- a/src/KrylovSolver.cpp
+++ b/src/KrylovSolver.cpp
@@ -59,6 +59,12 @@ KrylovSolver::KrylovSolver(KSP ksp) :
 {
 }
 
+KrylovSolver::~KrylovSolver()
+{
+    delete this->compute_rhs_method;
+    delete this->compute_operators_method;
+}
+
 void
 KrylovSolver::create(MPI_Comm comm)
 {

--- a/src/SNESolver.cpp
+++ b/src/SNESolver.cpp
@@ -107,6 +107,12 @@ SNESolver::SNESolver(SNES snes) :
 {
 }
 
+SNESolver::~SNESolver()
+{
+    delete this->compute_residual_method;
+    delete this->compute_jacobian_method;
+}
+
 void
 SNESolver::create(MPI_Comm comm)
 {

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -149,6 +149,10 @@ TransientProblemInterface::~TransientProblemInterface()
 {
     CALL_STACK_MSG();
     TSDestroy(&this->ts);
+    delete this->compute_rhs_method;
+    delete this->compute_ifunction_local_method;
+    delete this->compute_ijacobian_local_method;
+    delete this->compute_boundary_local_method;
 }
 
 SNESolver

--- a/test/src/BoundaryCondition_test.cpp
+++ b/test/src/BoundaryCondition_test.cpp
@@ -37,13 +37,18 @@ public:
 
 TEST_F(BoundaryConditionTest, api)
 {
+    this->mesh->create();
+    this->prob->create();
+
     Parameters params = BoundaryCondition::parameters();
     params.set<App *>("_app") = this->app;
     params.set<DiscreteProblemInterface *>("_dpi") = this->prob;
     params.set<std::string>("_name") = "obj";
     params.set<std::vector<std::string>>("boundary") = { "side1" };
     MockBoundaryCondition bc(params);
+    bc.create();
 
     EXPECT_THAT(bc.get_boundary(), ElementsAre("side1"));
     EXPECT_THAT(bc.get_prob(), this->prob);
+    EXPECT_THAT(bc.get_dimension(), 1);
 }

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -405,6 +405,13 @@ TEST(ExplicitFELinearProblemTest, allocate_lumped_mass_matrix)
     prob.create();
 
     prob.allocate_lumped_mass_matrix();
-    auto M = prob.get_lumped_mass_matrix();
-    EXPECT_NE(M, nullptr);
+    {
+        auto M = prob.get_lumped_mass_matrix();
+        EXPECT_NE(M, nullptr);
+    }
+    {
+        const auto & c_prob = prob;
+        auto M = c_prob.get_lumped_mass_matrix();
+        EXPECT_NE(M, nullptr);
+    }
 }

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -42,12 +42,21 @@ TEST_F(ImplicitFENonlinearProblemTest, run)
     x.restore_array_read(xx);
 
     this->prob->compute_solution_vector_local();
-    auto lx = this->prob->get_solution_vector_local();
-    auto lxx = lx.get_array_read();
-    EXPECT_NEAR(lxx[0], 0., 1e-7);
-    EXPECT_NEAR(lxx[1], 0.5, 1e-7);
-    EXPECT_NEAR(lxx[2], 1., 1e-7);
-    lx.restore_array_read(lxx);
+    {
+        auto lx = this->prob->get_solution_vector_local();
+        auto lxx = lx.get_array_read();
+        EXPECT_NEAR(lxx[0], 0., 1e-7);
+        EXPECT_NEAR(lxx[1], 0.5, 1e-7);
+        EXPECT_NEAR(lxx[2], 1., 1e-7);
+        lx.restore_array_read(lxx);
+    }
+    {
+        const auto * c_prob = this->prob;
+        auto lx = c_prob->get_solution_vector_local();
+        EXPECT_NEAR(lx(0), 0., 1e-7);
+        EXPECT_NEAR(lx(1), 0.5, 1e-7);
+        EXPECT_NEAR(lx(2), 1., 1e-7);
+    }
 }
 
 TEST_F(ImplicitFENonlinearProblemTest, wrong_scheme)

--- a/test/src/Mesh_test.cpp
+++ b/test/src/Mesh_test.cpp
@@ -141,3 +141,23 @@ TEST(MeshTest, clear_label_value)
     m->clear_label_value("bnd", 0, 1001);
     EXPECT_EQ(bnd.get_value(0), -1);
 }
+
+TEST(MeshTest, view)
+{
+    testing::internal::CaptureStdout();
+
+    TestApp app;
+
+    Parameters params = TestMesh::parameters();
+    params.set<App *>("_app") = &app;
+    params.set<std::string>("_name") = "obj";
+    TestMesh mesh(params);
+    mesh.create();
+
+    auto m = mesh.create_mesh();
+    m->view();
+
+    auto out = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(out, HasSubstr("DM Object:"));
+    EXPECT_THAT(out, HasSubstr("type: plex"));
+}

--- a/test/src/ParsedFunction_test.cpp
+++ b/test/src/ParsedFunction_test.cpp
@@ -73,3 +73,47 @@ TEST(ParsedFunctionTest, multi_eval)
     EXPECT_EQ(u[0], 3.);
     EXPECT_EQ(u[1], 4.);
 }
+
+TEST(ParsedFunctionTest, eval_via_parser)
+{
+    TestApp app;
+
+    Parameters mesh_params = RectangleMesh::parameters();
+    mesh_params.set<App *>("_app") = &app;
+    mesh_params.set<Int>("nx") = 2;
+    mesh_params.set<Int>("ny") = 1;
+    RectangleMesh mesh(mesh_params);
+
+    Parameters prob_params = GTestFENonlinearProblem::parameters();
+    prob_params.set<App *>("_app") = &app;
+    prob_params.set<MeshObject *>("_mesh_obj") = &mesh;
+    GTestFENonlinearProblem prob(prob_params);
+    app.set_problem(&prob);
+
+    mesh.create();
+    prob.create();
+
+    Parameters params = ParsedFunction::parameters();
+    params.set<App *>("_app") = &app;
+    params.set<std::string>("_name") = "exact_fn";
+    params.set<std::vector<std::string>>("function") = { "t + x + y" };
+    ParsedFunction obj(params);
+
+    mu::Parser parser;
+    obj.register_callback(parser);
+
+    parser.SetExpr("exact_fn(t, x, y, z)");
+
+    Real time = 1;
+    Real xx[2] = { 2, 3 };
+    Real zero = 0.;
+    parser.DefineVar("t", &time);
+    parser.DefineVar("x", &(xx[0]));
+    parser.DefineVar("y", &(xx[1]));
+    parser.DefineVar("z", &zero);
+
+    int n_num;
+    mu::value_type * val = parser.Eval(n_num);
+    EXPECT_EQ(1, n_num);
+    EXPECT_DOUBLE_EQ(val[0], 6.);
+}

--- a/test/src/Partitioner_test.cpp
+++ b/test/src/Partitioner_test.cpp
@@ -1,0 +1,55 @@
+#include "gmock/gmock.h"
+#include "GodzillaApp_test.h"
+#include "godzilla/Partitioner.h"
+
+using namespace godzilla;
+using namespace testing;
+
+TEST(PartitionerTest, null_ctor)
+{
+    Partitioner part;
+    auto p = (PetscPartitioner) part;
+    EXPECT_EQ(p, nullptr);
+}
+
+TEST(PartitionerTest, mpi_ctor)
+{
+    TestApp app;
+    Partitioner part(app.get_comm());
+    auto p = (PetscPartitioner) part;
+    EXPECT_NE(p, nullptr);
+}
+
+#ifdef PETSC_HAVE_PTSCOTCH
+TEST(PartitionerTest, ptscotch)
+{
+    TestApp app;
+    Partitioner part(app.get_comm());
+    part.set_type("ptscotch");
+    EXPECT_EQ(part.get_type(), "ptscotch");
+}
+#endif
+
+TEST(PartitionerTest, set_up)
+{
+    TestApp app;
+    Partitioner part(app.get_comm());
+    part.set_up();
+}
+
+TEST(PartitionerTest, reset)
+{
+    TestApp app;
+    Partitioner part(app.get_comm());
+    part.reset();
+}
+
+TEST(PartitionerTest, view)
+{
+    testing::internal::CaptureStdout();
+    TestApp app;
+    Partitioner part(app.get_comm());
+    part.view();
+    auto out = testing::internal::GetCapturedStdout();
+    EXPECT_THAT(out, HasSubstr("type: simple"));
+}

--- a/test/src/TSAbstract_test.cpp
+++ b/test/src/TSAbstract_test.cpp
@@ -95,12 +95,14 @@ public:
     void
     pre_stage(Real stage_time) override
     {
+        TransientProblemInterface::pre_stage(stage_time);
         pre_stage_called = true;
     }
 
     void
     post_stage(Real stage_time, Int stage_index, const std::vector<Vector> & Y) override
     {
+        TransientProblemInterface::post_stage(stage_time, stage_index, Y);
         post_stage_called = true;
     }
 

--- a/test/src/TimeSteppingAdaptor_test.cpp
+++ b/test/src/TimeSteppingAdaptor_test.cpp
@@ -133,6 +133,7 @@ protected:
 TestTSProblem::TestTSProblem(const Parameters & params) : GTestImplicitFENonlinearProblem(params)
 {
     this->dts.resize(5);
+    monitor_cancel();
     monitor_set(this, &TestTSProblem::ts_monitor);
 }
 


### PR DESCRIPTION
- Improving code coverage for `BoundaryCondition`
- Improving code coverage for `ExplicitProblemInterface`
- Improving code coverage for `Mesh`
- Improving code coverage for `TransientProblemInterface`
- Adding tests for `Partitioner`
- Improving code coverage for `TransientProblemInterface`
- Improving code coverage for `DiscreteProblemInterface`
- Fixing memory leaks
- Removing deprecated methods in UnstructuredMesh
- Putting back a removed test
