### PR TITLE
Look for OpenCL if PETSc was built with it

### DIFF
--- a/cmake/FindPETSc.cmake
+++ b/cmake/FindPETSc.cmake
@@ -2,9 +2,11 @@
 #
 # Once done this will define
 #  PETSC_FOUND - System has PETSc
-#  PETSC_INCLUDE_DIR - The PETSc include directory
-#  PETSC_LIBRARY - The PETSc library
+#  PETSC_INCLUDE_DIRS - The PETSc include directory
+#  PETSC_LIBRARIES - The PETSc library
 #  PETSC_VERSION - The PETSc version
+
+include(CheckSymbolExists)
 
 find_path(
     PETSC_INCLUDE_DIR
@@ -36,6 +38,16 @@ if (PETSCVERSION_H)
     string(REGEX MATCH "define[ ]+PETSC_VERSION_SUBMINOR[ ]+([0-9]+)" TMP "${PETSC_VERSION_FILE}")
     set(PETSC_VERSION_PATCH ${CMAKE_MATCH_1})
     set(PETSC_VERSION "${PETSC_VERSION_MAJOR}.${PETSC_VERSION_MINOR}.${PETSC_VERSION_PATCH}")
+endif()
+
+set(PETSC_INCLUDE_DIRS ${PETSC_INCLUDE_DIR})
+set(PETSC_LIBRARIES ${PETSC_LIBRARY})
+
+check_symbol_exists(PETSC_HAVE_OPENCL "${PETSC_INCLUDE_DIR}/petscconf.h" PETSC_HAVE_OPENCL)
+if (PETSC_HAVE_OPENCL)
+    find_package(OpenCL REQUIRED)
+    list(APPEND PETSC_INCLUDE_DIRS ${OpenCL_INCLUDE_DIR})
+    list(APPEND PETSC_LIBRARIES ${OpenCL_LIBRARY})
 endif()
 
 include(FindPackageHandleStandardArgs)

--- a/examples/advect-eqn/CMakeLists.txt
+++ b/examples/advect-eqn/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(
     ${PROJECT_NAME}
     PRIVATE
         godzilla
-        ${PETSC_LIBRARY}
+        ${PETSC_LIBRARIES}
 )
 
 if (GODZILLA_BUILD_TESTS)

--- a/examples/ns-incomp/CMakeLists.txt
+++ b/examples/ns-incomp/CMakeLists.txt
@@ -17,14 +17,14 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_SOURCE_DIR}/contrib
     PRIVATE
-        ${PETSC_INCLUDE_DIR}
+        ${PETSC_INCLUDE_DIRS}
 )
 
 target_link_libraries(
     ${PROJECT_NAME}
     PRIVATE
         godzilla
-        ${PETSC_LIBRARY}
+        ${PETSC_LIBRARIES}
 )
 
 if (GODZILLA_BUILD_TESTS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,7 @@ target_include_directories(
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
         $<INSTALL_INTERFACE:include>
     PRIVATE
-        ${PETSC_INCLUDE_DIR}
+        ${PETSC_INCLUDE_DIRS}
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_SOURCE_DIR}/contrib
 )
@@ -36,7 +36,7 @@ target_link_libraries(
     PUBLIC
         fmt::fmt
     PRIVATE
-        ${PETSC_LIBRARY}
+        ${PETSC_LIBRARIES}
         muParser
         exodusIIcpp::exodusIIcpp
         yaml-cpp::yaml-cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,7 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_SOURCE_DIR}/contrib
     PRIVATE
-        ${PETSC_INCLUDE_DIR}
+        ${PETSC_INCLUDE_DIRS}
 )
 
 target_link_libraries(
@@ -31,7 +31,7 @@ target_link_libraries(
     PRIVATE
         yaml-cpp::yaml-cpp
         godzilla
-        ${PETSC_LIBRARY}
+        ${PETSC_LIBRARIES}
         ${CMAKE_DL_LIBS}
         gtest_main
         gmock_main

--- a/tools/mesh-part/CMakeLists.txt
+++ b/tools/mesh-part/CMakeLists.txt
@@ -17,14 +17,14 @@ target_include_directories(
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_SOURCE_DIR}/contrib
     PRIVATE
-        ${PETSC_INCLUDE_DIR}
+        ${PETSC_INCLUDE_DIRS}
 )
 
 target_link_libraries(
     ${PROJECT_NAME}
     PRIVATE
         godzilla
-        ${PETSC_LIBRARY}
+        ${PETSC_LIBRARIES}
         fmt::fmt
 )
 if(GODZILLA_WITH_MPI)


### PR DESCRIPTION
We #include some internal parts of PETSc that can be using OpenCL,
so we need to make this available during our build.
