### PR TITLE
Maintenance in FEProblemInterface

### DIFF
--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -410,7 +410,7 @@ private:
         /// the multiplier a for dF/dU_t
         Real u_t_shift;
 
-        AssemblyData(Int dim);
+        explicit AssemblyData(Int dim);
     } * asmbl;
 
     /// Functionals that must be evaluated before the weak form residual functionals

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -199,55 +199,55 @@ public:
                                       Int part = 0);
 
     /// Integrate residual
-    virtual ErrorCode integrate_residual(PetscDS ds,
-                                         PetscFormKey key,
-                                         Int n_elems,
-                                         PetscFEGeom * cell_geom,
-                                         const Scalar coefficients[],
-                                         const Scalar coefficients_t[],
-                                         PetscDS ds_aux,
-                                         const Scalar coefficients_aux[],
-                                         Real t,
-                                         Scalar elem_vec[]);
+    ErrorCode integrate_residual(PetscDS ds,
+                                 PetscFormKey key,
+                                 Int n_elems,
+                                 PetscFEGeom * cell_geom,
+                                 const Scalar coefficients[],
+                                 const Scalar coefficients_t[],
+                                 PetscDS ds_aux,
+                                 const Scalar coefficients_aux[],
+                                 Real t,
+                                 Scalar elem_vec[]);
 
     /// Integrate residual over a boundary
-    virtual ErrorCode integrate_bnd_residual(PetscDS ds,
-                                             PetscFormKey key,
-                                             Int n_elems,
-                                             PetscFEGeom * face_geom,
-                                             const Scalar coefficients[],
-                                             const Scalar coefficients_t[],
-                                             PetscDS ds_aux,
-                                             const Scalar coefficients_aux[],
-                                             Real t,
-                                             Scalar elem_vec[]);
+    ErrorCode integrate_bnd_residual(PetscDS ds,
+                                     PetscFormKey key,
+                                     Int n_elems,
+                                     PetscFEGeom * face_geom,
+                                     const Scalar coefficients[],
+                                     const Scalar coefficients_t[],
+                                     PetscDS ds_aux,
+                                     const Scalar coefficients_aux[],
+                                     Real t,
+                                     Scalar elem_vec[]);
 
     /// Integrate Jacobian
-    virtual ErrorCode integrate_jacobian(PetscDS ds,
-                                         PetscFEJacobianType jtype,
-                                         PetscFormKey key,
-                                         Int n_elems,
-                                         PetscFEGeom * cell_geom,
-                                         const Scalar coefficients[],
-                                         const Scalar coefficients_t[],
-                                         PetscDS ds_aux,
-                                         const Scalar coefficients_aux[],
-                                         Real t,
-                                         Real u_tshift,
-                                         Scalar elem_mat[]);
+    ErrorCode integrate_jacobian(PetscDS ds,
+                                 PetscFEJacobianType jtype,
+                                 PetscFormKey key,
+                                 Int n_elems,
+                                 PetscFEGeom * cell_geom,
+                                 const Scalar coefficients[],
+                                 const Scalar coefficients_t[],
+                                 PetscDS ds_aux,
+                                 const Scalar coefficients_aux[],
+                                 Real t,
+                                 Real u_tshift,
+                                 Scalar elem_mat[]);
 
     // Integrate Jacobian over a boundary
-    virtual ErrorCode integrate_bnd_jacobian(PetscDS ds,
-                                             PetscFormKey key,
-                                             Int n_elems,
-                                             PetscFEGeom * face_geom,
-                                             const Scalar coefficients[],
-                                             const Scalar coefficients_t[],
-                                             PetscDS ds_aux,
-                                             const Scalar coefficients_aux[],
-                                             Real t,
-                                             Real u_tshift,
-                                             Scalar elem_mat[]);
+    ErrorCode integrate_bnd_jacobian(PetscDS ds,
+                                     PetscFormKey key,
+                                     Int n_elems,
+                                     PetscFEGeom * face_geom,
+                                     const Scalar coefficients[],
+                                     const Scalar coefficients_t[],
+                                     PetscDS ds_aux,
+                                     const Scalar coefficients_aux[],
+                                     Real t,
+                                     Real u_tshift,
+                                     Scalar elem_mat[]);
 
 protected:
     const std::map<Int, FieldInfo> & get_fields() const;

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -369,19 +369,7 @@ private:
         {
         }
 
-        FieldInfo(const FieldInfo & other) :
-            name(other.name),
-            id(other.id),
-            fe(other.fe),
-            block(other.block),
-            nc(other.nc),
-            k(other.k),
-            component_names(other.component_names),
-            values(other.values),
-            derivs(other.derivs),
-            dots(other.dots)
-        {
-        }
+        FieldInfo(const FieldInfo & other) = default;
     };
 
     /// Fields in the problem

--- a/src/PetscFEGodzilla.cpp
+++ b/src/PetscFEGodzilla.cpp
@@ -8,9 +8,9 @@
 #include "godzilla/CallStack.h"
 
 namespace godzilla {
-namespace internal {
+namespace {
 
-static ErrorCode
+ErrorCode
 integrate_residual(PetscDS ds,
                    PetscFormKey key,
                    Int ne,
@@ -26,20 +26,19 @@ integrate_residual(PetscDS ds,
     void * ctx;
     PETSC_CHECK(PetscDSGetContext(ds, key.field, &ctx));
     auto * fepi = static_cast<godzilla::FEProblemInterface *>(ctx);
-    ErrorCode err = fepi->integrate_residual(ds,
-                                             key,
-                                             ne,
-                                             cgeom,
-                                             coefficients,
-                                             coefficients_t,
-                                             ds_aux,
-                                             coefficients_aux,
-                                             t,
-                                             elem_vec);
-    return err;
+    return fepi->integrate_residual(ds,
+                                    key,
+                                    ne,
+                                    cgeom,
+                                    coefficients,
+                                    coefficients_t,
+                                    ds_aux,
+                                    coefficients_aux,
+                                    t,
+                                    elem_vec);
 }
 
-static ErrorCode
+ErrorCode
 integrate_bd_residual(PetscDS ds,
                       PetscWeakForm /*wf*/,
                       PetscFormKey key,
@@ -56,17 +55,16 @@ integrate_bd_residual(PetscDS ds,
     void * ctx;
     PETSC_CHECK(PetscDSGetContext(ds, key.field, &ctx));
     auto * fepi = static_cast<godzilla::FEProblemInterface *>(ctx);
-    ErrorCode err = fepi->integrate_bnd_residual(ds,
-                                                 key,
-                                                 ne,
-                                                 fgeom,
-                                                 coefficients,
-                                                 coefficients_t,
-                                                 ds_aux,
-                                                 coefficients_aux,
-                                                 t,
-                                                 elem_vec);
-    return err;
+    return fepi->integrate_bnd_residual(ds,
+                                        key,
+                                        ne,
+                                        fgeom,
+                                        coefficients,
+                                        coefficients_t,
+                                        ds_aux,
+                                        coefficients_aux,
+                                        t,
+                                        elem_vec);
 }
 
 ErrorCode
@@ -90,22 +88,21 @@ integrate_jacobian(PetscDS ds,
     void * ctx;
     PETSC_CHECK(PetscDSGetContext(ds, field_i, &ctx));
     auto * fepi = static_cast<godzilla::FEProblemInterface *>(ctx);
-    ErrorCode err = fepi->integrate_jacobian(ds,
-                                             jtype,
-                                             key,
-                                             ne,
-                                             cgeom,
-                                             coefficients,
-                                             coefficients_t,
-                                             ds_aux,
-                                             coefficients_aux,
-                                             t,
-                                             u_tshift,
-                                             elem_mat);
-    return err;
+    return fepi->integrate_jacobian(ds,
+                                    jtype,
+                                    key,
+                                    ne,
+                                    cgeom,
+                                    coefficients,
+                                    coefficients_t,
+                                    ds_aux,
+                                    coefficients_aux,
+                                    t,
+                                    u_tshift,
+                                    elem_mat);
 }
 
-static ErrorCode
+ErrorCode
 integrate_bd_jacobian(PetscDS ds,
                       PetscWeakForm /*wf*/,
                       PetscFormKey key,
@@ -126,19 +123,22 @@ integrate_bd_jacobian(PetscDS ds,
     void * ctx;
     PETSC_CHECK(PetscDSGetContext(ds, field_i, &ctx));
     auto * fepi = static_cast<godzilla::FEProblemInterface *>(ctx);
-    ErrorCode err = fepi->integrate_bnd_jacobian(ds,
-                                                 key,
-                                                 ne,
-                                                 fgeom,
-                                                 coefficients,
-                                                 coefficients_t,
-                                                 ds_aux,
-                                                 coefficients_aux,
-                                                 t,
-                                                 u_tshift,
-                                                 elem_mat);
-    return err;
+    return fepi->integrate_bnd_jacobian(ds,
+                                        key,
+                                        ne,
+                                        fgeom,
+                                        coefficients,
+                                        coefficients_t,
+                                        ds_aux,
+                                        coefficients_aux,
+                                        t,
+                                        u_tshift,
+                                        elem_mat);
 }
+
+} // namespace
+
+namespace internal {
 
 ErrorCode
 create_lagrange_petscfe(MPI_Comm comm,


### PR DESCRIPTION
- Use default copy ctor for `FEProblemInterface::FieldInfo`
- Use anonymous namespace on PetscFEGodzilla.cpp
- Changing integration methods in FEProblemInterface from virtual to non-virtual
- Marking `AssemblyData` ctor explicit
