### PR TITLE
Fixing problems reported by clang-tidy

### DIFF
--- a/examples/poisson/include/PoissonEquation.h
+++ b/examples/poisson/include/PoissonEquation.h
@@ -9,7 +9,6 @@ using namespace godzilla;
 class PoissonEquation : public FENonlinearProblem {
 public:
     PoissonEquation(const Parameters & parameters);
-    ~PoissonEquation() override;
 
 protected:
     void set_up_fields() override;

--- a/examples/poisson/src/PoissonEquation.cpp
+++ b/examples/poisson/src/PoissonEquation.cpp
@@ -22,8 +22,6 @@ PoissonEquation::PoissonEquation(const Parameters & parameters) :
     CALL_STACK_MSG();
 }
 
-PoissonEquation::~PoissonEquation() {}
-
 void
 PoissonEquation::set_up_fields()
 {

--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -68,17 +68,17 @@ public:
     /// Get logger associated with the application
     ///
     /// @return Logger
-    Logger * get_logger() const;
+    [[nodiscard]] Logger * get_logger() const;
 
     /// Get Application name
     ///
     /// @return Application name
-    const std::string & get_name() const;
+    [[nodiscard]] const std::string & get_name() const;
 
     /// Get application version
     ///
     /// @return The application version as a string
-    virtual const std::string & get_version() const;
+    [[nodiscard]] virtual const std::string & get_version() const;
 
     /// Get the factory for building objects
     ///
@@ -88,7 +88,7 @@ public:
     /// Get pointer to the `Problem` class in this application
     ///
     /// @return Get problem this application is representing
-    Problem * get_problem() const;
+    [[nodiscard]] Problem * get_problem() const;
 
     /// Get pointer to the `Problem`-derived class in this application
     ///
@@ -124,7 +124,7 @@ public:
     /// Get level of verbosity
     ///
     /// @return The verbosity level
-    const unsigned int & get_verbosity_level() const;
+    [[nodiscard]] const unsigned int & get_verbosity_level() const;
 
     /// Set verbosity level
     ///
@@ -134,12 +134,12 @@ public:
     /// Get the input file name
     ///
     /// @return The input file name
-    const std::string & get_input_file_name() const;
+    [[nodiscard]] const std::string & get_input_file_name() const;
 
     /// Get MPI communicator
     ///
     /// @return MPI communicator
-    const mpi::Communicator & get_comm() const;
+    [[nodiscard]] const mpi::Communicator & get_comm() const;
 
     /// Get parameters for a class
     ///

--- a/include/godzilla/Array1D.h
+++ b/include/godzilla/Array1D.h
@@ -87,7 +87,7 @@ public:
     /// Get number of entries in the array
     ///
     /// @return Number of entries in the array
-    Int
+    [[nodiscard]] Int
     get_size() const
     {
         return this->n;
@@ -97,7 +97,7 @@ public:
     ///
     /// @param i Index fo the entry
     /// @return Entry at the `ith` location
-    const T &
+    [[nodiscard]] const T &
     get(Int i) const
     {
         assert(this->data != nullptr);
@@ -234,7 +234,7 @@ public:
     ///
     /// @param a Vector to multiply with
     /// @return Dot product
-    T
+    [[nodiscard]] T
     dot(const Array1D<T> & a) const
     {
         error("Dot product not implemented");
@@ -263,7 +263,7 @@ public:
     //
 
     // Do your best to avoid abusing this API
-    T *
+    [[nodiscard]] T *
     get_data() const
     {
         return this->data;

--- a/include/godzilla/AuxiliaryField.h
+++ b/include/godzilla/AuxiliaryField.h
@@ -26,32 +26,32 @@ public:
     /// Get the spatial dimension of the problem this field is part of
     ///
     /// @return Spatial dimension of the problem
-    Int get_dimension() const;
+    [[nodiscard]] Int get_dimension() const;
 
     /// Get block ID this field is defined on
     ///
     /// @return Block ID
-    Int get_block_id() const;
+    [[nodiscard]] Int get_block_id() const;
 
     /// Get the `Label` this field is defined on
     ///
     /// @return Reference to a `Label`
-    const Label & get_label() const;
+    [[nodiscard]] const Label & get_label() const;
 
     /// Get the region name this field is defined on
     ///
     /// @return The region name
-    const std::string & get_region() const;
+    [[nodiscard]] const std::string & get_region() const;
 
     /// Get the ID of the field this boundary condition operates on
     ///
     /// @return ID of the field
-    Int get_field_id() const;
+    [[nodiscard]] Int get_field_id() const;
 
     /// Get field name
     ///
     /// @return The field name
-    const std::string & get_field() const;
+    [[nodiscard]] const std::string & get_field() const;
 
     /// Get the number of constrained components
     ///
@@ -70,12 +70,12 @@ protected:
     /// Get mesh this auxiliary field is defined on
     ///
     /// @return Mesh this auxiliary field is defined on
-    UnstructuredMesh * get_mesh() const;
+    [[nodiscard]] UnstructuredMesh * get_mesh() const;
 
     /// Get problem this auxiliary field is part of
     ///
     /// @return Problem this auxiliary field of part of
-    Problem * get_problem() const;
+    [[nodiscard]] Problem * get_problem() const;
 
 private:
     /// Discrete problem this object is part of

--- a/include/godzilla/BoundaryCondition.h
+++ b/include/godzilla/BoundaryCondition.h
@@ -23,7 +23,7 @@ public:
     /// Get problem spatial dimension
     ///
     /// @return Spatial dimension
-    Int get_dimension() const;
+    [[nodiscard]] Int get_dimension() const;
 
     /// Get the boundary name this BC is active on
     ///
@@ -40,7 +40,7 @@ public:
 
 protected:
     /// Get problem this auxiliary field is part of
-    Problem * get_problem() const;
+    [[nodiscard]] Problem * get_problem() const;
 
 private:
     /// Discrete problem this object is part of

--- a/include/godzilla/BoxMesh.h
+++ b/include/godzilla/BoxMesh.h
@@ -16,31 +16,31 @@ public:
     explicit BoxMesh(const Parameters & parameters);
 
     /// Get lower limit in x-direction
-    Real get_x_min() const;
+    [[nodiscard]] Real get_x_min() const;
 
     /// Get upper limit in x-direction
-    Real get_x_max() const;
+    [[nodiscard]] Real get_x_max() const;
 
     /// Get the number of mesh points in x direction
-    Int get_nx() const;
+    [[nodiscard]] Int get_nx() const;
 
     /// Get lower limit in y-direction
-    Real get_y_min() const;
+    [[nodiscard]] Real get_y_min() const;
 
     /// Get upper limit in y-direction
-    Real get_y_max() const;
+    [[nodiscard]] Real get_y_max() const;
 
     /// Get the number of mesh points in y-direction
-    Int get_ny() const;
+    [[nodiscard]] Int get_ny() const;
 
     /// Get lower limit in z-direction
-    Real get_z_min() const;
+    [[nodiscard]] Real get_z_min() const;
 
     /// Get upper limit in z-direction
-    Real get_z_max() const;
+    [[nodiscard]] Real get_z_max() const;
 
     /// Get the number of mesh points in z direction
-    Int get_nz() const;
+    [[nodiscard]] Int get_nz() const;
 
 protected:
     Mesh * create_mesh() override;

--- a/include/godzilla/CSVOutput.h
+++ b/include/godzilla/CSVOutput.h
@@ -22,7 +22,7 @@ public:
     /// Get post-processor names
     ///
     /// @return Post-processor names
-    const std::vector<std::string> &
+    [[nodiscard]] const std::vector<std::string> &
     get_pps_names() const
     {
         return pps_names;

--- a/include/godzilla/CallStack.h
+++ b/include/godzilla/CallStack.h
@@ -119,10 +119,10 @@ public:
     void remove(Msg * msg);
 
     /// Get size of the call stack
-    int get_size() const;
+    [[nodiscard]] int get_size() const;
 
     /// Get item at position `idx`
-    Msg * at(int idx) const;
+    [[nodiscard]] Msg * at(int idx) const;
 
 private:
     /// The object storing call stack objects

--- a/include/godzilla/DGProblemInterface.h
+++ b/include/godzilla/DGProblemInterface.h
@@ -18,24 +18,24 @@ public:
 
     [[nodiscard]] Int get_num_fields() const override;
     [[nodiscard]] std::vector<std::string> get_field_names() const override;
-    const std::string & get_field_name(Int fid) const override;
-    Int get_field_num_components(Int fid) const override;
+    [[nodiscard]] const std::string & get_field_name(Int fid) const override;
+    [[nodiscard]] Int get_field_num_components(Int fid) const override;
     [[nodiscard]] Int get_field_id(const std::string & name) const override;
     [[nodiscard]] bool has_field_by_id(Int fid) const override;
     [[nodiscard]] bool has_field_by_name(const std::string & name) const override;
-    Int get_field_order(Int fid) const override;
-    std::string get_field_component_name(Int fid, Int component) const override;
+    [[nodiscard]] Int get_field_order(Int fid) const override;
+    [[nodiscard]] std::string get_field_component_name(Int fid, Int component) const override;
     void set_field_component_name(Int fid, Int component, const std::string & name) override;
 
-    Int get_num_aux_fields() const override;
-    std::vector<std::string> get_aux_field_names() const override;
-    const std::string & get_aux_field_name(Int fid) const override;
-    Int get_aux_field_num_components(Int fid) const override;
-    Int get_aux_field_id(const std::string & name) const override;
-    bool has_aux_field_by_id(Int fid) const override;
-    bool has_aux_field_by_name(const std::string & name) const override;
-    Int get_aux_field_order(Int fid) const override;
-    std::string get_aux_field_component_name(Int fid, Int component) const override;
+    [[nodiscard]] Int get_num_aux_fields() const override;
+    [[nodiscard]] std::vector<std::string> get_aux_field_names() const override;
+    [[nodiscard]] const std::string & get_aux_field_name(Int fid) const override;
+    [[nodiscard]] Int get_aux_field_num_components(Int fid) const override;
+    [[nodiscard]] Int get_aux_field_id(const std::string & name) const override;
+    [[nodiscard]] bool has_aux_field_by_id(Int fid) const override;
+    [[nodiscard]] bool has_aux_field_by_name(const std::string & name) const override;
+    [[nodiscard]] Int get_aux_field_order(Int fid) const override;
+    [[nodiscard]] std::string get_aux_field_component_name(Int fid, Int component) const override;
     void set_aux_field_component_name(Int fid, Int component, const std::string & name) override;
 
     /// Adds a volumetric field
@@ -78,7 +78,7 @@ public:
     /// @param comp Component
     /// @param fid Field ID
     /// @return Degree of freedom
-    Int get_field_dof(Int elem, Int local_node, Int comp, Int fid) const;
+    [[nodiscard]] Int get_field_dof(Int elem, Int local_node, Int comp, Int fid) const;
 
     /// Get auxiliary field degree of freedom
     ///
@@ -87,10 +87,10 @@ public:
     /// @param comp Component
     /// @param fid Auxiliary field ID
     /// @return Degree of freedom
-    Int get_aux_field_dof(Int elem, Int local_node, Int comp, Int fid) const;
+    [[nodiscard]] Int get_aux_field_dof(Int elem, Int local_node, Int comp, Int fid) const;
 
 protected:
-    Int get_num_nodes_per_elem(Int c) const;
+    [[nodiscard]] Int get_num_nodes_per_elem(Int c) const;
 
     void init() override;
     void create() override;

--- a/include/godzilla/DGProblemInterface.h
+++ b/include/godzilla/DGProblemInterface.h
@@ -132,15 +132,7 @@ private:
         {
         }
 
-        FieldInfo(const FieldInfo & other) :
-            name(other.name),
-            id(other.id),
-            block(other.block),
-            nc(other.nc),
-            k(other.k),
-            component_names(other.component_names)
-        {
-        }
+        FieldInfo(const FieldInfo & other) = default;
     };
 
     /// Fields in the problem

--- a/include/godzilla/Delegate.h
+++ b/include/godzilla/Delegate.h
@@ -13,7 +13,7 @@ class Delegate;
 template <typename R, typename... ARGS>
 class Delegate<R(ARGS...)> {
 public:
-    Delegate() {}
+    Delegate() = default;
 
     template <typename T>
     Delegate(T * t, R (T::*method)(ARGS...))

--- a/include/godzilla/DenseMatrix.h
+++ b/include/godzilla/DenseMatrix.h
@@ -39,7 +39,7 @@ public:
     /// Get the number of rows
     ///
     /// @return The number of rows
-    int
+    [[nodiscard]] int
     get_num_rows() const
     {
         return ROWS;
@@ -48,7 +48,7 @@ public:
     /// Get the number of columns
     ///
     /// @return The number of columns
-    int
+    [[nodiscard]] int
     get_num_cols() const
     {
         return COLS;
@@ -296,7 +296,7 @@ public:
     }
 
     /// Compute determinant of the matrix
-    Real
+    [[nodiscard]] Real
     det() const
     {
         error("Determinant is not implemented for {}x{} matrices, yet.", ROWS, ROWS);
@@ -581,7 +581,7 @@ private:
     /// @param row Row number
     /// @param col Column number
     /// @return Offset into the `data` array that contains the entry at position (row, col)
-    Int
+    [[nodiscard]] Int
     idx(Int row, Int col) const
     {
         return row * COLS + col;

--- a/include/godzilla/DenseMatrix.h
+++ b/include/godzilla/DenseMatrix.h
@@ -485,13 +485,14 @@ public:
         return mult(x);
     }
 
-    void
+    DenseMatrix<Real, ROWS> &
     operator=(const DenseMatrixSymm<Real, ROWS> & m)
     {
         assert(COLS == ROWS);
         for (Int i = 0; i < ROWS; i++)
             for (Int j = 0; j < COLS; j++)
                 set(i, j) = m(i, j);
+        return *this;
     }
 
     /// Get access to the underlying data

--- a/include/godzilla/DenseMatrix.h
+++ b/include/godzilla/DenseMatrix.h
@@ -26,7 +26,7 @@ class DenseMatrixSymm;
 template <typename T, Int ROWS, Int COLS = ROWS>
 class DenseMatrix {
 public:
-    DenseMatrix() {};
+    DenseMatrix() = default;
 
     DenseMatrix(const DenseMatrixSymm<Real, ROWS> & m)
     {

--- a/include/godzilla/DenseMatrixSymm.h
+++ b/include/godzilla/DenseMatrixSymm.h
@@ -29,7 +29,7 @@ private:
     static const Int N = DIM * (1 + DIM) / 2;
 
 public:
-    DenseMatrixSymm() {};
+    DenseMatrixSymm() = default;
 
     /// Create matrix from values
     ///

--- a/include/godzilla/DenseMatrixSymm.h
+++ b/include/godzilla/DenseMatrixSymm.h
@@ -36,13 +36,13 @@ public:
     /// @param vals Values in column major format
     DenseMatrixSymm(const std::vector<Real> & vals) { set_values(vals); };
 
-    int
+    [[nodiscard]] int
     get_num_rows() const
     {
         return DIM;
     }
 
-    int
+    [[nodiscard]] int
     get_num_cols() const
     {
         return DIM;
@@ -195,7 +195,7 @@ public:
     }
 
     /// Compute determinant of the matrix
-    Real
+    [[nodiscard]] Real
     det() const
     {
         error("Determinant is not implemented for {}x{} matrices, yet.", DIM, DIM);
@@ -386,7 +386,7 @@ protected:
     }
 
 private:
-    inline Int
+    [[nodiscard]] inline Int
     idx(Int row, Int col) const
     {
         if (col < row)

--- a/include/godzilla/DenseVector.h
+++ b/include/godzilla/DenseVector.h
@@ -22,7 +22,7 @@ template <typename T, Int N>
 class DenseVector {
 public:
     /// Create empty vector
-    DenseVector() {}
+    DenseVector() = default;
 
     /// Create vector from a std::vector
     ///

--- a/include/godzilla/DenseVector.h
+++ b/include/godzilla/DenseVector.h
@@ -37,7 +37,7 @@ public:
     ///
     /// @param i Index
     /// @return Entry at location (i)
-    const T &
+    [[nodiscard]] const T &
     get(Int i) const
     {
         assert((i >= 0) && (i < N));
@@ -126,7 +126,7 @@ public:
     /// Compute average from vector entries
     ///
     /// @return Average of vector entries
-    Real
+    [[nodiscard]] Real
     avg() const
     {
         Real res = 0.;
@@ -139,7 +139,7 @@ public:
     ///
     /// @param a Dotted vector
     /// @return Dot product
-    T
+    [[nodiscard]] T
     dot(const DenseVector<T, N> & a) const
     {
         T dot = 0.;
@@ -148,7 +148,7 @@ public:
         return dot;
     }
 
-    DenseVector<Real, N>
+    [[nodiscard]] DenseVector<Real, N>
     cross(const DenseVector<Real, N> &) const
     {
         error("Cross product in {} dimensions is not unique.", N);
@@ -168,7 +168,7 @@ public:
     /// Sum all vector elements, i.e \Sum_i vec[i]
     ///
     /// @return Sum of all elements
-    T
+    [[nodiscard]] T
     sum() const
     {
         T sum = 0.;
@@ -180,7 +180,7 @@ public:
     /// Compute vector magnitude, i.e. sqrt(\Sum_i vec[i]^2)
     ///
     /// @return Vector magnitude
-    T
+    [[nodiscard]] T
     magnitude() const
     {
         T sum = 0.;
@@ -193,7 +193,7 @@ public:
     ///
     /// @param b Second vector
     /// @return Vector with entries this[i]*b[i]
-    DenseVector<T, N>
+    [[nodiscard]] DenseVector<T, N>
     pointwise_mult(const DenseVector<T, N> & b) const
     {
         DenseVector<T, N> res;
@@ -206,7 +206,7 @@ public:
     ///
     /// @param b Second vector
     /// @return Vector with entries this[i]/b[i]
-    DenseVector<T, N>
+    [[nodiscard]] DenseVector<T, N>
     pointwise_div(const DenseVector<T, N> & b) const
     {
         DenseVector<T, N> res;
@@ -218,7 +218,7 @@ public:
     /// Find the minimum value of the elements
     ///
     /// @return The minimum value of the elements
-    T
+    [[nodiscard]] T
     min() const
     {
         T res = std::numeric_limits<T>::max();
@@ -231,7 +231,7 @@ public:
     /// Find the minimum value of the elements
     ///
     /// @return The minimum value of the elements
-    T
+    [[nodiscard]] T
     max() const
     {
         T res = std::numeric_limits<T>::min();

--- a/include/godzilla/DependencyEvaluator.h
+++ b/include/godzilla/DependencyEvaluator.h
@@ -30,7 +30,7 @@ class DependencyEvaluator {
             this->declared = true;
         }
 
-        bool
+        [[nodiscard]] bool
         is_declared() const
         {
             return this->declared;
@@ -70,7 +70,7 @@ public:
     /// Get all functionals
     ///
     /// @return List of all functionals
-    const std::map<std::string, const ValueFunctional *> & get_functionals() const;
+    [[nodiscard]] const std::map<std::string, const ValueFunctional *> & get_functionals() const;
 
     /// Create a functional
     ///
@@ -84,7 +84,7 @@ public:
     ///
     /// @param name The name of the functional
     /// @return Reference to the functional
-    virtual const ValueFunctional & get_functional(const std::string & name) const;
+    [[nodiscard]] virtual const ValueFunctional & get_functional(const std::string & name) const;
 
     /// Declare a value with a name
     ///
@@ -102,7 +102,7 @@ public:
     template <typename T>
     const T & get_value(const std::string & val_name);
 
-    std::map<std::string, const ValueFunctional *> get_suppliers() const;
+    [[nodiscard]] std::map<std::string, const ValueFunctional *> get_suppliers() const;
 
     DependencyGraph<const Functional *>
     build_dependecy_graph(const std::map<std::string, const ValueFunctional *> & suppliers);

--- a/include/godzilla/DependencyEvaluator.h
+++ b/include/godzilla/DependencyEvaluator.h
@@ -64,7 +64,7 @@ class DependencyEvaluator {
     };
 
 public:
-    DependencyEvaluator();
+    DependencyEvaluator() = default;
     virtual ~DependencyEvaluator();
 
     /// Get all functionals

--- a/include/godzilla/DependencyGraph.h
+++ b/include/godzilla/DependencyGraph.h
@@ -15,7 +15,7 @@ namespace godzilla {
 template <typename T>
 class DependencyGraph {
 public:
-    DependencyGraph() {}
+    DependencyGraph() = default;
 
     /// Add node into the graph.
     ///

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -61,64 +61,64 @@ public:
     virtual ~DiscreteProblemInterface();
 
     /// Get unstructured mesh associated with this problem
-    UnstructuredMesh * get_unstr_mesh() const;
+    [[nodiscard]] UnstructuredMesh * get_unstr_mesh() const;
 
     /// Get problem
     ///
     /// @return Problem this interface is part of
-    Problem * get_problem() const;
+    [[nodiscard]] Problem * get_problem() const;
 
     /// Get number of fields
     ///
     /// @return The number of fields
-    virtual Int get_num_fields() const = 0;
+    [[nodiscard]] virtual Int get_num_fields() const = 0;
 
     /// Get list of all field names
     ///
     /// @return List of field names
-    virtual std::vector<std::string> get_field_names() const = 0;
+    [[nodiscard]] virtual std::vector<std::string> get_field_names() const = 0;
 
     /// Get field name
     ///
     /// @param fid Field ID
-    virtual const std::string & get_field_name(Int fid) const = 0;
+    [[nodiscard]] virtual const std::string & get_field_name(Int fid) const = 0;
 
     /// Get number of field components
     ///
     /// @param fid Field ID
     /// @return Number of components
-    virtual Int get_field_num_components(Int fid) const = 0;
+    [[nodiscard]] virtual Int get_field_num_components(Int fid) const = 0;
 
     /// Get field ID
     ///
     /// @param name Field name
     /// @param Field ID
-    virtual Int get_field_id(const std::string & name) const = 0;
+    [[nodiscard]] virtual Int get_field_id(const std::string & name) const = 0;
 
     /// Do we have field with specified ID
     ///
     /// @param fid The ID of the field
     /// @return True if the field exists, otherwise False
-    virtual bool has_field_by_id(Int fid) const = 0;
+    [[nodiscard]] virtual bool has_field_by_id(Int fid) const = 0;
 
     /// Do we have field with specified name
     ///
     /// @param name The name of the field
     /// @return True if the field exists, otherwise False
-    virtual bool has_field_by_name(const std::string & name) const = 0;
+    [[nodiscard]] virtual bool has_field_by_name(const std::string & name) const = 0;
 
     /// Get field order
     ///
     /// @param fid Field ID
     /// @return Field order
-    virtual Int get_field_order(Int fid) const = 0;
+    [[nodiscard]] virtual Int get_field_order(Int fid) const = 0;
 
     /// Get component name of a field
     ///
     /// @param fid Field ID
     /// @param component Component index
     /// @return Component name
-    virtual std::string get_field_component_name(Int fid, Int component) const = 0;
+    [[nodiscard]] virtual std::string get_field_component_name(Int fid, Int component) const = 0;
 
     /// Set the name of a component of afield variable
     ///
@@ -130,55 +130,56 @@ public:
     /// Get number of auxiliary fields
     ///
     /// @return The number of auxiliary fields
-    virtual Int get_num_aux_fields() const = 0;
+    [[nodiscard]] virtual Int get_num_aux_fields() const = 0;
 
     /// Get all auxiliary field names
     ///
     /// @return All auxiliary field names
-    virtual std::vector<std::string> get_aux_field_names() const = 0;
+    [[nodiscard]] virtual std::vector<std::string> get_aux_field_names() const = 0;
 
     /// Get auxiliary field name
     ///
     /// @param fid Auxiliary field ID
     /// @return Auxiliary field name
-    virtual const std::string & get_aux_field_name(Int fid) const = 0;
+    [[nodiscard]] virtual const std::string & get_aux_field_name(Int fid) const = 0;
 
     /// Get number of auxiliary field components
     ///
     /// @param fid Auxiliary field ID
     /// @return Number of components
-    virtual Int get_aux_field_num_components(Int fid) const = 0;
+    [[nodiscard]] virtual Int get_aux_field_num_components(Int fid) const = 0;
 
     /// Get auxiliary field ID
     ///
     /// @param name Auxiliary field name
     /// @return Auxiliary field ID
-    virtual Int get_aux_field_id(const std::string & name) const = 0;
+    [[nodiscard]] virtual Int get_aux_field_id(const std::string & name) const = 0;
 
     /// Do we have auxiliary field with specified ID
     ///
     /// @param fid The ID of the auxiliary field
     /// @return True if the auxiliary field exists, otherwise False
-    virtual bool has_aux_field_by_id(Int fid) const = 0;
+    [[nodiscard]] virtual bool has_aux_field_by_id(Int fid) const = 0;
 
     /// Do we have auxiliary field with specified name
     ///
     /// @param name The name of the auxiliary field
     /// @return True if the auxiliary field exists, otherwise False
-    virtual bool has_aux_field_by_name(const std::string & name) const = 0;
+    [[nodiscard]] virtual bool has_aux_field_by_name(const std::string & name) const = 0;
 
     /// Get auxiliary field order
     ///
     /// @param fid Auxiliary field ID
     /// @return Auxiliary field order
-    virtual Int get_aux_field_order(Int fid) const = 0;
+    [[nodiscard]] virtual Int get_aux_field_order(Int fid) const = 0;
 
     /// Get component name of an auxiliary field
     ///
     /// @param fid Auxiliary field ID
     /// @param component Component index
     /// @return Component name
-    virtual std::string get_aux_field_component_name(Int fid, Int component) const = 0;
+    [[nodiscard]] virtual std::string get_aux_field_component_name(Int fid,
+                                                                   Int component) const = 0;
 
     /// Set the name of a component of an auxiliary field variable
     ///
@@ -206,13 +207,13 @@ public:
     ///
     /// @param name The name of the object
     /// @return True if the object exists, otherwise false
-    bool has_initial_condition(const std::string & name) const;
+    [[nodiscard]] bool has_initial_condition(const std::string & name) const;
 
     /// Get initial condition object with a specified name
     ///
     /// @param name The name of the object
     /// @return Pointer to the initial condition object
-    InitialCondition * get_initial_condition(const std::string & name) const;
+    [[nodiscard]] InitialCondition * get_initial_condition(const std::string & name) const;
 
     /// Add essential boundary condition
     ///
@@ -228,20 +229,20 @@ public:
     ///
     /// @param name The name of the object
     /// @return True if the object exists, otherwise false
-    bool has_aux(const std::string & name) const;
+    [[nodiscard]] bool has_aux(const std::string & name) const;
 
     /// Get auxiliary object with a specified name
     ///
     /// @param name The name of the object
     /// @return Pointer to the auxiliary object
-    AuxiliaryField * get_aux(const std::string & name) const;
+    [[nodiscard]] AuxiliaryField * get_aux(const std::string & name) const;
 
     /// Return the offset into an array or local Vec for the dof associated with the given point
     ///
     /// @param point Point
     /// @param fid Field ID
     /// @return The offset
-    Int get_field_dof(Int point, Int fid) const;
+    [[nodiscard]] Int get_field_dof(Int point, Int fid) const;
 
     /// Return the offset into an array of local auxiliary Vec for the dof associated with the given
     /// point
@@ -249,12 +250,12 @@ public:
     /// @param point Point
     /// @param fid Field ID
     /// @return The offset
-    Int get_aux_field_dof(Int point, Int fid) const;
+    [[nodiscard]] Int get_aux_field_dof(Int point, Int fid) const;
 
     /// Get local solution vector
     ///
     /// @return Local solution vector
-    const Vector & get_solution_vector_local() const;
+    [[nodiscard]] const Vector & get_solution_vector_local() const;
 
     /// Get local solution vector
     ///
@@ -264,7 +265,7 @@ public:
     /// Get local auxiliary solution vector
     ///
     /// @return Local auxiliary solution vector
-    const Vector & get_aux_solution_vector_local() const;
+    [[nodiscard]] const Vector & get_aux_solution_vector_local() const;
 
     /// Get local auxiliary solution vector
     ///
@@ -376,11 +377,11 @@ public:
 
 protected:
     /// Get list of all boundary conditions
-    const std::vector<BoundaryCondition *> & get_boundary_conditions() const;
+    [[nodiscard]] const std::vector<BoundaryCondition *> & get_boundary_conditions() const;
     /// Get list of all essential boundary conditions
-    const std::vector<EssentialBC *> & get_essential_bcs() const;
+    [[nodiscard]] const std::vector<EssentialBC *> & get_essential_bcs() const;
     /// Get list of all natural boundary conditions
-    const std::vector<NaturalBC *> & get_natural_bcs() const;
+    [[nodiscard]] const std::vector<NaturalBC *> & get_natural_bcs() const;
     /// Distribute the problem among processors for parallel execution
     void distribute();
 
@@ -390,7 +391,7 @@ protected:
     /// Create underlying PetscDS object
     void create_ds();
     /// Get underlying PetscDS object
-    PetscDS get_ds() const;
+    [[nodiscard]] PetscDS get_ds() const;
     /// Set up discrete system
     virtual void set_up_ds() = 0;
 
@@ -410,11 +411,11 @@ protected:
     /// Check existence of boundaries used by BCs
     bool check_bcs_boundaries();
 
-    DM get_dm_aux() const;
+    [[nodiscard]] DM get_dm_aux() const;
 
-    PetscDS get_ds_aux() const;
+    [[nodiscard]] PetscDS get_ds_aux() const;
 
-    Section get_local_section_aux() const;
+    [[nodiscard]] Section get_local_section_aux() const;
 
     void set_local_section_aux(const Section & section);
 
@@ -437,7 +438,7 @@ protected:
     /// Update auxiliary vector
     virtual void update_aux_vector();
 
-    Int get_next_id(const std::vector<Int> & ids) const;
+    [[nodiscard]] Int get_next_id(const std::vector<Int> & ids) const;
 
 private:
     /// Problem this interface is part of

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -278,8 +278,8 @@ public:
                       const std::vector<Int> & ids,
                       Int field,
                       const std::vector<Int> & components,
-                      void (*bc_fn)(void),
-                      void (*bc_fn_t)(void),
+                      void (*bc_fn)(),
+                      void (*bc_fn_t)(),
                       void * context);
 
     template <class T>

--- a/include/godzilla/DynamicLibrary.h
+++ b/include/godzilla/DynamicLibrary.h
@@ -119,7 +119,7 @@ public:
 
 private:
     /// Get extension file path
-    std::string get_ext_file_path() const;
+    [[nodiscard]] std::string get_ext_file_path() const;
 
     /// Extension file name
     std::string file_name;

--- a/include/godzilla/Exception.h
+++ b/include/godzilla/Exception.h
@@ -23,10 +23,10 @@ public:
     }
 
     /// Get the exception message
-    const char * what() const noexcept override;
+    [[nodiscard]] const char * what() const noexcept override;
 
     /// Get the call stack from the time the exception occured
-    const std::vector<std::string> & get_call_stack() const;
+    [[nodiscard]] const std::vector<std::string> & get_call_stack() const;
 
 private:
     /// Store call stack

--- a/include/godzilla/ExplicitDGLinearProblem.h
+++ b/include/godzilla/ExplicitDGLinearProblem.h
@@ -20,8 +20,8 @@ public:
     void create() override;
     bool converged() override;
     void solve() override;
-    Real get_time() const override;
-    Int get_step_num() const override;
+    [[nodiscard]] Real get_time() const override;
+    [[nodiscard]] Int get_step_num() const override;
     void compute_solution_vector_local() override;
 
 protected:

--- a/include/godzilla/ExplicitFELinearProblem.h
+++ b/include/godzilla/ExplicitFELinearProblem.h
@@ -15,8 +15,8 @@ public:
     explicit ExplicitFELinearProblem(const Parameters & params);
     ~ExplicitFELinearProblem() override;
 
-    Real get_time() const override;
-    Int get_step_num() const override;
+    [[nodiscard]] Real get_time() const override;
+    [[nodiscard]] Int get_step_num() const override;
     void create() override;
     bool converged() override;
     void solve() override;

--- a/include/godzilla/ExplicitFVLinearProblem.h
+++ b/include/godzilla/ExplicitFVLinearProblem.h
@@ -20,8 +20,8 @@ public:
     void create() override;
     bool converged() override;
     void solve() override;
-    Real get_time() const override;
-    Int get_step_num() const override;
+    [[nodiscard]] Real get_time() const override;
+    [[nodiscard]] Int get_step_num() const override;
     void compute_solution_vector_local() override;
 
 protected:

--- a/include/godzilla/ExplicitFVLinearProblem.h
+++ b/include/godzilla/ExplicitFVLinearProblem.h
@@ -15,7 +15,6 @@ class ExplicitFVLinearProblem :
     public ExplicitProblemInterface {
 public:
     explicit ExplicitFVLinearProblem(const Parameters & params);
-    ~ExplicitFVLinearProblem() override;
 
     void create() override;
     bool converged() override;

--- a/include/godzilla/ExplicitProblemInterface.h
+++ b/include/godzilla/ExplicitProblemInterface.h
@@ -15,7 +15,7 @@ namespace godzilla {
 class ExplicitProblemInterface : public TransientProblemInterface {
 public:
     explicit ExplicitProblemInterface(NonlinearProblem * problem, const Parameters & params);
-    ~ExplicitProblemInterface();
+    ~ExplicitProblemInterface() override;
 
     /// Get the name of time stepping scheme
     [[nodiscard]] std::string get_scheme() const;

--- a/include/godzilla/ExplicitProblemInterface.h
+++ b/include/godzilla/ExplicitProblemInterface.h
@@ -18,13 +18,13 @@ public:
     ~ExplicitProblemInterface();
 
     /// Get the name of time stepping scheme
-    std::string get_scheme() const;
+    [[nodiscard]] std::string get_scheme() const;
 
-    const Matrix & get_mass_matrix() const;
+    [[nodiscard]] const Matrix & get_mass_matrix() const;
 
     Matrix & get_mass_matrix();
 
-    const Vector & get_lumped_mass_matrix() const;
+    [[nodiscard]] const Vector & get_lumped_mass_matrix() const;
 
     Vector & get_lumped_mass_matrix();
 

--- a/include/godzilla/Extension.h
+++ b/include/godzilla/Extension.h
@@ -20,7 +20,7 @@ public:
     /// Get extension name
     ///
     /// @return Extension name
-    const std::string & get_name() const;
+    [[nodiscard]] const std::string & get_name() const;
 
 private:
     /// Extension name

--- a/include/godzilla/FEBoundary.h
+++ b/include/godzilla/FEBoundary.h
@@ -45,7 +45,7 @@ public:
         this->facets.sort();
     }
 
-    UnstructuredMesh *
+    [[nodiscard]] UnstructuredMesh *
     get_mesh() const
     {
         return this->mesh;

--- a/include/godzilla/FENonlinearProblem.h
+++ b/include/godzilla/FENonlinearProblem.h
@@ -20,7 +20,7 @@ public:
     explicit FENonlinearProblem(const Parameters & parameters);
 
     void create() override;
-    Real get_time() const override;
+    [[nodiscard]] Real get_time() const override;
     void compute_solution_vector_local() override;
 
 protected:

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -33,29 +33,29 @@ public:
     FEProblemInterface(Problem * problem, const Parameters & params);
     ~FEProblemInterface() override;
 
-    Int get_num_fields() const override;
-    std::vector<std::string> get_field_names() const override;
-    const std::string & get_field_name(Int fid) const override;
-    Int get_field_num_components(Int fid) const override;
-    Int get_field_id(const std::string & name) const override;
-    bool has_field_by_id(Int fid) const override;
-    bool has_field_by_name(const std::string & name) const override;
-    Int get_field_order(Int fid) const override;
-    std::string get_field_component_name(Int fid, Int component) const override;
+    [[nodiscard]] Int get_num_fields() const override;
+    [[nodiscard]] std::vector<std::string> get_field_names() const override;
+    [[nodiscard]] const std::string & get_field_name(Int fid) const override;
+    [[nodiscard]] Int get_field_num_components(Int fid) const override;
+    [[nodiscard]] Int get_field_id(const std::string & name) const override;
+    [[nodiscard]] bool has_field_by_id(Int fid) const override;
+    [[nodiscard]] bool has_field_by_name(const std::string & name) const override;
+    [[nodiscard]] Int get_field_order(Int fid) const override;
+    [[nodiscard]] std::string get_field_component_name(Int fid, Int component) const override;
     void set_field_component_name(Int fid, Int component, const std::string & name) override;
 
-    Int get_num_aux_fields() const override;
-    std::vector<std::string> get_aux_field_names() const override;
-    const std::string & get_aux_field_name(Int fid) const override;
-    Int get_aux_field_num_components(Int fid) const override;
-    Int get_aux_field_id(const std::string & name) const override;
-    bool has_aux_field_by_id(Int fid) const override;
-    bool has_aux_field_by_name(const std::string & name) const override;
-    Int get_aux_field_order(Int fid) const override;
-    std::string get_aux_field_component_name(Int fid, Int component) const override;
+    [[nodiscard]] Int get_num_aux_fields() const override;
+    [[nodiscard]] std::vector<std::string> get_aux_field_names() const override;
+    [[nodiscard]] const std::string & get_aux_field_name(Int fid) const override;
+    [[nodiscard]] Int get_aux_field_num_components(Int fid) const override;
+    [[nodiscard]] Int get_aux_field_id(const std::string & name) const override;
+    [[nodiscard]] bool has_aux_field_by_id(Int fid) const override;
+    [[nodiscard]] bool has_aux_field_by_name(const std::string & name) const override;
+    [[nodiscard]] Int get_aux_field_order(Int fid) const override;
+    [[nodiscard]] std::string get_aux_field_component_name(Int fid, Int component) const override;
     void set_aux_field_component_name(Int fid, Int component, const std::string & name) override;
 
-    virtual WeakForm * get_weak_form() const;
+    [[nodiscard]] virtual WeakForm * get_weak_form() const;
 
     /// Adds a volumetric field
     ///
@@ -94,21 +94,21 @@ public:
     void
     set_aux_field(Int id, const std::string & name, Int nc, Int k, const Label & block = Label());
 
-    const Int & get_spatial_dimension() const;
+    [[nodiscard]] const Int & get_spatial_dimension() const;
 
-    const FieldValue & get_field_value(const std::string & field_name) const;
+    [[nodiscard]] const FieldValue & get_field_value(const std::string & field_name) const;
 
-    const FieldGradient & get_field_gradient(const std::string & field_name) const;
+    [[nodiscard]] const FieldGradient & get_field_gradient(const std::string & field_name) const;
 
-    const FieldValue & get_field_dot(const std::string & field_name) const;
+    [[nodiscard]] const FieldValue & get_field_dot(const std::string & field_name) const;
 
-    const Real & get_time_shift() const;
+    [[nodiscard]] const Real & get_time_shift() const;
 
-    const Real & get_assembly_time() const;
+    [[nodiscard]] const Real & get_assembly_time() const;
 
-    const Normal & get_normal() const;
+    [[nodiscard]] const Normal & get_normal() const;
 
-    const Point & get_xyz() const;
+    [[nodiscard]] const Point & get_xyz() const;
 
     /// Add residual statement for a field variable
     ///
@@ -250,7 +250,7 @@ public:
                                      Scalar elem_mat[]);
 
 protected:
-    const std::map<Int, FieldInfo> & get_fields() const;
+    [[nodiscard]] const std::map<Int, FieldInfo> & get_fields() const;
 
     void create() override;
     void init() override;

--- a/include/godzilla/FVProblemInterface.h
+++ b/include/godzilla/FVProblemInterface.h
@@ -23,24 +23,24 @@ public:
 
     [[nodiscard]] Int get_num_fields() const override;
     [[nodiscard]] std::vector<std::string> get_field_names() const override;
-    const std::string & get_field_name(Int fid) const override;
-    Int get_field_num_components(Int fid) const override;
+    [[nodiscard]] const std::string & get_field_name(Int fid) const override;
+    [[nodiscard]] Int get_field_num_components(Int fid) const override;
     [[nodiscard]] Int get_field_id(const std::string & name) const override;
     [[nodiscard]] bool has_field_by_id(Int fid) const override;
     [[nodiscard]] bool has_field_by_name(const std::string & name) const override;
-    Int get_field_order(Int fid) const override;
-    std::string get_field_component_name(Int fid, Int component) const override;
+    [[nodiscard]] Int get_field_order(Int fid) const override;
+    [[nodiscard]] std::string get_field_component_name(Int fid, Int component) const override;
     void set_field_component_name(Int fid, Int component, const std::string & name) override;
 
-    Int get_num_aux_fields() const override;
-    std::vector<std::string> get_aux_field_names() const override;
-    const std::string & get_aux_field_name(Int fid) const override;
-    Int get_aux_field_num_components(Int fid) const override;
-    Int get_aux_field_id(const std::string & name) const override;
-    bool has_aux_field_by_id(Int fid) const override;
-    bool has_aux_field_by_name(const std::string & name) const override;
-    Int get_aux_field_order(Int fid) const override;
-    std::string get_aux_field_component_name(Int fid, Int component) const override;
+    [[nodiscard]] Int get_num_aux_fields() const override;
+    [[nodiscard]] std::vector<std::string> get_aux_field_names() const override;
+    [[nodiscard]] const std::string & get_aux_field_name(Int fid) const override;
+    [[nodiscard]] Int get_aux_field_num_components(Int fid) const override;
+    [[nodiscard]] Int get_aux_field_id(const std::string & name) const override;
+    [[nodiscard]] bool has_aux_field_by_id(Int fid) const override;
+    [[nodiscard]] bool has_aux_field_by_name(const std::string & name) const override;
+    [[nodiscard]] Int get_aux_field_order(Int fid) const override;
+    [[nodiscard]] std::string get_aux_field_component_name(Int fid, Int component) const override;
     void set_aux_field_component_name(Int fid, Int component, const std::string & name) override;
 
     /// Adds a volumetric field

--- a/include/godzilla/FVProblemInterface.h
+++ b/include/godzilla/FVProblemInterface.h
@@ -133,15 +133,7 @@ private:
         {
         }
 
-        FieldInfo(const FieldInfo & other) :
-            name(other.name),
-            id(other.id),
-            block(other.block),
-            nc(other.nc),
-            k(other.k),
-            component_names(other.component_names)
-        {
-        }
+        FieldInfo(const FieldInfo & other) = default;
     };
 
     /// Fields in the problem

--- a/include/godzilla/Factory.h
+++ b/include/godzilla/Factory.h
@@ -67,7 +67,7 @@ public:
     ///
     /// @param class_name Class name to check
     /// @return `true` if class name is known, `false` otherwise
-    bool
+    [[nodiscard]] bool
     is_registered(const std::string & class_name) const
     {
         return this->registry.exists(class_name);

--- a/include/godzilla/FieldValue.h
+++ b/include/godzilla/FieldValue.h
@@ -23,7 +23,7 @@ public:
         this->data = new_data;
     }
 
-    T *
+    [[nodiscard]] T *
     get() const
     {
         return this->data;

--- a/include/godzilla/FileMesh.h
+++ b/include/godzilla/FileMesh.h
@@ -25,7 +25,7 @@ public:
     /// Get mesh file format
     ///
     /// @return Mesh file format
-    FileFormat get_file_format() const;
+    [[nodiscard]] FileFormat get_file_format() const;
 
 protected:
     void set_file_format(FileFormat fmt);

--- a/include/godzilla/FileOutput.h
+++ b/include/godzilla/FileOutput.h
@@ -19,7 +19,7 @@ public:
     /// Get the file name with the output file produced by this outputter
     ///
     /// @return The file name with the output
-    std::string get_file_name() const;
+    [[nodiscard]] std::string get_file_name() const;
 
     /// Set file base
     ///

--- a/include/godzilla/Function.h
+++ b/include/godzilla/Function.h
@@ -25,7 +25,7 @@ public:
     /// Get problem spatial dimension
     ///
     /// @return Spatial dimension
-    Int get_dimension() const;
+    [[nodiscard]] Int get_dimension() const;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/Functional.h
+++ b/include/godzilla/Functional.h
@@ -21,14 +21,14 @@ public:
     /// Get value names this functional depends on
     ///
     /// @return List of value names this functional depends on
-    const std::set<std::string> & get_dependent_values() const;
+    [[nodiscard]] const std::set<std::string> & get_dependent_values() const;
 
     /// Get region where this function is defined
     ///
     /// @return Region name where this functional is defined
-    const std::string & get_region() const;
+    [[nodiscard]] const std::string & get_region() const;
 
-    const std::string
+    [[nodiscard]] const std::string
     get_value_name(const std::string & val_name) const
     {
         return this->region.empty() ? val_name : val_name + "@" + this->region;
@@ -43,35 +43,35 @@ protected:
     /// Get spatial dimension
     ///
     /// @return Spatial dimension
-    const Int & get_spatial_dimension() const;
+    [[nodiscard]] const Int & get_spatial_dimension() const;
 
     /// Get physical coordinates
     ///
     /// @return Physical coordinates
-    const Point & get_xyz() const;
+    [[nodiscard]] const Point & get_xyz() const;
 
     /// Get values of a field
     ///
     /// @param field_name The name of the field
     /// @return Reference to a class that contains the field values
-    const FieldValue & get_field_value(const std::string & field_name) const;
+    [[nodiscard]] const FieldValue & get_field_value(const std::string & field_name) const;
 
     /// Get values of a gradient of a field
     ///
     /// @param field_name The name of the field
     /// @return Pointer to array that contains the field gradient values
-    const FieldGradient & get_field_gradient(const std::string & field_name) const;
+    [[nodiscard]] const FieldGradient & get_field_gradient(const std::string & field_name) const;
 
     /// Get values of a time derivative of a field
     ///
     /// @param field_name The name of the field
     /// @return Reference to a class that contains the field time derivative values
-    const FieldValue & get_field_dot(const std::string & field_name) const;
+    [[nodiscard]] const FieldValue & get_field_dot(const std::string & field_name) const;
 
     /// Get time at which the function is evaluated
     ///
     /// @return Time at which is the function evaluated
-    const Real & get_time() const;
+    [[nodiscard]] const Real & get_time() const;
 
     /// Get value specified by a name
     ///

--- a/include/godzilla/HashMap.h
+++ b/include/godzilla/HashMap.h
@@ -140,10 +140,10 @@ public:
     int resize(Int nb);
 
     /// Get the number of entries in a hash table
-    Int get_size() const;
+    [[nodiscard]] Int get_size() const;
 
     /// Get the current size of the array in the hash table
-    Int get_capacity() const;
+    [[nodiscard]] Int get_capacity() const;
 
     /// Query for a key in the hash table
     bool has(const KEY & key);
@@ -243,7 +243,7 @@ private:
         flag[i >> 4] |= 1U << ((i & 0xfU) << 1);
     }
 
-    inline khint_t
+    [[nodiscard]] inline khint_t
     fsize(khint_t m) const
     {
         return m < 16 ? 1 : m >> 4;
@@ -361,19 +361,19 @@ private:
         }
     }
 
-    inline khiter_t
+    [[nodiscard]] inline khiter_t
     kh_begin() const
     {
         return 0;
     }
 
-    inline khiter_t
+    [[nodiscard]] inline khiter_t
     kh_end() const
     {
         return this->n_buckets;
     }
 
-    inline bool
+    [[nodiscard]] inline bool
     kh_exist(khint_t x) const
     {
         return !iseither(this->flags, x);

--- a/include/godzilla/ImplicitFENonlinearProblem.h
+++ b/include/godzilla/ImplicitFENonlinearProblem.h
@@ -16,8 +16,8 @@ public:
     void create() override;
     bool converged() override;
     void solve() override;
-    Real get_time() const override;
-    Int get_step_num() const override;
+    [[nodiscard]] Real get_time() const override;
+    [[nodiscard]] Int get_step_num() const override;
     void compute_solution_vector_local() override;
 
 protected:
@@ -30,11 +30,11 @@ protected:
     ErrorCode compute_boundary(Real time, const Vector & X, const Vector & X_t);
     ErrorCode compute_ifunction(Real time, const Vector & X, const Vector & X_t, Vector & F);
     ErrorCode compute_ijacobian(Real time,
-                                     const Vector & X,
-                                     const Vector & X_t,
-                                     Real x_t_shift,
-                                     Matrix & J,
-                                     Matrix & Jp);
+                                const Vector & X,
+                                const Vector & X_t,
+                                Real x_t_shift,
+                                Matrix & J,
+                                Matrix & Jp);
 
 private:
     /// Time stepping scheme

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -19,7 +19,7 @@ public:
         using reference = Int &;
 
         explicit Iterator(IndexSet & is, Int idx);
-        ~Iterator();
+        ~Iterator() = default;
 
         const value_type & operator*() const;
 
@@ -42,7 +42,7 @@ public:
 
     IndexSet();
     explicit IndexSet(IS is);
-    ~IndexSet();
+    ~IndexSet() = default;
 
     void create(MPI_Comm comm);
     void destroy();

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -87,14 +87,14 @@ public:
     operator IS() const;
     operator IS *();
 
-    bool empty() const;
+    [[nodiscard]] bool empty() const;
 
-    PetscObjectId get_id() const;
+    [[nodiscard]] PetscObjectId get_id() const;
 
     /// Checks the indices to determine whether they have been sorted
     ///
     /// @return `true` is index set is sorted
-    bool sorted() const;
+    [[nodiscard]] bool sorted() const;
 
     /// Sort the indices of the index set
     void sort() const;

--- a/include/godzilla/InitialCondition.h
+++ b/include/godzilla/InitialCondition.h
@@ -23,12 +23,12 @@ public:
     /// Get problem spatial dimension
     ///
     /// @return Spatial dimension
-    Int get_dimension() const;
+    [[nodiscard]] Int get_dimension() const;
 
     /// Get field name
     ///
     /// @return The field name
-    virtual const std::string & get_field_name() const;
+    [[nodiscard]] virtual const std::string & get_field_name() const;
 
     /// Get the ID of the field this boundary condition operates on
     ///

--- a/include/godzilla/KrylovSolver.h
+++ b/include/godzilla/KrylovSolver.h
@@ -159,9 +159,9 @@ public:
     /// Gets the reason the KSP iteration was stopped
     ///
     /// @return
-    ConvergedReason get_converged_reason() const;
+    [[nodiscard]] ConvergedReason get_converged_reason() const;
 
-    PC get_pc() const;
+    [[nodiscard]] PC get_pc() const;
 
     /// typecast operator so we can use our class directly with PETSc API
     operator KSP() const;

--- a/include/godzilla/Label.h
+++ b/include/godzilla/Label.h
@@ -29,7 +29,7 @@ public:
     /// Test if the label is "null"
     ///
     /// @return `true` is the label is null, `false` otherwise
-    bool is_null() const;
+    [[nodiscard]] bool is_null() const;
 
     /// Set the default value returned by `get_value()` if a point has not been explicitly given a
     /// value. When a label is created, it is initialized to -1.
@@ -41,29 +41,29 @@ public:
     /// value. When a label is created, it is initialized to -1.
     ///
     /// @return The default value
-    Int get_default_value() const;
+    [[nodiscard]] Int get_default_value() const;
 
     /// Get the number of values that the label takes
     ///
     /// @return The number of values
-    Int get_num_values() const;
+    [[nodiscard]] Int get_num_values() const;
 
     /// Return the value a label assigns to a point
     ///
     /// @param point The point
     /// @return The value associated with the point. If value is not set, return the label’s default
     /// value
-    Int get_value(Int point) const;
+    [[nodiscard]] Int get_value(Int point) const;
 
     /// Get an IndexSet of all values that the Label takes
     ///
     /// @return IndexSet with all label values
-    IndexSet get_value_index_set() const;
+    [[nodiscard]] IndexSet get_value_index_set() const;
 
     /// Get all values that the `Label` takes
     ///
     /// @return `std::vector` with all label values
-    std::vector<Int> get_values() const;
+    [[nodiscard]] std::vector<Int> get_values() const;
 
     void set_value(Int point, Int value);
 
@@ -71,13 +71,13 @@ public:
     ///
     /// @param value The stratum value
     /// @return Size of the stratum
-    Int get_stratum_size(Int value) const;
+    [[nodiscard]] Int get_stratum_size(Int value) const;
 
     /// Get an IndexSet with the stratum points
     ///
     /// @param value The stratum value
     /// @return The stratum points
-    IndexSet get_stratum(Int value) const;
+    [[nodiscard]] IndexSet get_stratum(Int value) const;
 
     /// Set the stratum points using an IndexSet
     ///

--- a/include/godzilla/Logger.h
+++ b/include/godzilla/Logger.h
@@ -62,17 +62,17 @@ public:
     /// Get the number of logged errors/warnings
     ///
     /// @return Number of logger errors/warnings
-    std::size_t get_num_entries() const;
+    [[nodiscard]] std::size_t get_num_entries() const;
 
     /// Get the number of errors
     ///
     /// @return Number of errors
-    std::size_t get_num_errors() const;
+    [[nodiscard]] std::size_t get_num_errors() const;
 
     /// Get the number of warnings
     ///
     /// @return Number of warnings
-    std::size_t get_num_warnings() const;
+    [[nodiscard]] std::size_t get_num_warnings() const;
 
     /// Print logged errors and warnings
     void print() const;

--- a/include/godzilla/Matrix.h
+++ b/include/godzilla/Matrix.h
@@ -18,7 +18,7 @@ public:
     Matrix();
     Matrix(Mat mat);
 
-    std::string get_type() const;
+    [[nodiscard]] std::string get_type() const;
 
     void set_name(const std::string & name);
 
@@ -32,10 +32,10 @@ public:
     void assemble(MatAssemblyType type = MAT_FINAL_ASSEMBLY);
 
     void get_size(Int & m, Int & n) const;
-    Int get_n_rows() const;
-    Int get_n_cols() const;
+    [[nodiscard]] Int get_n_rows() const;
+    [[nodiscard]] Int get_n_cols() const;
 
-    Scalar get_value(Int row, Int col) const;
+    [[nodiscard]] Scalar get_value(Int row, Int col) const;
 
     void set_sizes(Int m, Int n, Int M = PETSC_DECIDE, Int N = PETSC_DECIDE);
 

--- a/include/godzilla/Mesh.h
+++ b/include/godzilla/Mesh.h
@@ -23,12 +23,12 @@ public:
     virtual ~Mesh();
 
     /// Get the MPI comm this object works on
-    mpi::Communicator get_comm() const;
+    [[nodiscard]] mpi::Communicator get_comm() const;
 
     /// Get the underlying DM object
     ///
     /// @return Underlying PETSc DM
-    DM get_dm() const;
+    [[nodiscard]] DM get_dm() const;
 
     /// Get the mesh spatial dimension
     ///
@@ -56,7 +56,7 @@ public:
     ///
     /// @param name Label name
     /// @return Created label
-    Label create_label(const std::string & name) const;
+    [[nodiscard]] Label create_label(const std::string & name) const;
 
     /// Remove label with given name
     ///
@@ -67,22 +67,22 @@ public:
     /// coordinates
     ///
     /// @return coordinate `DM`
-    DM get_coordinate_dm() const;
+    [[nodiscard]] DM get_coordinate_dm() const;
 
     /// Get a global vector with the coordinates associated with this mesh
     ///
     /// @return Global coordinate vector
-    Vector get_coordinates() const;
+    [[nodiscard]] Vector get_coordinates() const;
 
     /// Get a local vector with the coordinates associated with this mesh
     ///
     /// @return Coordinate vector
-    Vector get_coordinates_local() const;
+    [[nodiscard]] Vector get_coordinates_local() const;
 
     /// Retrieve the layout of coordinate values over the mesh.
     ///
     /// @return Local section from the coordinate `DM`
-    Section get_coordinate_section() const;
+    [[nodiscard]] Section get_coordinate_section() const;
 
     /// Set the dimension of the embedding space for coordinate values
     ///

--- a/include/godzilla/Mesh.h
+++ b/include/godzilla/Mesh.h
@@ -55,8 +55,7 @@ public:
     /// Create label
     ///
     /// @param name Label name
-    /// @return Created label
-    [[nodiscard]] Label create_label(const std::string & name) const;
+    void create_label(const std::string & name) const;
 
     /// Remove label with given name
     ///

--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -22,11 +22,11 @@ public:
     void run() override;
 
     /// Get underlying KSP
-    KrylovSolver get_ksp() const;
+    [[nodiscard]] KrylovSolver get_ksp() const;
     /// Set KSP operators
     void set_ksp_operators(const Matrix & A, const Matrix & B);
     /// Get Jacobian matrix
-    const Matrix & get_jacobian() const;
+    [[nodiscard]] const Matrix & get_jacobian() const;
     /// true if solve converged, otherwise false
     virtual bool converged();
 
@@ -38,7 +38,7 @@ public:
 
 protected:
     /// Get underlying non-linear solver
-    SNESolver get_snes() const;
+    [[nodiscard]] SNESolver get_snes() const;
     /// Set non-linear solver
     void set_snes(const SNESolver & snes);
     /// Set residual vector

--- a/include/godzilla/Object.h
+++ b/include/godzilla/Object.h
@@ -24,15 +24,15 @@ public:
 
     /// Get the type of this object.
     /// @return the name of the type of this object
-    const std::string & get_type() const;
+    [[nodiscard]] const std::string & get_type() const;
 
     /// Get the name of the object
     /// @return The name of the object
-    const std::string & get_name() const;
+    [[nodiscard]] const std::string & get_name() const;
 
     /// Get the parameters of the object
     /// @return The parameters of the object
-    const Parameters & get_parameters() const;
+    [[nodiscard]] const Parameters & get_parameters() const;
 
     /// Retrieve a parameter for the object
     /// @param par_name The name of the parameter
@@ -42,17 +42,17 @@ public:
 
     /// Test if the supplied parameter is valid
     /// @param par_name The name of the parameter to test
-    bool is_param_valid(const std::string & par_name) const;
+    [[nodiscard]] bool is_param_valid(const std::string & par_name) const;
 
     /// Get the App this object is associated with
 
-    App * get_app() const;
+    [[nodiscard]] App * get_app() const;
 
     /// Get the MPI comm this object works on
-    const mpi::Communicator & get_comm() const;
+    [[nodiscard]] const mpi::Communicator & get_comm() const;
 
     /// Get processor ID (aka MPI rank) this object is running at
-    int get_processor_id() const;
+    [[nodiscard]] int get_processor_id() const;
 
     /// Called to construct the object
     virtual void create();

--- a/include/godzilla/Output.h
+++ b/include/godzilla/Output.h
@@ -27,7 +27,7 @@ public:
     /// Get execution mask
     ///
     /// @return execution mask
-    ExecuteOn get_exec_mask() const;
+    [[nodiscard]] ExecuteOn get_exec_mask() const;
 
     /// Should output happen at a specified occasion
     ///
@@ -42,7 +42,7 @@ protected:
     /// Get problem
     ///
     /// @return Problem this output is part of
-    Problem * get_problem() const;
+    [[nodiscard]] Problem * get_problem() const;
 
     /// Set up the execution mask
     void set_up_exec();

--- a/include/godzilla/PCComposite.h
+++ b/include/godzilla/PCComposite.h
@@ -33,7 +33,7 @@ public:
 
     /// Gets the type of composite preconditioner
     ///
-    Type get_type() const;
+    [[nodiscard]] Type get_type() const;
 
     /// Adds another PC to the composite PC.
     ///
@@ -43,13 +43,13 @@ public:
     /// Gets the number of PC objects in the composite PC
     ///
     /// @return The number of sub PCs
-    Int get_number_pc() const;
+    [[nodiscard]] Int get_number_pc() const;
 
     /// Gets one of the PC objects in the composite PC
     ///
     /// @param n The number of the PC requested
     /// @return The PC requested
-    Preconditioner get_pc(Int n) const;
+    [[nodiscard]] Preconditioner get_pc(Int n) const;
 
     /// Sets alpha for the special composite preconditioner
     void special_set_alpha(Scalar alpha);

--- a/include/godzilla/PCFactor.h
+++ b/include/godzilla/PCFactor.h
@@ -78,41 +78,41 @@ public:
     /// Get the precoditioner type
     ///
     /// @return Preconditioner type
-    Type get_type() const;
+    [[nodiscard]] Type get_type() const;
 
     /// Determines if all diagonal matrix entries are treated as level 0 fill even if there is no
     /// non-zero location
     ///
     /// @return `true` if all diagonal matrix entries are treated as level 0, `false` otherwise
-    bool get_allow_diagonal_fill() const;
+    [[nodiscard]] bool get_allow_diagonal_fill() const;
 
     /// Gets the number of levels of fill to use
     ///
     /// @return Number of levels of fill
-    Int get_levels() const;
+    [[nodiscard]] Int get_levels() const;
 
     /// Gets the solver package that is used to perform the factorization
     ///
     /// @return The solver package that is used to perform the factorization
-    MatSolverType get_mat_solver_type() const;
+    [[nodiscard]] MatSolverType get_mat_solver_type() const;
 
     /// Gets the tolerance used to define a zero pivot
     ///
     /// @return How much to shift the diagonal entry
-    Real get_shift_amount() const;
+    [[nodiscard]] Real get_shift_amount() const;
 
     /// Gets the type of shift, if any, done when a zero pivot is detected
-    MatShiftType get_shift_type() const;
+    [[nodiscard]] MatShiftType get_shift_type() const;
 
     /// Determines if an in-place factorization is being used
     ///
     /// @return `true` if an in-place factorization is being used, `false` otherwise
-    bool get_use_in_place() const;
+    [[nodiscard]] bool get_use_in_place() const;
 
     /// Gets the tolerance used to define a zero pivot
     ///
     /// @return The tolerance that defines a zero pivot
-    Real get_zero_pivot() const;
+    [[nodiscard]] Real get_zero_pivot() const;
 
     /// Reorders rows/columns of matrix to remove zeros from diagonal
     ///

--- a/include/godzilla/PCFieldSplit.h
+++ b/include/godzilla/PCFieldSplit.h
@@ -72,57 +72,57 @@ public:
     /// Gets the type of the field split preconditioner
     ///
     /// @return Type of the preconditioner
-    Type get_type() const;
+    [[nodiscard]] Type get_type() const;
 
     /// Returns flag indicating whether `DMCreateFieldDecomposition()` should be used to define the
     /// splits, whenever possible.
-    bool get_dm_splits() const;
+    [[nodiscard]] bool get_dm_splits() const;
 
     /// Returns flag indicating whether this preconditioner will attempt to automatically determine
     /// fields based on zero diagonal entries.
-    bool get_detect_saddle_point() const;
+    [[nodiscard]] bool get_detect_saddle_point() const;
 
     /// Get the flag indicating whether to extract diagonal blocks from `Amat` (rather than `Pmat`)
     /// to build the sub-matrices associated with each split. Where
     /// `KSPSetOperators(ksp, Amat, Pmat)` was used to supply the operators.
-    bool get_diag_use_amat() const;
+    [[nodiscard]] bool get_diag_use_amat() const;
 
     /// Retrieves the elements for a split as an IndexSet
     ///
     /// @param split_name Name of the split
     /// @return The `IndexSet` that defines the elements in this split
-    IndexSet get_is(const std::string & split_name) const;
+    [[nodiscard]] IndexSet get_is(const std::string & split_name) const;
 
     /// Retrieves the elements for a given split as an IS
     ///
     /// @param index Index of the split
     /// @return The index set that defines the elements in this split
-    IndexSet get_is_by_index(Int index) const;
+    [[nodiscard]] IndexSet get_is_by_index(Int index) const;
 
     /// Get the flag indicating whether to extract off-diagonal blocks from `Amat` (rather than
     /// `Pmat`) to build the sub-matrices associated with each split. Where
     /// `KSPSetOperators(ksp, Amat, Pmat)` was used to supply the operators.
-    bool get_off_diag_use_amat() const;
+    [[nodiscard]] bool get_off_diag_use_amat() const;
 
     /// Gets all matrix blocks for the Schur complement
-    SchurBlocks get_schur_blocks() const;
+    [[nodiscard]] SchurBlocks get_schur_blocks() const;
 
     /// For Schur complement fieldsplit, determine how the Schur complement will be preconditioned.
-    SchurPC get_schur_pre() const;
+    [[nodiscard]] SchurPC get_schur_pre() const;
 
     /// Gets the `KrylovSolver`s for all splits
-    std::vector<KrylovSolver> get_sub_ksp() const;
+    [[nodiscard]] std::vector<KrylovSolver> get_sub_ksp() const;
 
     /// Extract the MATSCHURCOMPLEMENT object used by this PCFIELDSPLIT in case it needs to be
     /// configured separately
     ///
     /// @return The Schur complement matrix
-    Matrix schur_get_s() const;
+    [[nodiscard]] Matrix schur_get_s() const;
 
     /// Gets the KSP contexts used inside the Schur complement based PCFIELDSPLIT
     ///
     /// @return The array of `KrylovSolver`s
-    std::vector<KrylovSolver> schur_get_sub_ksp() const;
+    [[nodiscard]] std::vector<KrylovSolver> schur_get_sub_ksp() const;
 
     /// Restore the `MATSCHURCOMPLEMENT` matrix used by this preconditioner
     ///

--- a/include/godzilla/PCHypre.h
+++ b/include/godzilla/PCHypre.h
@@ -29,7 +29,7 @@ public:
     /// Gets which HYPRE preconditioner is used
     ///
     /// @return HYPRE preconditioner type
-    Type get_type() const;
+    [[nodiscard]] Type get_type() const;
 
     /// Set the list of interior nodes to a zero-conductivity region for PCHYPRE of type `AMS`
     ///

--- a/include/godzilla/PCJacobi.h
+++ b/include/godzilla/PCJacobi.h
@@ -32,18 +32,18 @@ public:
     /// Gets how the diagonal matrix is produced for the preconditioner
     ///
     /// @return How the diagonal matrix is produced
-    Type get_type() const;
+    [[nodiscard]] Type get_type() const;
 
     /// Determines if the preconditioner checks for zero diagonal terms
     ///
     /// @return `true` if check is on, `false` otherwise
-    bool get_fix_diagonal() const;
+    [[nodiscard]] bool get_fix_diagonal() const;
 
     /// Determines if the preconditioner uses the absolute values of the diagonal divisors in
     /// the preconditioner
     ///
     /// @return `true` if checking is on, `false` otherwise
-    bool get_use_abs() const;
+    [[nodiscard]] bool get_use_abs() const;
 
     /// Check for zero values on the diagonal and replace them with 1.0
     ///

--- a/include/godzilla/Parameters.h
+++ b/include/godzilla/Parameters.h
@@ -26,10 +26,10 @@ protected:
         virtual ~Value() = default;
 
         /// Return the type of this value as a string
-        virtual std::string type() const = 0;
+        [[nodiscard]] virtual std::string type() const = 0;
 
         /// Create a copy of this value
-        virtual Value * copy() const = 0;
+        [[nodiscard]] virtual Value * copy() const = 0;
 
         /// Is required
         bool required;
@@ -61,13 +61,13 @@ protected:
             return this->value;
         }
 
-        inline std::string
+        [[nodiscard]] inline std::string
         type() const override
         {
             return std::string(typeid(T).name());
         }
 
-        Value *
+        [[nodiscard]] Value *
         copy() const override
         {
             auto * copy = new Parameter<T>;
@@ -87,7 +87,7 @@ protected:
 public:
     /// Check if parameter exist
     template <typename T>
-    bool
+    [[nodiscard]] bool
     has(const std::string & name) const
     {
         auto it = this->params.find(name);
@@ -150,7 +150,7 @@ public:
     ///@}
 
     /// Returns a boolean indicating whether the specified parameter is required or not
-    bool
+    [[nodiscard]] bool
     is_param_required(const std::string & name) const
     {
         return this->params.count(name) > 0 && this->params.at(name)->required;
@@ -159,27 +159,27 @@ public:
     /// This method returns parameters that have been initialized in one fashion or another,
     /// i.e. The value was supplied as a default argument or read and properly converted from
     /// the input file
-    bool
+    [[nodiscard]] bool
     is_param_valid(const std::string & name) const
     {
         return this->params.count(name) > 0 && this->params.at(name)->valid;
     }
 
-    bool
+    [[nodiscard]] bool
     is_private(const std::string & name) const
     {
         return this->params.count(name) > 0 && this->params.at(name)->is_private;
     }
 
     ///
-    std::string
+    [[nodiscard]] std::string
     type(const std::string & name) const
     {
         return this->params.at(name)->type();
     }
 
     ///
-    std::string
+    [[nodiscard]] std::string
     get_doc_string(const std::string & name) const
     {
         auto it = this->params.find(name);
@@ -203,7 +203,7 @@ public:
     }
 
     /// Iterator pointing to the beginning of the set of parameters.
-    Parameters::const_iterator
+    [[nodiscard]] Parameters::const_iterator
     begin() const
     {
         return this->params.begin();
@@ -217,7 +217,7 @@ public:
     }
 
     /// Iterator pointing to the end of the set of parameters
-    Parameters::const_iterator
+    [[nodiscard]] Parameters::const_iterator
     end() const
     {
         return this->params.end();

--- a/include/godzilla/Partitioner.h
+++ b/include/godzilla/Partitioner.h
@@ -20,7 +20,7 @@ public:
     void destroy();
 
     void set_type(const std::string & type);
-    std::string get_type() const;
+    [[nodiscard]] std::string get_type() const;
 
     void reset();
     void set_up();

--- a/include/godzilla/Postprocessor.h
+++ b/include/godzilla/Postprocessor.h
@@ -30,7 +30,7 @@ public:
     /// Get problem this post-processor is part of
     ///
     /// @return Problem this postprocessor is part of
-    Problem * get_problem() const;
+    [[nodiscard]] Problem * get_problem() const;
 
 private:
     /// Problem this object is part of

--- a/include/godzilla/Preconditioner.h
+++ b/include/godzilla/Preconditioner.h
@@ -31,7 +31,7 @@ public:
     /// Gets the preconditioner type (as a string)
     ///
     /// @return name of preconditioner method
-    std::string get_type() const;
+    [[nodiscard]] std::string get_type() const;
 
     /// Resets the preconditioner and removes any allocated Vectors and Matrices
     void reset();

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -40,7 +40,7 @@ public:
     };
 
     explicit Problem(const Parameters & parameters);
-    virtual ~Problem();
+    ~Problem() override;
 
     /// Build the problem to solve
     void create() override;

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -34,7 +34,7 @@ public:
 
         FieldDecomposition(Int n = 0);
 
-        Int get_num_fields() const;
+        [[nodiscard]] Int get_num_fields() const;
 
         void destroy();
     };
@@ -47,29 +47,29 @@ public:
     /// Run the problem
     virtual void run() = 0;
     /// Provide DM for this problem
-    DM get_dm() const;
+    [[nodiscard]] DM get_dm() const;
     /// Return solution vector
-    const Vector & get_solution_vector() const;
+    [[nodiscard]] const Vector & get_solution_vector() const;
     Vector & get_solution_vector();
     /// Get mesh this problem is using
-    virtual Mesh * get_mesh() const;
+    [[nodiscard]] virtual Mesh * get_mesh() const;
     /// Get problem spatial dimension
-    virtual Int get_dimension() const;
+    [[nodiscard]] virtual Int get_dimension() const;
 
     /// Get simulation time. For steady-state simulations, time is always 0
     ///
     /// @return Simulation time
-    virtual Real get_time() const;
+    [[nodiscard]] virtual Real get_time() const;
 
     /// Get time step number
     ///
     /// @return Time step number
-    virtual Int get_step_num() const;
+    [[nodiscard]] virtual Int get_step_num() const;
 
     /// Get list of functions
     ///
     /// @return List of functions
-    const std::vector<Function *> & get_functions() const;
+    [[nodiscard]] const std::vector<Function *> & get_functions() const;
 
     /// Add a function object
     ///
@@ -90,12 +90,12 @@ public:
     ///
     /// @param name The name of the postprocessor
     /// @return Pointer to the postprocessor with name 'name' if it exists, otherwise `nullptr`
-    virtual Postprocessor * get_postprocessor(const std::string & name) const;
+    [[nodiscard]] virtual Postprocessor * get_postprocessor(const std::string & name) const;
 
     /// Get postprocessor names
     ///
     /// @return List of postprocessor names
-    virtual const std::vector<std::string> & get_postprocessor_names() const;
+    [[nodiscard]] virtual const std::vector<std::string> & get_postprocessor_names() const;
 
     /// Compute all postprocessors
     virtual void compute_postprocessors();
@@ -108,7 +108,7 @@ public:
     /// Gets the type of vector created with `create_local_vector` and `create_global_vector`
     ///
     /// @return The vector type
-    std::string get_vector_type() const;
+    [[nodiscard]] std::string get_vector_type() const;
 
     /// Sets the type of vector to be created with `create_local_vector` and `create_global_vector`
     ///
@@ -118,13 +118,13 @@ public:
     /// Creates a local vector from a DM object
     ///
     /// @return New local vector
-    Vector create_local_vector() const;
+    [[nodiscard]] Vector create_local_vector() const;
 
     /// Get a vector that may be used with the DM local routines. This vector has spaces for the
     /// ghost values.
     ///
     /// @return Local vector
-    Vector get_local_vector() const;
+    [[nodiscard]] Vector get_local_vector() const;
 
     void restore_local_vector(const Vector & vec) const;
 
@@ -132,19 +132,19 @@ public:
     /// duplicate values shared between MPI ranks, that is it has no ghost locations.
     ///
     /// @return New global vector
-    Vector create_global_vector() const;
+    [[nodiscard]] Vector create_global_vector() const;
 
     /// Get a vector that may be used with the DM global routines
     ///
     /// @return Global vector
-    Vector get_global_vector() const;
+    [[nodiscard]] Vector get_global_vector() const;
 
     void restore_global_vector(const Vector & vec) const;
 
     /// Gets the type of matrix that would be created with `create_matrix`
     ///
     /// @return The matrix type
-    std::string get_matrix_type() const;
+    [[nodiscard]] std::string get_matrix_type() const;
 
     /// Sets the type of matrix created with `create_matrix`
     ///
@@ -152,16 +152,16 @@ public:
     void set_matrix_type(const std::string & type);
 
     /// Get an empty matrix for a `DM`
-    Matrix create_matrix() const;
+    [[nodiscard]] Matrix create_matrix() const;
 
     /// Get the Section encoding the local data layout for the DM
-    Section get_local_section() const;
+    [[nodiscard]] Section get_local_section() const;
 
     /// Set the `Section` encoding the local data layout for the `DM`.
     void set_local_section(const Section & section) const;
 
     /// Get the Section encoding the global data layout for the DM
-    Section get_global_section() const;
+    [[nodiscard]] Section get_global_section() const;
 
     /// Set the `Section` encoding the global data layout for the `DM`.
     void set_global_section(const Section & section) const;
@@ -195,7 +195,7 @@ public:
     /// Get the number of auxiliary vectors
     ///
     /// @return The number of auxiliary data vectors
-    Int get_num_auxiliary_vec() const;
+    [[nodiscard]] Int get_num_auxiliary_vec() const;
 
     /// Get the auxiliary vector for region specified by the given label, value, and equation part
     ///
@@ -203,7 +203,7 @@ public:
     /// @param value The label value indicating the region
     /// @param part The equation part, or 0 if unused
     /// @return The `Vector` holding auxiliary field data
-    Vector get_auxiliary_vec(const Label & label, Int value, Int part = 0) const;
+    [[nodiscard]] Vector get_auxiliary_vec(const Label & label, Int value, Int part = 0) const;
 
     /// Set an auxiliary vector for region specified by the given label, value, and equation part
     ///

--- a/include/godzilla/Quadrature.h
+++ b/include/godzilla/Quadrature.h
@@ -27,24 +27,24 @@ public:
     /// Get the spatial dimension
     ///
     /// @return The spatial dimension
-    Int get_dim() const;
+    [[nodiscard]] Int get_dim() const;
 
     /// Get number of components
     ///
     /// @return the number of components
-    Int get_num_components() const;
+    [[nodiscard]] Int get_num_components() const;
 
     /// Get order
     ///
     /// @return The order of the quadrature, i.e. the highest degree polynomial that is exactly
     /// integrated
-    Int get_order() const;
+    [[nodiscard]] Int get_order() const;
 
     /// Determine whether two quadratures are equivalent
     ///
     /// @param q Quadrature to compare to
     /// @return `true` if quadratures are the same, `false` otherwise
-    bool equal(const Quadrature & q) const;
+    [[nodiscard]] bool equal(const Quadrature & q) const;
 
     explicit operator PetscQuadrature() const;
 

--- a/include/godzilla/Random.h
+++ b/include/godzilla/Random.h
@@ -17,10 +17,10 @@ public:
     void destroy();
 
     void get_interval(Scalar & low, Scalar & high) const;
-    unsigned long get_seed() const;
-    std::string get_type() const;
-    Scalar get_value() const;
-    Real get_value_real() const;
+    [[nodiscard]] unsigned long get_seed() const;
+    [[nodiscard]] std::string get_type() const;
+    [[nodiscard]] Scalar get_value() const;
+    [[nodiscard]] Real get_value_real() const;
     void get_values(std::vector<Scalar> & vals) const;
     void get_values_real(std::vector<Real> & vals) const;
 

--- a/include/godzilla/Registry.h
+++ b/include/godzilla/Registry.h
@@ -58,13 +58,13 @@ public:
     ///
     /// @param class_name Class name to check
     /// @return `true` is class is registered, `false` otherwise
-    bool exists(const std::string & class_name) const;
+    [[nodiscard]] bool exists(const std::string & class_name) const;
 
     /// Find registry entry for a given class
     ///
     /// @param class_name Name of the class
     /// @return Registry entry
-    const Entry & get(const std::string & class_name) const;
+    [[nodiscard]] const Entry & get(const std::string & class_name) const;
 
 public:
     Registry() = default;

--- a/include/godzilla/SNESolver.h
+++ b/include/godzilla/SNESolver.h
@@ -67,9 +67,9 @@ public:
     /// Destroy the solver
     void destroy();
 
-    KrylovSolver get_ksp() const;
+    [[nodiscard]] KrylovSolver get_ksp() const;
 
-    LineSearch get_line_search() const;
+    [[nodiscard]] LineSearch get_line_search() const;
 
     void set_line_search(LineSearch ls);
 
@@ -202,7 +202,7 @@ public:
     /// Gets the reason the KSP iteration was stopped
     ///
     /// @return
-    ConvergedReason get_converged_reason() const;
+    [[nodiscard]] ConvergedReason get_converged_reason() const;
 
     /// typecast operator so we can use our class directly with PETSc API
     operator SNES() const;

--- a/include/godzilla/SNESolver.h
+++ b/include/godzilla/SNESolver.h
@@ -56,7 +56,7 @@ public:
 
     /// Construct empty non-linear solver
     SNESolver();
-    ~SNESolver();
+    ~SNESolver() = default;
 
     /// Construct a non-linear solver from a PETSc SNES object
     explicit SNESolver(SNES snes);

--- a/include/godzilla/Section.h
+++ b/include/godzilla/Section.h
@@ -55,12 +55,12 @@ public:
     /// Returns the flag for dof ordering
     ///
     /// @return `true` if it is point major, `false` if it is field major
-    bool get_point_major() const;
+    [[nodiscard]] bool get_point_major() const;
 
     /// Return the maximum number of degrees of freedom on any point in the Section
     ///
     /// @return The maximum dof
-    Int get_max_dof() const;
+    [[nodiscard]] Int get_max_dof() const;
 
     /// Sets the number of fields in the Section
     ///
@@ -70,7 +70,7 @@ public:
     /// Returns the number of fields in Section
     ///
     /// @return The number of fields defined, or 0 if none were defined
-    Int get_num_fields() const;
+    [[nodiscard]] Int get_num_fields() const;
 
     /// Adds to the total number of degrees of freedom associated with a given point
     ///
@@ -88,13 +88,13 @@ public:
     ///
     /// @param point The point
     /// @return The number of dof
-    Int get_dof(Int point) const;
+    [[nodiscard]] Int get_dof(Int point) const;
 
     /// Get the Section associated with a single field
     ///
     /// @param field The field number
     /// @return The `Section` for the given field, note the chart of the section is not set
-    Section get_field(Int field) const;
+    [[nodiscard]] Section get_field(Int field) const;
 
     /// Sets the number of field components for the given field
     ///
@@ -106,7 +106,7 @@ public:
     ///
     /// @param field The field number
     /// @return The number of field components
-    Int get_num_field_components(Int field) const;
+    [[nodiscard]] Int get_num_field_components(Int field) const;
 
     /// Increment the number of constrained degrees of freedom associated with a given field on a
     /// point
@@ -128,7 +128,7 @@ public:
     /// @param point The point
     /// @param field The field
     /// @return The number of dof which are fixed by constraints
-    Int get_field_constraint_dof(Int point, Int field) const;
+    [[nodiscard]] Int get_field_constraint_dof(Int point, Int field) const;
 
     /// Adds a number of degrees of freedom associated with a field on a given point
     ///
@@ -149,7 +149,7 @@ public:
     /// @param point The point
     /// @param field The field
     /// @return The number of dof
-    Int get_field_dof(Int point, Int field) const;
+    [[nodiscard]] Int get_field_dof(Int point, Int field) const;
 
     /// Sets the name of a field in the Section
     ///
@@ -161,13 +161,13 @@ public:
     ///
     /// @param field The field number
     /// @return The field name
-    std::string get_field_name(Int field) const;
+    [[nodiscard]] std::string get_field_name(Int field) const;
 
     /// Return the offset into an array or `Vector` for the dof associated with the given point
     ///
     /// @param point The point
     /// @return The offset
-    Int get_offset(Int point) const;
+    [[nodiscard]] Int get_offset(Int point) const;
 
     /// Return the full range of offsets [`start`, `end`) for the Section
     ///
@@ -181,7 +181,7 @@ public:
     /// @param point The point
     /// @param field The field
     /// @return The offset
-    Int get_field_offset(Int point, Int field) const;
+    [[nodiscard]] Int get_field_offset(Int point, Int field) const;
 
     /// Return the offset for the first field dof associated with the given point relative to the
     /// offset for that point for the unnamed default field’s first dof
@@ -189,18 +189,18 @@ public:
     /// @param point The point
     /// @param field The field
     /// @return The offset
-    Int get_field_point_offset(Int point, Int field) const;
+    [[nodiscard]] Int get_field_point_offset(Int point, Int field) const;
 
     /// Return the size of an array or local Vector capable of holding all the degrees of freedom
     /// defined in a Section
     ///
     /// @return The size of an array which can hold all the dofs
-    Int get_storage_size() const;
+    [[nodiscard]] Int get_storage_size() const;
 
     /// Determine whether the Section has constrained dofs
     ///
     /// @return `true` if the section has constrained dofs, `false` otherwise
-    bool has_constraints() const;
+    [[nodiscard]] bool has_constraints() const;
 
     /// Sets the name of a field component in the Section
     ///
@@ -214,7 +214,7 @@ public:
     /// @param field The field number
     /// @param comp The component number
     /// @return The component name
-    std::string get_component_name(Int field, Int comp) const;
+    [[nodiscard]] std::string get_component_name(Int field, Int comp) const;
 
     /// Increment the number of constrained degrees of freedom associated with a given point
     ///
@@ -232,7 +232,7 @@ public:
     ///
     /// @param point The point
     /// @return The number of dof which are fixed by constraints
-    Int get_constraint_dof(Int point) const;
+    [[nodiscard]] Int get_constraint_dof(Int point) const;
 
     /// Set the point dof numbers, in [0, dof), which are constrained
     ///
@@ -244,7 +244,7 @@ public:
     ///
     /// @param point The point
     /// @return The constrained dofs
-    const Int * get_constraint_indices(Int point) const;
+    [[nodiscard]] const Int * get_constraint_indices(Int point) const;
 
     /// Set the field dof numbers, in [0, fdof), which are constrained
     ///
@@ -258,7 +258,7 @@ public:
     /// @param point The point
     /// @param field The field number
     /// @return The constrained dofs sorted in ascending order
-    const Int * get_field_constraint_indices(Int point, Int field) const;
+    [[nodiscard]] const Int * get_field_constraint_indices(Int point, Int field) const;
 
     operator const PetscSection &() const { return this->section; }
 

--- a/include/godzilla/StarForest.h
+++ b/include/godzilla/StarForest.h
@@ -19,16 +19,16 @@ public:
         Graph();
         Graph(Int n_roots, Int n_leaves, const Int * leaves, const Node * remote_leaves);
 
-        Int get_num_roots() const;
+        [[nodiscard]] Int get_num_roots() const;
 
-        Int get_num_leaves() const;
+        [[nodiscard]] Int get_num_leaves() const;
 
-        const Int * get_leaves() const;
+        [[nodiscard]] const Int * get_leaves() const;
 
-        const Node * get_remote_leaves() const;
+        [[nodiscard]] const Node * get_remote_leaves() const;
 
         ///
-        Int find_leaf(Int point) const;
+        [[nodiscard]] Int find_leaf(Int point) const;
 
         /// Test if graph is empty
         operator bool() const;
@@ -56,7 +56,7 @@ public:
     void set_up();
 
     /// Get the graph specifying a parallel star forest
-    Graph get_graph() const;
+    [[nodiscard]] Graph get_graph() const;
 
     /// Set a parallel star forest
     void set_graph(Int n_roots,

--- a/include/godzilla/TSAbstract.h
+++ b/include/godzilla/TSAbstract.h
@@ -26,7 +26,7 @@ public:
     virtual void rollback() = 0;
     virtual void view(PetscViewer viewer) = 0;
 
-    const std::vector<Vector> & get_stage_vectors() const;
+    [[nodiscard]] const std::vector<Vector> & get_stage_vectors() const;
     std::vector<Vector> & get_stage_vectors();
 
     /// Runs the user-defined pre-stage function set using

--- a/include/godzilla/TimeStepAdapt.h
+++ b/include/godzilla/TimeStepAdapt.h
@@ -45,7 +45,7 @@ public:
     /// Get the list of candidate orders of accuracy and cost
     ///
     /// @return List of candidates
-    std::vector<Candidate> get_candidates() const;
+    [[nodiscard]] std::vector<Candidate> get_candidates() const;
 
     /// Checks whether to accept a stage, (e.g. reject and change time step size if nonlinear
     /// solve fails or solution vector is infeasible)
@@ -72,37 +72,37 @@ public:
     /// @return [low, high]
     /// - low: admissible decrease factor,
     /// - high: admissible increase factor
-    std::tuple<Real, Real> get_clip() const;
+    [[nodiscard]] std::tuple<Real, Real> get_clip() const;
 
     /// Get error estimation threshold. Solution components below this threshold value will not be
     /// considered when computing error norms for time step adaptivity (in absolute value).
     ///
     /// @return Threshold for solution components that are ignored during error estimation
-    Real get_max_ignore() const;
+    [[nodiscard]] Real get_max_ignore() const;
 
     /// Get safety factors for time step adapter
     ///
     /// @return [safety, reject_safety]
     /// - safety: safety factor relative to target error/stability goal
     /// - reject_safety: extra safety factor to apply if the last step was rejected
-    std::tuple<Real, Real> get_safety() const;
+    [[nodiscard]] std::tuple<Real, Real> get_safety() const;
 
     /// Gets the admissible decrease/increase factor in step size
     ///
     /// @return Scale factor
-    Real get_scale_solve_failed() const;
+    [[nodiscard]] Real get_scale_solve_failed() const;
 
     /// Get the minimum and maximum step sizes to be considered by the time step controller
     ///
     /// @return [hmin, hmax]
     /// - hmin: minimum time step
     /// - hmax: maximum time step
-    std::tuple<Real, Real> get_step_limits() const;
+    [[nodiscard]] std::tuple<Real, Real> get_step_limits() const;
 
     /// Get the adapter method type (as a string)
     ///
     /// @return The name of adapter method
-    std::string get_type() const;
+    [[nodiscard]] std::string get_type() const;
 
     /// Reset the time stepper to its defaults
     void reset();

--- a/include/godzilla/TimeSteppingAdaptor.h
+++ b/include/godzilla/TimeSteppingAdaptor.h
@@ -50,7 +50,7 @@ protected:
     /// Get problem this time adaptor is part of
     ///
     /// @return Problem this time adaptor is part of
-    Problem * get_problem() const;
+    [[nodiscard]] Problem * get_problem() const;
 
 private:
     /// Problem this adaptor is part of

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -49,19 +49,19 @@ public:
     /// Get time stepping adaptor
     ///
     /// @return Time stepping adaptor
-    TimeSteppingAdaptor * get_time_stepping_adaptor() const;
+    [[nodiscard]] TimeSteppingAdaptor * get_time_stepping_adaptor() const;
 
     /// Get TS object
     ///
     /// @return PETSc TS object
-    TS get_ts() const;
+    [[nodiscard]] TS get_ts() const;
 
-    Vector get_solution() const;
+    [[nodiscard]] Vector get_solution() const;
 
     /// Get the current timestep size
     ///
     /// @return the current timestep size
-    Real get_time_step() const;
+    [[nodiscard]] Real get_time_step() const;
 
     /// Allows one to reset the timestep at any time, useful for simple pseudo-timestepping codes.
     ///
@@ -76,7 +76,7 @@ public:
     /// Gets the maximum (or final) time for time-stepping
     ///
     /// @return Final time to step to
-    Real get_max_time() const;
+    [[nodiscard]] Real get_max_time() const;
 
     /// Sets the reason for handling the convergence
     ///
@@ -88,7 +88,7 @@ public:
     /// NOTE: Can only be called after the call to solve() is complete.
     ///
     /// @return Converged reason
-    TSConvergedReason get_converged_reason() const;
+    [[nodiscard]] TSConvergedReason get_converged_reason() const;
 
     /// Set simulation time
     ///
@@ -123,11 +123,11 @@ public:
 
 protected:
     /// Get underlying non-linear solver
-    SNESolver get_snes() const;
+    [[nodiscard]] SNESolver get_snes() const;
     /// Get time
-    Real get_time() const;
+    [[nodiscard]] Real get_time() const;
     /// Get step number
-    Int get_step_number() const;
+    [[nodiscard]] Int get_step_number() const;
     /// Initialize
     void init();
     /// Create
@@ -143,7 +143,7 @@ protected:
     /// Check if problem converged
     ///
     /// @return `true` if solve converged, otherwise `false`
-    bool converged() const;
+    [[nodiscard]] bool converged() const;
     /// Solve
     void solve(Vector & x);
     /// Set time-stepping scheme

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -64,34 +64,34 @@ public:
         Int idx;
     };
 
-    Iterator vertex_begin() const;
-    Iterator vertex_end() const;
+    [[nodiscard]] Iterator vertex_begin() const;
+    [[nodiscard]] Iterator vertex_end() const;
 
-    Iterator face_begin() const;
-    Iterator face_end() const;
+    [[nodiscard]] Iterator face_begin() const;
+    [[nodiscard]] Iterator face_end() const;
 
-    Iterator cell_begin() const;
-    Iterator cell_end() const;
+    [[nodiscard]] Iterator cell_begin() const;
+    [[nodiscard]] Iterator cell_end() const;
 
     /// Contiguous range of indices
     struct Range {
         Range() : first_idx(-1), last_idx(-1) {}
         Range(Int first, Int last) : first_idx(first), last_idx(last) {}
 
-        Iterator
+        [[nodiscard]] Iterator
         begin() const
         {
             return Iterator(this->first_idx);
         }
 
-        Iterator
+        [[nodiscard]] Iterator
         end() const
         {
             return Iterator(this->last_idx);
         }
 
         /// Get the number of indices in the range
-        Int
+        [[nodiscard]] Int
         size() const
         {
             return last_idx - first_idx;
@@ -100,7 +100,7 @@ public:
         /// Get the first index in the range
         ///
         /// @return First index in the range
-        Int
+        [[nodiscard]] Int
         first() const
         {
             return first_idx;
@@ -109,7 +109,7 @@ public:
         /// Get the last index (not included) in the range
         ///
         /// @return Last index (not included) in the range
-        Int
+        [[nodiscard]] Int
         last() const
         {
             return last_idx;
@@ -131,7 +131,7 @@ public:
     /// Get the `Label` recording the depth of each point
     ///
     /// @return The `Label` recording point depth
-    Label get_depth_label() const;
+    [[nodiscard]] Label get_depth_label() const;
 
     /// Return the number of mesh vertices
     [[nodiscard]] virtual Int get_num_vertices() const;
@@ -139,7 +139,7 @@ public:
     /// Get range of vertex indices
     ///
     /// @return Range of vertex indices
-    Range get_vertex_range() const;
+    [[nodiscard]] Range get_vertex_range() const;
 
     /// Return the number of mesh faces
     [[nodiscard]] virtual Int get_num_faces() const;
@@ -147,7 +147,7 @@ public:
     /// Get range of face indices
     ///
     /// @return Range of face indices
-    Range get_face_range() const;
+    [[nodiscard]] Range get_face_range() const;
 
     /// Return the number of mesh cells (interior)
     ///
@@ -162,22 +162,22 @@ public:
     /// Get range of cell indices (interior only)
     ///
     /// @return Range of cell indices
-    Range get_cell_range() const;
+    [[nodiscard]] Range get_cell_range() const;
 
     /// Get range of all cell indices (interior + ghosted)
     ///
     /// @param Range of all cell indices (interior + ghosted)
-    Range get_all_cell_range() const;
+    [[nodiscard]] Range get_all_cell_range() const;
 
     /// Get range of ghost cell indices
     ///
     /// @param Range of ghost cell indices
-    Range get_ghost_cell_range() const;
+    [[nodiscard]] Range get_ghost_cell_range() const;
 
     /// Get index set with all cells
     ///
     /// @return Index set with all cells
-    IndexSet get_all_cells() const;
+    [[nodiscard]] IndexSet get_all_cells() const;
 
     /// Return the interval for all mesh points [start, end)
     ///
@@ -188,7 +188,7 @@ public:
     /// Return the interval for all mesh points [start, end)
     ///
     /// @return Range of mesh points
-    Range get_chart() const;
+    [[nodiscard]] Range get_chart() const;
 
     /// Set the interval for all mesh points `[start, end)`
     ///
@@ -206,26 +206,26 @@ public:
     ///
     /// @param point Point with must lie in the chart
     /// @return Point connectivity
-    std::vector<Int> get_connectivity(Int point) const;
+    [[nodiscard]] std::vector<Int> get_connectivity(Int point) const;
 
     /// Return the points on the out-edges for this point
     ///
     /// @param point Point with must lie in the chart
     /// @return Points which are on the out-edges for point `p`
-    std::vector<Int> get_support(Int point) const;
+    [[nodiscard]] std::vector<Int> get_support(Int point) const;
 
     /// Return the points on the in-edges for this point
     ///
     /// @param point Point with must lie in the chart
     /// @return Points which are on the out-edges for point `p`
-    std::vector<Int> get_cone(Int point) const;
+    [[nodiscard]] std::vector<Int> get_cone(Int point) const;
 
     /// Expand each given point into its cone points and do that recursively until we end up just
     /// with vertices.
     ///
     /// @param points IndexSet of points with must lie in the chart
     /// @return Vertices recursively expanded from input points
-    IndexSet get_cone_recursive_vertices(IndexSet points) const;
+    [[nodiscard]] IndexSet get_cone_recursive_vertices(IndexSet points) const;
 
     /// Set the number of in-edges for this point in the DAG
     ///
@@ -249,13 +249,13 @@ public:
     ///
     /// @param id The ID of the cell set
     /// @return Cell set name
-    const std::string & get_cell_set_name(Int id) const;
+    [[nodiscard]] const std::string & get_cell_set_name(Int id) const;
 
     /// Get cell set ID
     ///
     /// @param name The name of a cell sel
     /// @return Cell set ID
-    Int get_cell_set_id(const std::string & name) const;
+    [[nodiscard]] Int get_cell_set_id(const std::string & name) const;
 
     /// Get number of cell sets
     ///
@@ -265,7 +265,7 @@ public:
     /// Get cell sets
     ///
     /// @return Cell sets
-    const std::map<Int, std::string> & get_cell_sets() const;
+    [[nodiscard]] const std::map<Int, std::string> & get_cell_sets() const;
 
     /// Create cell set. Takes the ID and creates a label with `name` corresponding to the ID.
     ///
@@ -289,7 +289,7 @@ public:
     ///
     /// @param id The ID of the face set
     /// @return Facet name
-    const std::string & get_face_set_name(Int id) const;
+    [[nodiscard]] const std::string & get_face_set_name(Int id) const;
 
     /// Get number of face sets
     ///
@@ -299,7 +299,7 @@ public:
     /// Get face sets
     ///
     /// @return Face sets
-    const std::map<Int, std::string> & get_face_sets() const;
+    [[nodiscard]] const std::map<Int, std::string> & get_face_sets() const;
 
     /// Check if mesh has a label corresponding to a face set name
     ///
@@ -358,7 +358,7 @@ public:
     ///
     /// @param cell The cell
     /// @return The cell volume
-    Real compute_cell_volume(Int cell) const;
+    [[nodiscard]] Real compute_cell_volume(Int cell) const;
 
     /// Compute a map of cells common to a vertex
     ///
@@ -372,7 +372,7 @@ public:
     void mark_boundary_faces(Int val, Label & label);
 
     /// Get the encoding of the parallel section point overlap
-    StarForest get_point_star_forest() const;
+    [[nodiscard]] StarForest get_point_star_forest() const;
 
     void set_point_star_forest(const StarForest & sf);
 

--- a/include/godzilla/ValueFunctional.h
+++ b/include/godzilla/ValueFunctional.h
@@ -16,7 +16,7 @@ public:
     /// Get value names provided by this functional
     ///
     /// @return List of value names provided by this functional
-    const std::set<std::string> & get_provided_values() const;
+    [[nodiscard]] const std::set<std::string> & get_provided_values() const;
 
     /// Evaluate this functional
     virtual void evaluate() const = 0;

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -15,7 +15,6 @@ public:
     Vector();
     Vector(MPI_Comm comm);
     Vector(Vec vec);
-    virtual ~Vector();
 
     void create(MPI_Comm comm);
     void destroy();

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -31,24 +31,24 @@ public:
     /// Get the vector type name
     ///
     /// @return The vector type
-    std::string get_type() const;
+    [[nodiscard]] std::string get_type() const;
 
     Scalar * get_array();
-    const Scalar * get_array_read() const;
+    [[nodiscard]] const Scalar * get_array_read() const;
     void restore_array(Scalar * arr);
     void restore_array_read(const Scalar * arr) const;
 
     /// Returns the global number of elements of the vector
-    Int get_size() const;
+    [[nodiscard]] Int get_size() const;
     /// Returns the local number of elements of the vector
-    Int get_local_size() const;
+    [[nodiscard]] Int get_local_size() const;
     void get_values(const std::vector<Int> & idx, std::vector<Scalar> & y) const;
 
     void abs();
-    Scalar dot(const Vector & y) const;
+    [[nodiscard]] Scalar dot(const Vector & y) const;
     void scale(Scalar alpha);
     void duplicate(Vector & b) const;
-    Vector duplicate() const;
+    [[nodiscard]] Vector duplicate() const;
 
     /// Copy this vector into `y`
     ///
@@ -57,8 +57,8 @@ public:
 
     void normalize();
     void shift(Scalar shift);
-    Scalar min() const;
-    Scalar max() const;
+    [[nodiscard]] Scalar min() const;
+    [[nodiscard]] Scalar max() const;
 #if PETSC_VERSION_LT(3, 20, 0)
     void chop(Real tol);
 #else
@@ -132,7 +132,7 @@ public:
                           const std::vector<Scalar> & y,
                           InsertMode mode = INSERT_VALUES);
 
-    Scalar sum() const;
+    [[nodiscard]] Scalar sum() const;
 
     void zero();
 

--- a/include/godzilla/WeakForm.h
+++ b/include/godzilla/WeakForm.h
@@ -50,19 +50,19 @@ public:
     /// Get residual keys
     ///
     /// FIXME: needs a better name
-    std::vector<PetscFormKey> get_residual_keys() const;
+    [[nodiscard]] std::vector<PetscFormKey> get_residual_keys() const;
 
     /// Get Jacobian keys
     ///
     /// FIXME: needs a better name
-    std::vector<PetscFormKey> get_jacobian_keys() const;
+    [[nodiscard]] std::vector<PetscFormKey> get_jacobian_keys() const;
 
     /// Get residual forms
-    const std::vector<ResidualFunc *> &
+    [[nodiscard]] const std::vector<ResidualFunc *> &
     get(ResidualKind kind, const Label & label, Int val, Int f, Int part) const;
 
     /// Get Jacobian forms
-    const std::vector<JacobianFunc *> &
+    [[nodiscard]] const std::vector<JacobianFunc *> &
     get(JacobianKind kind, const Label & label, Int val, Int f, Int g, Int part) const;
 
     /// Add a residual form
@@ -95,12 +95,12 @@ public:
     /// Query if Jacobian statement is set
     ///
     /// @return `true` if weak form for Jacobian statement is set, otherwise `false`
-    bool has_jacobian() const;
+    [[nodiscard]] bool has_jacobian() const;
 
     /// Query if Jacobian preconditioner statement is set
     ///
     /// @return `true` if weak form for Jacobian preconditioner statement is set, otherwise `false`
-    bool has_jacobian_preconditioner() const;
+    [[nodiscard]] bool has_jacobian_preconditioner() const;
 
     /// Get field ID for the combination of fields `f` and `g`
     ///

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -35,7 +35,7 @@ App::App(const mpi::Communicator & comm,
     CALL_STACK_MSG();
     this->args.resize(argc);
     for (int i = 0; i < argc; i++)
-        this->args.push_back(std::string(argv[i]));
+        this->args.emplace_back(argv[i]);
 }
 
 App::App(const mpi::Communicator & comm,
@@ -72,7 +72,7 @@ App::App(const mpi::Communicator & comm,
     CALL_STACK_MSG();
     this->args.resize(argc);
     for (int i = 0; i < argc; i++)
-        this->args.push_back(std::string(argv[i]));
+        this->args.emplace_back(argv[i]);
 }
 
 App::App(const mpi::Communicator & comm,

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -32,7 +32,7 @@ AuxiliaryField::AuxiliaryField(const Parameters & params) :
     block_id(-1)
 {
     CALL_STACK_MSG();
-    if (this->field.length() == 0)
+    if (this->field.empty())
         this->field = this->get_name();
 }
 
@@ -62,7 +62,7 @@ AuxiliaryField::create()
 {
     CALL_STACK_MSG();
     this->mesh = this->dpi->get_unstr_mesh();
-    if (this->region.length() > 0) {
+    if (!this->region.empty()) {
         if (this->mesh->has_label(this->region)) {
             this->label = this->mesh->get_label(this->region);
             this->block_id = this->mesh->get_cell_set_id(this->region);

--- a/src/ConstantAuxiliaryField.cpp
+++ b/src/ConstantAuxiliaryField.cpp
@@ -23,7 +23,7 @@ ConstantAuxiliaryField::ConstantAuxiliaryField(const Parameters & params) :
     values(params.get<std::vector<Real>>("value"))
 {
     CALL_STACK_MSG();
-    assert(this->values.size() >= 1);
+    assert(!this->values.empty());
 }
 
 Int

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -347,7 +347,7 @@ DGProblemInterface::get_num_nodes_per_elem(Int c) const
 {
     auto unstr_mesh = get_unstr_mesh();
     auto ct = unstr_mesh->get_cell_type(c);
-    auto n_nodes = unstr_mesh->get_num_cell_nodes(ct);
+    auto n_nodes = UnstructuredMesh::get_num_cell_nodes(ct);
     return n_nodes;
 }
 

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -356,7 +356,7 @@ DGProblemInterface::get_field_dof(Int elem, Int local_node, Int comp, Int fid) c
 {
     CALL_STACK_MSG();
     auto section = get_problem()->get_local_section();
-    Int offset = section.get_field_offset(elem, fid);
+    auto offset = section.get_field_offset(elem, fid);
     // FIXME: works only for order = 1
     offset += (comp * get_num_nodes_per_elem(elem)) + local_node;
     return offset;
@@ -366,7 +366,7 @@ Int
 DGProblemInterface::get_aux_field_dof(Int elem, Int local_node, Int comp, Int fid) const
 {
     CALL_STACK_MSG();
-    Int offset = get_local_section_aux().get_field_offset(elem, fid);
+    auto offset = get_local_section_aux().get_field_offset(elem, fid);
     // FIXME: works only for order = 1
     offset += (comp * get_num_nodes_per_elem(elem)) + local_node;
     return offset;
@@ -397,7 +397,7 @@ DGProblemInterface::create_section()
     PETSC_CHECK(DMSetNumFields(dm, 1));
     Section section;
     section.create(comm);
-    section.set_num_fields(this->fields.size());
+    section.set_num_fields(get_num_fields());
     for (auto & it : this->fields) {
         auto & fi = it.second;
         section.set_num_field_components(fi.id, fi.nc);
@@ -428,11 +428,11 @@ DGProblemInterface::set_up_section_constraint_dofs(Section & section)
     auto unstr_mesh = get_unstr_mesh();
 
     auto depth_label = unstr_mesh->get_depth_label();
-    Int dim = unstr_mesh->get_dimension();
+    auto dim = unstr_mesh->get_dimension();
     IndexSet all_facets = depth_label.get_stratum(dim - 1);
 
     for (auto & bnd : get_essential_bcs()) {
-        Int n_ced_dofs = bnd->get_components().size();
+        auto n_ced_dofs = (Int) bnd->get_components().size();
         auto fid = bnd->get_field_id();
 
         auto & bnd_names = bnd->get_boundary();
@@ -485,7 +485,7 @@ DGProblemInterface::set_up_section_constraint_indicies(Section & section)
                     auto econn = unstr_mesh->get_connectivity(support[0]);
 
                     auto cell_id = support[0];
-                    auto n_nodes_per_elem = econn.size();
+                    auto n_nodes_per_elem = (Int) econn.size();
                     std::vector<Int> indices;
                     for (Int j = 0; j < fconn.size(); j++) {
                         auto local_node_idx = fe::get_local_vertex_index(econn, fconn[j]);
@@ -511,7 +511,7 @@ DGProblemInterface::create_aux_fields()
     auto comm = get_problem()->get_comm();
     Section section_aux;
     section_aux.create(comm);
-    section_aux.set_num_fields(this->aux_fields.size());
+    section_aux.set_num_fields(get_num_aux_fields());
     for (auto & it : this->aux_fields) {
         auto & fi = it.second;
         section_aux.set_num_field_components(fi.id, fi.nc);
@@ -522,11 +522,11 @@ DGProblemInterface::create_aux_fields()
     section_aux.set_chart(cell_range.first(), cell_range.last());
     for (Int c = cell_range.first(); c < cell_range.last(); c++) {
         auto n_nodes = get_num_nodes_per_elem(c);
-        int n_dofs = 0;
+        Int n_dofs = 0;
         for (auto & it : this->aux_fields) {
             auto & fi = it.second;
             // FIXME: this works for order = 1
-            Int n_field_dofs = fi.nc * n_nodes;
+            auto n_field_dofs = fi.nc * n_nodes;
             section_aux.set_field_dof(c, fi.id, n_field_dofs);
             n_dofs += n_field_dofs;
         }

--- a/src/DependencyEvaluator.cpp
+++ b/src/DependencyEvaluator.cpp
@@ -6,8 +6,6 @@
 
 namespace godzilla {
 
-DependencyEvaluator::DependencyEvaluator() {}
-
 DependencyEvaluator::~DependencyEvaluator()
 {
     for (auto & kv : this->values)

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -621,8 +621,8 @@ DiscreteProblemInterface::add_boundary(DMBoundaryConditionType type,
                                        const std::vector<Int> & ids,
                                        Int field,
                                        const std::vector<Int> & components,
-                                       void (*bc_fn)(void),
-                                       void (*bc_fn_t)(void),
+                                       void (*bc_fn)(),
+                                       void (*bc_fn_t)(),
                                        void * context)
 {
     CALL_STACK_MSG();

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -505,7 +505,7 @@ DiscreteProblemInterface::compute_aux_fields()
         const std::string & region_name = it.first;
         const std::vector<AuxiliaryField *> & auxs = it.second;
         Label label;
-        if (region_name.length() > 0)
+        if (!region_name.empty())
             label = get_unstr_mesh()->get_label(region_name);
 
         if (label.is_null())
@@ -634,7 +634,7 @@ DiscreteProblemInterface::add_boundary(DMBoundaryConditionType type,
                                    ids.data(),
                                    field,
                                    components.size(),
-                                   components.size() == 0 ? nullptr : components.data(),
+                                   components.empty() ? nullptr : components.data(),
                                    bc_fn,
                                    bc_fn_t,
                                    context,

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -293,7 +293,7 @@ DiscreteProblemInterface::check_initial_conditions(const std::vector<InitialCond
     if (n_ics == 0)
         return;
 
-    Int n_fields = field_comps.size();
+    auto n_fields = field_comps.size();
     if (n_ics == n_fields) {
         std::map<Int, InitialCondition *> ics_by_fields;
         for (auto & ic : ics) {

--- a/src/EssentialBC.cpp
+++ b/src/EssentialBC.cpp
@@ -37,7 +37,7 @@ EssentialBC::create()
     }
     else if (field_names.size() > 1) {
         const auto & field_name = get_param<std::string>("field");
-        if (field_name.length() > 0) {
+        if (!field_name.empty()) {
             if (dpi->has_field_by_name(field_name))
                 this->fid = dpi->get_field_id(field_name);
             else

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -121,7 +121,6 @@ ExodusIIOutput::ExodusIIOutput(const Parameters & params) :
         this->discont = true;
     else
         this->cont = true;
-
 }
 
 ExodusIIOutput::~ExodusIIOutput()
@@ -537,7 +536,7 @@ ExodusIIOutput::add_var_names(Int fid, std::vector<std::string> & var_names)
         for (Int c = 0; c < nc; c++) {
             std::string comp_name = this->dpi->get_field_component_name(fid, c);
             std::string s;
-            if (comp_name.length() == 0)
+            if (comp_name.empty())
                 s = fmt::format("{}_{}", name, c);
             else
                 s = fmt::format("{}", comp_name);
@@ -558,7 +557,7 @@ ExodusIIOutput::add_aux_var_names(Int fid, std::vector<std::string> & var_names)
         for (Int c = 0; c < nc; c++) {
             std::string comp_name = this->dpi->get_aux_field_component_name(fid, c);
             std::string s;
-            if (comp_name.length() == 0)
+            if (comp_name.empty())
                 s = fmt::format("{}_{}", name, c);
             else
                 s = fmt::format("{}", comp_name);

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -25,8 +25,6 @@ ExplicitFVLinearProblem::ExplicitFVLinearProblem(const Parameters & params) :
     set_default_output_on(EXECUTE_ON_INITIAL | EXECUTE_ON_TIMESTEP);
 }
 
-ExplicitFVLinearProblem::~ExplicitFVLinearProblem() {}
-
 Real
 ExplicitFVLinearProblem::get_time() const
 {

--- a/src/FileMeshExodusII.cpp
+++ b/src/FileMeshExodusII.cpp
@@ -66,10 +66,10 @@ FileMesh::create_from_exodus()
         }
         m->set_chart(0, n_cells + n_vertices);
         // We do not want this label automatically computed, instead we compute it here
-        auto celltypes = m->create_label("celltype");
+        m->create_label("celltype");
         // Create Cell/Face Sets labels on all processes
-        auto cell_sets = m->create_label("Cell Sets");
-        auto face_sets = m->create_label("Face Sets");
+        m->create_label("Cell Sets");
+        m->create_label("Face Sets");
 
         if (rank == 0) {
             f.read_blocks();
@@ -105,6 +105,8 @@ FileMesh::create_from_exodus()
             m->set_up();
 
             // process element blocks
+            auto cell_sets = m->get_label("Cell Sets");
+
             for (Int i = 0, cell = 0; i < n_elem_blocks; ++i) {
                 int blk_idx = cs_order[i];
                 auto & eb = f.get_element_block(blk_idx);
@@ -113,7 +115,8 @@ FileMesh::create_from_exodus()
                 if (name.empty())
                     name = fmt::format("{}", id);
 
-                auto block_label = m->create_label(name);
+                m->create_label(name);
+                auto block_label = m->get_label(name);
                 cell_set_names[id] = name;
 
                 auto n_blk_elems = eb.get_num_elements();
@@ -195,6 +198,8 @@ FileMesh::create_from_exodus()
         // Create side set labels
         std::map<Int, std::string> side_set_names;
         if ((rank == 0) && (n_side_sets > 0)) {
+            auto face_sets = m->get_label("Face Sets");
+
             f.read_side_sets();
             auto & side_sets = f.get_side_sets();
             for (int i = 0; i < n_side_sets; ++i) {
@@ -204,7 +209,8 @@ FileMesh::create_from_exodus()
                 if (name.empty())
                     name = fmt::format("{}", id);
 
-                auto face_set_label = m->create_label(name);
+                m->create_label(name);
+                auto face_set_label = m->get_label(name);
                 side_set_names[id] = name;
 
                 std::vector<int> node_count_list;

--- a/src/FileMeshExodusII.cpp
+++ b/src/FileMeshExodusII.cpp
@@ -66,10 +66,10 @@ FileMesh::create_from_exodus()
         }
         m->set_chart(0, n_cells + n_vertices);
         // We do not want this label automatically computed, instead we compute it here
-        m->create_label("celltype");
+        auto celltypes = m->create_label("celltype");
         // Create Cell/Face Sets labels on all processes
-        m->create_label("Cell Sets");
-        m->create_label("Face Sets");
+        auto cell_sets = m->create_label("Cell Sets");
+        auto face_sets = m->create_label("Face Sets");
 
         if (rank == 0) {
             f.read_blocks();
@@ -105,8 +105,6 @@ FileMesh::create_from_exodus()
             m->set_up();
 
             // process element blocks
-            auto cell_sets = m->get_label("Cell Sets");
-
             for (Int i = 0, cell = 0; i < n_elem_blocks; ++i) {
                 int blk_idx = cs_order[i];
                 auto & eb = f.get_element_block(blk_idx);
@@ -115,8 +113,7 @@ FileMesh::create_from_exodus()
                 if (name.empty())
                     name = fmt::format("{}", id);
 
-                m->create_label(name);
-                auto block_label = m->get_label(name);
+                auto block_label = m->create_label(name);
                 cell_set_names[id] = name;
 
                 auto n_blk_elems = eb.get_num_elements();
@@ -198,8 +195,6 @@ FileMesh::create_from_exodus()
         // Create side set labels
         std::map<Int, std::string> side_set_names;
         if ((rank == 0) && (n_side_sets > 0)) {
-            auto face_sets = m->get_label("Face Sets");
-
             f.read_side_sets();
             auto & side_sets = f.get_side_sets();
             for (int i = 0; i < n_side_sets; ++i) {
@@ -209,8 +204,7 @@ FileMesh::create_from_exodus()
                 if (name.empty())
                     name = fmt::format("{}", id);
 
-                m->create_label(name);
-                auto face_set_label = m->get_label(name);
+                auto face_set_label = m->create_label(name);
                 side_set_names[id] = name;
 
                 std::vector<int> node_count_list;

--- a/src/FileOutput.cpp
+++ b/src/FileOutput.cpp
@@ -30,7 +30,7 @@ FileOutput::create()
 {
     CALL_STACK_MSG();
     Output::create();
-    if (this->file_base.length() == 0) {
+    if (this->file_base.empty()) {
         std::filesystem::path input_file_name(get_app()->get_input_file_name());
         this->file_base = input_file_name.stem().u8string();
     }

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -15,8 +15,6 @@ IndexSet::Iterator::Iterator(IndexSet & is, Int idx) : is(is), idx(idx)
         throw Exception("Must call IndexSet::get_indices() first.");
 }
 
-IndexSet::Iterator::~Iterator() {}
-
 const IndexSet::Iterator::value_type &
 IndexSet::Iterator::operator*() const
 {
@@ -55,8 +53,6 @@ operator!=(const IndexSet::Iterator & a, const IndexSet::Iterator & b)
 IndexSet::IndexSet() : is(nullptr), indices(nullptr) {}
 
 IndexSet::IndexSet(IS is) : is(is), indices(nullptr) {}
-
-IndexSet::~IndexSet() {}
 
 const Int *
 IndexSet::data() const

--- a/src/InitialCondition.cpp
+++ b/src/InitialCondition.cpp
@@ -33,7 +33,18 @@ InitialCondition::create()
     CALL_STACK_MSG();
     assert(this->dpi != nullptr);
     auto fld = get_param<std::string>("field");
-    if (fld.length() > 0) {
+    if (fld.empty()) {
+        std::vector<std::string> field_names = this->dpi->get_field_names();
+        std::vector<std::string> aux_field_names = this->dpi->get_aux_field_names();
+        if ((field_names.size() == 1) && (aux_field_names.empty())) {
+            this->fid = this->dpi->get_field_id(field_names[0]);
+            this->field_name = this->dpi->get_field_name(this->fid);
+        }
+        else
+            log_error(
+                "Use the 'field' parameter to assign this initial condition to an existing field.");
+    }
+    else {
         this->field_name = fld;
         if (this->dpi->has_field_by_name(fld))
             this->fid = this->dpi->get_field_id(fld);
@@ -41,17 +52,6 @@ InitialCondition::create()
             this->fid = this->dpi->get_aux_field_id(fld);
         else
             log_error("Field '{}' does not exists. Typo?", fld);
-    }
-    else {
-        std::vector<std::string> field_names = this->dpi->get_field_names();
-        std::vector<std::string> aux_field_names = this->dpi->get_aux_field_names();
-        if ((field_names.size() == 1) && (aux_field_names.size() == 0)) {
-            this->fid = this->dpi->get_field_id(field_names[0]);
-            this->field_name = this->dpi->get_field_name(this->fid);
-        }
-        else
-            log_error(
-                "Use the 'field' parameter to assign this initial condition to an existing field.");
     }
 }
 
@@ -75,6 +75,5 @@ InitialCondition::get_dimension() const
     CALL_STACK_MSG();
     return this->dpi->get_problem()->get_dimension();
 }
-
 
 } // namespace godzilla

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -68,14 +68,12 @@ Mesh::get_label(const std::string & name) const
     return Label(label);
 }
 
-Label
+void
 Mesh::create_label(const std::string & name) const
 {
     CALL_STACK_MSG();
     DMLabel label;
     PETSC_CHECK(DMCreateLabel(this->dm, name.c_str()));
-    PETSC_CHECK(DMGetLabel(this->dm, name.c_str(), &label));
-    return Label(label);
 }
 
 void

--- a/src/NaturalBC.cpp
+++ b/src/NaturalBC.cpp
@@ -39,7 +39,7 @@ NaturalBC::create()
     }
     else if (field_names.size() > 1) {
         const auto & field_name = get_param<std::string>("field");
-        if (field_name.length() > 0) {
+        if (!field_name.empty()) {
             if (dpi->has_field_by_name(field_name))
                 this->fid = dpi->get_field_id(field_name);
             else

--- a/src/NaturalRiemannBC.cpp
+++ b/src/NaturalRiemannBC.cpp
@@ -18,7 +18,7 @@ NaturalRiemannBC::parameters()
     return params;
 }
 
-NaturalRiemannBC::NaturalRiemannBC(const Parameters & params) : BoundaryCondition(params)
+NaturalRiemannBC::NaturalRiemannBC(const Parameters & params) : BoundaryCondition(params), fid(-1)
 {
     CALL_STACK_MSG();
 }

--- a/src/ParsedFunction.cpp
+++ b/src/ParsedFunction.cpp
@@ -51,7 +51,7 @@ void
 ParsedFunction::evaluate(Real time, const Real x[], Scalar u[])
 {
     CALL_STACK_MSG();
-    this->evalr.evaluate(get_dimension(), time, x, this->function.size(), u);
+    this->evalr.evaluate(get_dimension(), time, x, static_cast<Int>(this->function.size()), u);
 }
 
 } // namespace godzilla

--- a/src/PiecewiseConstant.cpp
+++ b/src/PiecewiseConstant.cpp
@@ -40,7 +40,7 @@ PiecewiseConstant::PiecewiseConstant(const Parameters & params) :
                   this->x.size(),
                   this->y.size());
 
-    if (this->x.size() == 0)
+    if (this->x.empty())
         log_error("Size of 'x' is {}. It must be 1 or more.", this->x.size());
     else {
         // check monotonicity

--- a/src/PrintInterface.cpp
+++ b/src/PrintInterface.cpp
@@ -58,6 +58,7 @@ PrintInterface::PrintInterface(const App * app) :
 PrintInterface::PrintInterface(const mpi::Communicator & comm,
                                const unsigned int & verbosity_level,
                                std::string prefix) :
+    pi_app(nullptr),
     proc_id(comm.rank()),
     verbosity_level(verbosity_level),
     prefix(std::move(prefix))

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -17,7 +17,7 @@ Problem::FieldDecomposition::FieldDecomposition(Int n) : field_name(n), is(n) {}
 Int
 Problem::FieldDecomposition::get_num_fields() const
 {
-    return this->field_name.size();
+    return static_cast<Int>(this->field_name.size());
 }
 
 void

--- a/src/SNESolver.cpp
+++ b/src/SNESolver.cpp
@@ -88,8 +88,6 @@ SNESolver::SNESolver() : snes(nullptr) {}
 
 SNESolver::SNESolver(SNES snes) : snes(snes) {}
 
-SNESolver::~SNESolver() {}
-
 void
 SNESolver::create(MPI_Comm comm)
 {

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -335,7 +335,8 @@ UnstructuredMesh::create_face_set(Int id, const std::string & name)
     Label face_sets_label = get_label("Face Sets");
     IndexSet is = face_sets_label.get_stratum(id);
     if (!is.empty()) {
-        Label label = create_label(name);
+        create_label(name);
+        Label label = get_label(name);
         label.set_stratum(id, is);
     }
     is.destroy();
@@ -385,7 +386,8 @@ UnstructuredMesh::create_cell_set(Int id, const std::string & name)
     CALL_STACK_MSG();
     auto cell_sets_label = get_label("Cell Sets");
     auto cell_set = cell_sets_label.get_stratum(id);
-    auto label = create_label(name);
+    create_label(name);
+    auto label = get_label(name);
     if (!cell_set.empty())
         label.set_stratum(id, cell_set);
     cell_set.destroy();

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -11,7 +11,7 @@ namespace godzilla {
 
 Vector::Vector() : vec(nullptr) {}
 
-Vector::Vector(MPI_Comm comm)
+Vector::Vector(MPI_Comm comm) : vec(nullptr)
 {
     CALL_STACK_MSG();
     create(comm);

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -227,9 +227,9 @@ Vector::maxpy(const std::vector<Scalar> & alpha, const std::vector<Vector> & x)
 {
     CALL_STACK_MSG();
     if (alpha.size() == x.size()) {
-        Int n = alpha.size();
+        auto n = alpha.size();
         std::vector<Vec> xx(n);
-        for (Int i = 0; i < n; i++)
+        for (std::size_t i = 0; i < n; i++)
             xx[i] = (Vec) x[i];
         PETSC_CHECK(VecMAXPY(this->vec, n, alpha.data(), xx.data()));
     }

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -22,8 +22,6 @@ Vector::Vector(Vec vec) : vec(vec)
     CALL_STACK_MSG();
 }
 
-Vector::~Vector() {}
-
 void
 Vector::create(MPI_Comm comm)
 {

--- a/test/src/DenseMatrixSymm_test.cpp
+++ b/test/src/DenseMatrixSymm_test.cpp
@@ -352,7 +352,7 @@ TEST(DenseMatrixSymmTest, det4)
     //    m.set_row(2, { 0, 1, 0, 2 });
     //    m.set_row(3, { 1, -2, -3, 2 });
     //    EXPECT_EQ(m.det(), 21.);
-    EXPECT_DEATH(m.det(), "Determinant is not implemented for 4x4 matrices, yet.");
+    EXPECT_DEATH({ auto d = m.det(); }, "Determinant is not implemented for 4x4 matrices, yet.");
 }
 
 TEST(DenseMatrixSymmTest, transpose3)

--- a/test/src/DenseMatrix_test.cpp
+++ b/test/src/DenseMatrix_test.cpp
@@ -410,7 +410,7 @@ TEST(DenseMatrixTest, det4)
     m.set_row(2, { 0, 1, 0, 2 });
     m.set_row(3, { 1, -2, -3, 2 });
     //    EXPECT_EQ(m.det(), 21.);
-    EXPECT_DEATH(m.det(), "Determinant is not implemented for 4x4 matrices, yet.");
+    EXPECT_DEATH({ auto d = m.det(); }, "Determinant is not implemented for 4x4 matrices, yet.");
 }
 
 TEST(DenseMatrixTest, inv1)

--- a/test/src/DenseVector_test.cpp
+++ b/test/src/DenseVector_test.cpp
@@ -270,13 +270,13 @@ TEST(DenseVectorTest, tensor_prod)
 TEST(DenseVectorDeathTest, cross_prod_1_2)
 {
     DenseVector<Real, 1> a({ -2. });
-    EXPECT_DEATH(a.cross(a), "Cross product of 1D vectors is not defined.");
+    EXPECT_DEATH({ auto v = a.cross(a); }, "Cross product of 1D vectors is not defined.");
 
     DenseVector<Real, 2> b({ -2., 5. });
-    EXPECT_DEATH(b.cross(b), "Cross product of 2D vectors is not defined.");
+    EXPECT_DEATH({ auto v = b.cross(b); }, "Cross product of 2D vectors is not defined.");
 
     DenseVector<Real, 4> c({ -2., 5., 5., 6. });
-    EXPECT_DEATH(c.cross(c), "Cross product in 4 dimensions is not unique.");
+    EXPECT_DEATH({ auto v = c.cross(c); }, "Cross product in 4 dimensions is not unique.");
 }
 
 TEST(DenseVectorTest, cross_prod_3)

--- a/test/src/DependencyEvaluator_test.cpp
+++ b/test/src/DependencyEvaluator_test.cpp
@@ -138,7 +138,9 @@ TEST(DependencyEvaluator, get_non_existent_functional)
     mesh.create();
     prob.create();
 
-    EXPECT_THROW_MSG(prob.get_functional("asdf"), "No functional with name 'asdf' found. Typo?");
+    EXPECT_THROW_MSG(
+        { auto & f = prob.get_functional("asdf"); },
+        "No functional with name 'asdf' found. Typo?");
 }
 
 TEST(DependencyEvaluator, eval)

--- a/test/src/ExodusIIMesh_test.cpp
+++ b/test/src/ExodusIIMesh_test.cpp
@@ -78,8 +78,10 @@ TEST(ExodusIIMeshTest, two_block_nonexistent_blk)
     mesh.create();
 
     auto m = mesh.get_mesh<UnstructuredMesh>();
-    EXPECT_THROW_MSG(m->get_cell_set_name(1234), "Cell set ID '1234' does not exist.");
-    EXPECT_THROW_MSG(m->get_cell_set_id("1234"), "Cell set '1234' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto & name = m->get_cell_set_name(1234); },
+        "Cell set ID '1234' does not exist.");
+    EXPECT_THROW_MSG({ auto id = m->get_cell_set_id("1234"); }, "Cell set '1234' does not exist.");
 }
 
 TEST(ExodusIIMeshTest, nonexitent_file)

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -21,7 +21,7 @@ public:
     {
     }
 
-    const std::vector<Int> &
+    [[nodiscard]] const std::vector<Int> &
     get_components() const override
     {
         return this->components;
@@ -140,11 +140,14 @@ TEST(ExplicitFVLinearProblemTest, api)
     EXPECT_THAT(prob.get_field_names(), testing::ElementsAre(""));
 
     EXPECT_EQ(prob.get_field_name(0), "u");
-    EXPECT_THROW_MSG(prob.get_field_name(65536), "Field with ID = '65536' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto & n = prob.get_field_name(65536); },
+        "Field with ID = '65536' does not exist.");
 
     EXPECT_EQ(prob.get_field_num_components(0), 1);
-    EXPECT_THROW_MSG(prob.get_field_num_components(65536),
-                     "Field with ID = '65536' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto id = prob.get_field_num_components(65536); },
+        "Field with ID = '65536' does not exist.");
 
     EXPECT_EQ(prob.get_field_id("u"), 0);
     EXPECT_EQ(prob.get_field_id("nonexistent"), 0);
@@ -156,12 +159,14 @@ TEST(ExplicitFVLinearProblemTest, api)
     EXPECT_FALSE(prob.has_field_by_name("nonexistent"));
 
     EXPECT_EQ(prob.get_field_order(0), 0);
-    EXPECT_DEATH(prob.get_field_order(65536),
-                 "\\[ERROR\\] Multiple-field problems are not implemented");
+    EXPECT_DEATH(
+        { auto o = prob.get_field_order(65536); },
+        "\\[ERROR\\] Multiple-field problems are not implemented");
 
     EXPECT_EQ(prob.get_field_component_name(0, 0).compare("u"), 0);
-    EXPECT_DEATH(prob.get_field_component_name(65536, 0),
-                 "\\[ERROR\\] Multiple-field problems are not implemented");
+    EXPECT_DEATH(
+        { auto n = prob.get_field_component_name(65536, 0); },
+        "\\[ERROR\\] Multiple-field problems are not implemented");
 
     EXPECT_THROW_MSG(prob.set_field_component_name(0, 0, "x"),
                      "Unable to set component name for single-component field");
@@ -170,15 +175,19 @@ TEST(ExplicitFVLinearProblemTest, api)
     EXPECT_THAT(prob.get_aux_field_names(), ElementsAre("a0", "a1"));
     EXPECT_TRUE(prob.get_aux_field_name(0) == "a0");
     EXPECT_TRUE(prob.get_aux_field_name(1) == "a1");
-    EXPECT_THROW_MSG(prob.get_aux_field_name(99), "Auxiliary field with ID = '99' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto n = prob.get_aux_field_name(99); },
+        "Auxiliary field with ID = '99' does not exist.");
     EXPECT_EQ(prob.get_aux_field_num_components(0), 1);
     EXPECT_EQ(prob.get_aux_field_num_components(1), 2);
-    EXPECT_THROW_MSG(prob.get_aux_field_num_components(99),
-                     "Auxiliary field with ID = '99' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto nc = prob.get_aux_field_num_components(99); },
+        "Auxiliary field with ID = '99' does not exist.");
     EXPECT_EQ(prob.get_aux_field_id("a0"), 0);
     EXPECT_EQ(prob.get_aux_field_id("a1"), 1);
-    EXPECT_THROW_MSG(prob.get_aux_field_id("non-existent"),
-                     "Auxiliary field 'non-existent' does not exist. Typo?");
+    EXPECT_THROW_MSG(
+        { auto id = prob.get_aux_field_id("non-existent"); },
+        "Auxiliary field 'non-existent' does not exist. Typo?");
     EXPECT_TRUE(prob.has_aux_field_by_id(0));
     EXPECT_TRUE(prob.has_aux_field_by_id(1));
     EXPECT_FALSE(prob.has_aux_field_by_id(99));
@@ -187,12 +196,14 @@ TEST(ExplicitFVLinearProblemTest, api)
     EXPECT_FALSE(prob.has_aux_field_by_name("non-existent"));
     EXPECT_EQ(prob.get_aux_field_order(0), 0);
     EXPECT_EQ(prob.get_aux_field_order(1), 0);
-    EXPECT_THROW_MSG(prob.get_aux_field_order(99),
-                     "Auxiliary field with ID = '99' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto o = prob.get_aux_field_order(99); },
+        "Auxiliary field with ID = '99' does not exist.");
     EXPECT_TRUE(prob.get_aux_field_component_name(0, 1) == "");
     EXPECT_TRUE(prob.get_aux_field_component_name(1, 0) == "0");
-    EXPECT_THROW_MSG(prob.get_aux_field_component_name(99, 0),
-                     "Auxiliary field with ID = '99' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto n = prob.get_aux_field_component_name(99, 0); },
+        "Auxiliary field with ID = '99' does not exist.");
     EXPECT_THROW_MSG(prob.set_aux_field_component_name(0, 0, "C"),
                      "Unable to set component name for single-component field");
     prob.set_aux_field_component_name(1, 1, "Y");

--- a/test/src/FEBoundary1D_test.cpp
+++ b/test/src/FEBoundary1D_test.cpp
@@ -43,7 +43,8 @@ public:
                                                         true);
 
         // create "side sets"
-        auto face_sets = m->create_label("Face Sets");
+        m->create_label("Face Sets");
+        auto face_sets = m->get_label("Face Sets");
 
         create_side_set(m, face_sets, 1, { 2 }, "left");
         create_side_set(m, face_sets, 2, { 4 }, "right");

--- a/test/src/FEBoundary2D_test.cpp
+++ b/test/src/FEBoundary2D_test.cpp
@@ -44,7 +44,8 @@ public:
                                                         true);
 
         // create "side sets"
-        auto face_sets = m->create_label("Face Sets");
+        m->create_label("Face Sets");
+        auto face_sets = m->get_label("Face Sets");
 
         create_side_set(m, face_sets, 1, { 8 }, "left");
         create_side_set(m, face_sets, 2, { 6 }, "bottom");

--- a/test/src/FEBoundary3D_test.cpp
+++ b/test/src/FEBoundary3D_test.cpp
@@ -43,7 +43,8 @@ public:
                                                         true);
 
         // create "side sets"
-        auto face_sets = m->create_label("Face Sets");
+        m->create_label("Face Sets");
+        auto face_sets = m->get_label("Face Sets");
 
         create_side_set(m, face_sets, 1, { 6 }, "front");
         create_side_set(m, face_sets, 2, { 5 }, "bottom");

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -23,7 +23,7 @@ class GTest2CompIC : public InitialCondition {
 public:
     explicit GTest2CompIC(const Parameters & params) : InitialCondition(params) {}
 
-    Int
+    [[nodiscard]] Int
     get_num_components() const override
     {
         return 2;
@@ -54,17 +54,23 @@ TEST_F(FENonlinearProblemTest, fields)
     EXPECT_EQ(prob->has_field_by_id(0), true);
     EXPECT_EQ(prob->has_field_by_name("u"), true);
 
-    EXPECT_THROW_MSG(prob->get_field_name(65536), "Field with ID = '65536' does not exist.");
-    EXPECT_THROW_MSG(prob->get_field_id("nonexistent"),
-                     "Field 'nonexistent' does not exist. Typo?");
+    EXPECT_THROW_MSG(
+        { auto n = prob->get_field_name(65536); },
+        "Field with ID = '65536' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto id = prob->get_field_id("nonexistent"); },
+        "Field 'nonexistent' does not exist. Typo?");
     EXPECT_EQ(prob->has_field_by_id(65536), false);
     EXPECT_EQ(prob->has_field_by_name("nonexistent"), false);
 
     EXPECT_EQ(prob->get_field_order(0), 1);
-    EXPECT_THROW_MSG(prob->get_field_order(65536), "Field with ID = '65536' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto o = prob->get_field_order(65536); },
+        "Field with ID = '65536' does not exist.");
 
-    EXPECT_THROW_MSG(prob->get_field_num_components(65536),
-                     "Field with ID = '65536' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto nc = prob->get_field_num_components(65536); },
+        "Field with ID = '65536' does not exist.");
 
     EXPECT_EQ(prob->get_field_component_name(0, 0).compare(""), 0);
     EXPECT_EQ(prob->get_field_component_name(1, 0).compare("0"), 0);
@@ -72,8 +78,9 @@ TEST_F(FENonlinearProblemTest, fields)
     EXPECT_EQ(prob->get_field_component_name(1, 2).compare("2"), 0);
     prob->set_field_component_name(1, 0, "x");
     EXPECT_EQ(prob->get_field_component_name(1, 0).compare("x"), 0);
-    EXPECT_THROW_MSG(prob->get_field_component_name(65536, 0),
-                     "Field with ID = '65536' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto n = prob->get_field_component_name(65536, 0); },
+        "Field with ID = '65536' does not exist.");
     EXPECT_THROW_MSG(prob->set_field_component_name(0, 0, "x"),
                      "Unable to set component name for single-component field");
     EXPECT_THROW_MSG(prob->set_field_component_name(65536, 0, "x"),
@@ -118,17 +125,24 @@ TEST_F(FENonlinearProblemTest, get_aux_fields)
     EXPECT_TRUE(prob->get_aux_field_component_name(0, 0) == "");
     EXPECT_TRUE(prob->get_aux_field_component_name(1, 0) == "0");
     EXPECT_TRUE(prob->get_aux_field_component_name(1, 1) == "Y");
-    EXPECT_THROW_MSG(prob->get_aux_field_component_name(2, 1),
-                     "Auxiliary field with ID = '2' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto n = prob->get_aux_field_component_name(2, 1); },
+        "Auxiliary field with ID = '2' does not exist.");
 
-    EXPECT_THROW_MSG(prob->get_aux_field_name(2), "Auxiliary field with ID = '2' does not exist.");
-    EXPECT_THROW_MSG(prob->get_aux_field_num_components(2),
-                     "Auxiliary field with ID = '2' does not exist.");
-    EXPECT_THROW_MSG(prob->get_aux_field_id("aux_none"),
-                     "Auxiliary field 'aux_none' does not exist. Typo?");
+    EXPECT_THROW_MSG(
+        { auto n = prob->get_aux_field_name(2); },
+        "Auxiliary field with ID = '2' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto nc = prob->get_aux_field_num_components(2); },
+        "Auxiliary field with ID = '2' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto id = prob->get_aux_field_id("aux_none"); },
+        "Auxiliary field 'aux_none' does not exist. Typo?");
     EXPECT_EQ(prob->has_aux_field_by_id(2), false);
     EXPECT_EQ(prob->has_aux_field_by_name("aux_none"), false);
-    EXPECT_THROW_MSG(prob->get_aux_field_order(2), "Auxiliary field with ID = '2' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto o = prob->get_aux_field_order(2); },
+        "Auxiliary field with ID = '2' does not exist.");
     EXPECT_THROW_MSG(prob->set_aux_field_component_name(0, 1, "C"),
                      "Unable to set component name for single-component field");
     EXPECT_THROW_MSG(prob->set_aux_field_component_name(2, 1, "C"),

--- a/test/src/Mesh_test.cpp
+++ b/test/src/Mesh_test.cpp
@@ -119,7 +119,8 @@ TEST(MeshTest, set_label_value)
     mesh.create();
 
     auto m = mesh.get_mesh<UnstructuredMesh>();
-    auto bnd = m->create_label("bnd");
+    m->create_label("bnd");
+    auto bnd = m->get_label("bnd");
     m->set_label_value("bnd", 0, 1001);
 
     EXPECT_EQ(bnd.get_value(0), 1001);
@@ -136,7 +137,8 @@ TEST(MeshTest, clear_label_value)
     mesh.create();
 
     auto m = mesh.get_mesh<UnstructuredMesh>();
-    auto bnd = m->create_label("bnd");
+    m->create_label("bnd");
+    auto bnd = m->get_label("bnd");
     m->set_label_value("bnd", 0, 1001);
     m->clear_label_value("bnd", 0, 1001);
     EXPECT_EQ(bnd.get_value(0), -1);

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -155,7 +155,9 @@ TEST(UnstructuredMeshTest, nonexistent_face_set)
     mesh.create();
 
     auto m = mesh.get_mesh<UnstructuredMesh>();
-    EXPECT_THROW_MSG(m->get_face_set_name(1234), "Face set ID '1234' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto n = m->get_face_set_name(1234); },
+        "Face set ID '1234' does not exist.");
 }
 
 TEST(UnstructuredMeshTest, nonexistent_cell_set)
@@ -169,7 +171,9 @@ TEST(UnstructuredMeshTest, nonexistent_cell_set)
     mesh.create();
 
     auto m = mesh.get_mesh<UnstructuredMesh>();
-    EXPECT_THROW_MSG(m->get_cell_set_name(1234), "Cell set ID '1234' does not exist.");
+    EXPECT_THROW_MSG(
+        { auto n = m->get_cell_set_name(1234); },
+        "Cell set ID '1234' does not exist.");
 }
 
 TEST(UnstructuredMeshTest, get_connectivity)

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -545,7 +545,8 @@ TEST(UnstructuredMesh, mark_boundary_faces)
             std::vector<Real> vertices = { 0, 0, 1, 0, 0, 1, 1, 1 };
             auto m =
                 UnstructuredMesh::build_from_cell_list(get_comm(), 2, 3, cells, 2, vertices, true);
-            auto face_sets = m->create_label("face sets");
+            m->create_label("face sets");
+            auto face_sets = m->get_label("face sets");
             m->mark_boundary_faces(10, face_sets);
             return m;
         }


### PR DESCRIPTION
- Adding [[nodiscard]]
- Use default for ctors/dtors
- Fixing assignment operator in `DenseMatrix`
- Removing redundant void
- Use override on dtors
- Fixing access to static member function
- Use `empty` over `length`
- Fixing uninitialized member variable
- Fixing narrowing conversions
- Using `emplace_back`
- `UnstructuredMesh::create_label` no longer returns created Label
