### PR TITLE
Refactoring virtual methods

### DIFF
--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -181,9 +181,6 @@ protected:
     ///
     virtual void create_command_line_options();
 
-    /// Create an input file instance
-    virtual InputFile * create_input_file();
-
     /// Build application objects from an input file
     ///
     /// @param file_name The input file name
@@ -198,6 +195,9 @@ protected:
     void run_problem();
 
 private:
+    /// Create an input file instance
+    virtual InputFile * create_input_file();
+
     /// Application name
     std::string name;
 

--- a/include/godzilla/BoundaryCondition.h
+++ b/include/godzilla/BoundaryCondition.h
@@ -28,12 +28,12 @@ public:
     /// Get the boundary name this BC is active on
     ///
     /// @return The boundary name
-    [[nodiscard]] virtual const std::vector<std::string> & get_boundary() const;
+    [[nodiscard]] const std::vector<std::string> & get_boundary() const;
 
     /// Get DiscreteProblemInterface
     ///
     /// @return Discrete problem this BC is part of
-    [[nodiscard]] virtual DiscreteProblemInterface * get_discrete_problem_interface() const;
+    [[nodiscard]] DiscreteProblemInterface * get_discrete_problem_interface() const;
 
     /// Set up this boundary condition
     virtual void set_up() = 0;

--- a/include/godzilla/DGProblemInterface.h
+++ b/include/godzilla/DGProblemInterface.h
@@ -100,7 +100,7 @@ protected:
     void set_up_section_constraint_dofs(Section & section);
     void set_up_section_constraint_indicies(Section & section);
 
-    virtual void set_up_assembly_data_aux();
+    void set_up_assembly_data_aux();
 
     /// Set up field variables
     virtual void set_up_fields() = 0;

--- a/include/godzilla/DGProblemInterface.h
+++ b/include/godzilla/DGProblemInterface.h
@@ -107,6 +107,8 @@ protected:
 
     void create_aux_fields() override;
 
+    void set_up_weak_form() override;
+
 private:
     /// Field information
     struct FieldInfo {

--- a/include/godzilla/DependencyEvaluator.h
+++ b/include/godzilla/DependencyEvaluator.h
@@ -84,7 +84,7 @@ public:
     ///
     /// @param name The name of the functional
     /// @return Reference to the functional
-    [[nodiscard]] virtual const ValueFunctional & get_functional(const std::string & name) const;
+    [[nodiscard]] const ValueFunctional & get_functional(const std::string & name) const;
 
     /// Declare a value with a name
     ///

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -440,6 +440,9 @@ protected:
 
     [[nodiscard]] Int get_next_id(const std::vector<Int> & ids) const;
 
+    /// Setup weak form terms
+    virtual void set_up_weak_form() = 0;
+
 private:
     /// Problem this interface is part of
     Problem * problem;

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -392,8 +392,6 @@ protected:
     void create_ds();
     /// Get underlying PetscDS object
     [[nodiscard]] PetscDS get_ds() const;
-    /// Set up discrete system
-    virtual void set_up_ds() = 0;
 
     /// Check initial conditions
     void check_initial_conditions(const std::vector<InitialCondition *> & ics,
@@ -444,6 +442,9 @@ protected:
     virtual void set_up_weak_form() = 0;
 
 private:
+    /// Set up discrete system
+    virtual void set_up_ds() = 0;
+
     /// Problem this interface is part of
     Problem * problem;
 

--- a/include/godzilla/EssentialBC.h
+++ b/include/godzilla/EssentialBC.h
@@ -15,11 +15,12 @@ public:
     explicit EssentialBC(const Parameters & params);
 
     void create() override;
+    void set_up() override;
 
     /// Get the ID of the field this boundary condition operates on
     ///
     /// @return ID of the field
-    [[nodiscard]] virtual Int get_field_id() const;
+    [[nodiscard]] Int get_field_id() const;
 
     /// Get the component numbers this boundary condition is constraining
     ///
@@ -39,8 +40,6 @@ public:
     /// @param x The coordinates
     /// @param u  The output field values
     virtual void evaluate_t(Real time, const Real x[], Scalar u[]) = 0;
-
-    void set_up() override;
 
 private:
     /// Field ID this boundary condition is attached to

--- a/include/godzilla/ExplicitDGLinearProblem.h
+++ b/include/godzilla/ExplicitDGLinearProblem.h
@@ -29,7 +29,6 @@ protected:
     void allocate_objects() override;
     void set_up_callbacks() override;
     void set_up_initial_guess() override;
-    void set_up_time_scheme() override;
     void set_up_monitors() override;
     void post_step() override;
 

--- a/include/godzilla/ExplicitFELinearProblem.h
+++ b/include/godzilla/ExplicitFELinearProblem.h
@@ -25,7 +25,6 @@ public:
 protected:
     void init() override;
     void set_up_callbacks() override;
-    void set_up_time_scheme() override;
     void set_up_monitors() override;
     void add_residual_block(Int field_id,
                             ResidualFunc * f0,

--- a/include/godzilla/ExplicitFVLinearProblem.h
+++ b/include/godzilla/ExplicitFVLinearProblem.h
@@ -28,7 +28,6 @@ protected:
     void allocate_objects() override;
     void set_up_callbacks() override;
     void set_up_initial_guess() override;
-    void set_up_time_scheme() override;
     void set_up_monitors() override;
     void post_step() override;
 

--- a/include/godzilla/ExplicitProblemInterface.h
+++ b/include/godzilla/ExplicitProblemInterface.h
@@ -17,9 +17,6 @@ public:
     explicit ExplicitProblemInterface(NonlinearProblem * problem, const Parameters & params);
     ~ExplicitProblemInterface() override;
 
-    /// Get the name of time stepping scheme
-    [[nodiscard]] std::string get_scheme() const;
-
     [[nodiscard]] const Matrix & get_mass_matrix() const;
 
     Matrix & get_mass_matrix();
@@ -30,13 +27,14 @@ public:
 
 protected:
     void set_up_callbacks();
-    void set_up_time_scheme() override;
     void allocate_mass_matrix();
     void allocate_lumped_mass_matrix();
     void create_mass_matrix();
     void create_mass_matrix_lumped();
 
 private:
+    void set_up_time_scheme() override;
+
     /// Form the global residual 'F' from the global input 'x' using pointwise functions specified
     /// by the user
     /// @param time The time

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -55,7 +55,7 @@ public:
     [[nodiscard]] std::string get_aux_field_component_name(Int fid, Int component) const override;
     void set_aux_field_component_name(Int fid, Int component, const std::string & name) override;
 
-    [[nodiscard]] virtual WeakForm * get_weak_form() const;
+    [[nodiscard]] WeakForm * get_weak_form() const;
 
     /// Adds a volumetric field
     ///
@@ -275,9 +275,6 @@ protected:
     virtual void set_up_field_null_space(DM dm);
 
     void create_aux_fields() override;
-
-    /// Setup volumetric weak form terms
-    virtual void set_up_weak_form() = 0;
 
     virtual void sort_functionals();
     void

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -263,22 +263,24 @@ protected:
     /// Set up discretization system
     void set_up_ds() override;
 
-    virtual void set_up_assembly_data();
-    virtual void set_up_assembly_data_aux();
+    void set_up_assembly_data();
+    void set_up_assembly_data_aux();
 
     /// Set up field variables
     virtual void set_up_fields() = 0;
 
     /// Set up quadrature
-    virtual void set_up_quadrature();
+    void set_up_quadrature();
 
     virtual void set_up_field_null_space(DM dm);
 
     void create_aux_fields() override;
 
-    virtual void sort_functionals();
+    void sort_functionals();
+
     void
     sort_residual_functionals(const std::map<std::string, const ValueFunctional *> & suppliers);
+
     void
     sort_jacobian_functionals(const std::map<std::string, const ValueFunctional *> & suppliers);
 

--- a/include/godzilla/FVProblemInterface.h
+++ b/include/godzilla/FVProblemInterface.h
@@ -81,9 +81,6 @@ protected:
     /// Set up field variables
     virtual void set_up_fields() = 0;
 
-    /// Setup weak form terms
-    virtual void set_up_weak_form() = 0;
-
     /// Set Riemann solver for the given field
     ///
     /// @tparam T C++ class type

--- a/include/godzilla/InitialCondition.h
+++ b/include/godzilla/InitialCondition.h
@@ -28,12 +28,12 @@ public:
     /// Get field name
     ///
     /// @return The field name
-    [[nodiscard]] virtual const std::string & get_field_name() const;
+    [[nodiscard]] const std::string & get_field_name() const;
 
     /// Get the ID of the field this boundary condition operates on
     ///
     /// @return ID of the field
-    [[nodiscard]] virtual Int get_field_id() const;
+    [[nodiscard]] Int get_field_id() const;
 
     /// Get the number of constrained components
     ///
@@ -44,7 +44,6 @@ public:
     ///
     /// @param time The time at which to sample
     /// @param x The coordinates
-    /// @param nc The number of components
     /// @param u  The output field values
     virtual void evaluate(Real time, const Real x[], Scalar u[]) = 0;
 

--- a/include/godzilla/Mesh.h
+++ b/include/godzilla/Mesh.h
@@ -44,13 +44,13 @@ public:
     ///
     /// @param name The name of the label
     /// @return true if label exists, otherwise false
-    [[nodiscard]] virtual bool has_label(const std::string & name) const;
+    [[nodiscard]] bool has_label(const std::string & name) const;
 
     /// Get label associated with a name
     ///
     /// @param name Label name
     /// @return Label associated with the `name`
-    [[nodiscard]] virtual Label get_label(const std::string & name) const;
+    [[nodiscard]] Label get_label(const std::string & name) const;
 
     /// Create label
     ///

--- a/include/godzilla/NaturalBC.h
+++ b/include/godzilla/NaturalBC.h
@@ -24,7 +24,7 @@ public:
     /// Get the ID of the field this boundary condition operates on
     ///
     /// @return ID of the field
-    [[nodiscard]] virtual Int get_field_id() const;
+    [[nodiscard]] Int get_field_id() const;
 
     /// Get the component numbers this boundary condition is constraining
     ///

--- a/include/godzilla/NaturalRiemannBC.h
+++ b/include/godzilla/NaturalRiemannBC.h
@@ -20,7 +20,7 @@ public:
     /// Get the ID of the field this boundary condition operates on
     ///
     /// @return ID of the field
-    [[nodiscard]] virtual Int get_field_id() const;
+    [[nodiscard]] Int get_field_id() const;
 
     /// Get the component numbers this boundary condition is constraining
     ///

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -90,6 +90,15 @@ public:
     /// @return Converged reason
     [[nodiscard]] TSConvergedReason get_converged_reason() const;
 
+    /// Set time-stepping scheme
+    void set_scheme(TimeScheme scheme);
+
+    /// Set time-stepping scheme
+    void set_scheme(const std::string & scheme_name);
+
+    /// Get the name of time stepping scheme
+    [[nodiscard]] std::string get_scheme() const;
+
     /// Set simulation time
     ///
     /// @param t New simulation time
@@ -135,8 +144,6 @@ protected:
     void set_up_callbacks();
     /// Set up monitors
     void set_up_monitors();
-    /// Set up time integration scheme
-    virtual void set_up_time_scheme() = 0;
     /// Default TS monitor
     void default_monitor(Int stepi, Real time, const Vector & x);
     /// Check if problem converged
@@ -145,10 +152,6 @@ protected:
     [[nodiscard]] bool converged() const;
     /// Solve
     void solve(Vector & x);
-    /// Set time-stepping scheme
-    void set_scheme(TimeScheme scheme);
-    /// Set time-stepping scheme
-    void set_scheme(const std::string & scheme_name);
 
     /// Sets an *additional* member function to be called at every iteration to monitor the
     /// residual/error etc.
@@ -249,6 +252,9 @@ protected:
     void compute_boundary_local(Real time, Vector & x, Vector & x_t);
 
 private:
+    /// Set up time integration scheme
+    virtual void set_up_time_scheme() = 0;
+
     /// PETSc TS object
     TS ts;
     /// Method for computing right-hand side

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -134,7 +134,7 @@ public:
     [[nodiscard]] Label get_depth_label() const;
 
     /// Return the number of mesh vertices
-    [[nodiscard]] virtual Int get_num_vertices() const;
+    [[nodiscard]] Int get_num_vertices() const;
 
     /// Get range of vertex indices
     ///
@@ -142,7 +142,7 @@ public:
     [[nodiscard]] Range get_vertex_range() const;
 
     /// Return the number of mesh faces
-    [[nodiscard]] virtual Int get_num_faces() const;
+    [[nodiscard]] Int get_num_faces() const;
 
     /// Get range of face indices
     ///
@@ -152,12 +152,12 @@ public:
     /// Return the number of mesh cells (interior)
     ///
     /// @return Number of mesh cells (interior)
-    [[nodiscard]] virtual Int get_num_cells() const;
+    [[nodiscard]] Int get_num_cells() const;
 
     /// Return the number of all mesh cells (interior + ghosted)
     ///
     /// @return Number of all mesh cells (interior + ghosted)
-    [[nodiscard]] virtual Int get_num_all_cells() const;
+    [[nodiscard]] Int get_num_all_cells() const;
 
     /// Get range of cell indices (interior only)
     ///
@@ -200,7 +200,7 @@ public:
     ///
     /// @param cell Cell index
     /// @return Cell type
-    [[nodiscard]] virtual DMPolytopeType get_cell_type(Int cell) const;
+    [[nodiscard]] DMPolytopeType get_cell_type(Int cell) const;
 
     /// Get connectivity
     ///
@@ -243,7 +243,7 @@ public:
     /// Is the first cell in the mesh a simplex?
     ///
     /// @return true if cell is a simplex, otherwise false
-    [[nodiscard]] virtual bool is_simplex() const;
+    [[nodiscard]] bool is_simplex() const;
 
     /// Get cell set name
     ///
@@ -344,7 +344,7 @@ public:
 
     /// Construct ghost cells which connect to every boundary face
     ///
-    virtual void construct_ghost_cells();
+    void construct_ghost_cells();
 
     /// Compute the volume for a given cell
     ///

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -266,7 +266,7 @@ void
 App::run()
 {
     CALL_STACK_MSG();
-    this->create_command_line_options();
+    create_command_line_options();
     auto result = parse_command_line();
     process_command_line(result);
 }

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -537,6 +537,11 @@ DGProblemInterface::create_aux_fields()
 }
 
 void
+DGProblemInterface::set_up_weak_form()
+{
+}
+
+void
 DGProblemInterface::set_up_assembly_data_aux()
 {
     CALL_STACK_MSG();

--- a/src/ExplicitDGLinearProblem.cpp
+++ b/src/ExplicitDGLinearProblem.cpp
@@ -25,9 +25,7 @@ ExplicitDGLinearProblem::ExplicitDGLinearProblem(const Parameters & params) :
     set_default_output_on(EXECUTE_ON_INITIAL | EXECUTE_ON_TIMESTEP);
 }
 
-ExplicitDGLinearProblem::~ExplicitDGLinearProblem()
-{
-}
+ExplicitDGLinearProblem::~ExplicitDGLinearProblem() {}
 
 Real
 ExplicitDGLinearProblem::get_time() const
@@ -107,13 +105,6 @@ ExplicitDGLinearProblem::set_up_initial_guess()
     CALL_STACK_MSG();
     TIMED_EVENT(9, "InitialGuess", "Setting initial guess");
     DiscreteProblemInterface::set_up_initial_guess();
-}
-
-void
-ExplicitDGLinearProblem::set_up_time_scheme()
-{
-    CALL_STACK_MSG();
-    ExplicitProblemInterface::set_up_time_scheme();
 }
 
 void

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -128,13 +128,6 @@ ExplicitFELinearProblem::set_up_callbacks()
 }
 
 void
-ExplicitFELinearProblem::set_up_time_scheme()
-{
-    CALL_STACK_MSG();
-    ExplicitProblemInterface::set_up_time_scheme();
-}
-
-void
 ExplicitFELinearProblem::set_up_monitors()
 {
     CALL_STACK_MSG();

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -106,13 +106,6 @@ ExplicitFVLinearProblem::set_up_initial_guess()
 }
 
 void
-ExplicitFVLinearProblem::set_up_time_scheme()
-{
-    CALL_STACK_MSG();
-    ExplicitProblemInterface::set_up_time_scheme();
-}
-
-void
 ExplicitFVLinearProblem::set_up_monitors()
 {
     CALL_STACK_MSG();

--- a/src/ExplicitProblemInterface.cpp
+++ b/src/ExplicitProblemInterface.cpp
@@ -36,13 +36,6 @@ ExplicitProblemInterface::~ExplicitProblemInterface()
     this->M_lumped_inv.destroy();
 }
 
-std::string
-ExplicitProblemInterface::get_scheme() const
-{
-    CALL_STACK_MSG();
-    return this->scheme;
-}
-
 const Matrix &
 ExplicitProblemInterface::get_mass_matrix() const
 {

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -416,6 +416,15 @@ TransientProblemInterface::set_scheme(const std::string & scheme_name)
     PETSC_CHECK(TSSetType(this->ts, scheme_name.c_str()));
 }
 
+std::string
+TransientProblemInterface::get_scheme() const
+{
+    CALL_STACK_MSG();
+    TSType type;
+    TSGetType(this->ts, &type);
+    return { type };
+}
+
 void
 TransientProblemInterface::monitor_cancel()
 {

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -35,12 +35,6 @@ public:
     }
 
     void
-    set_up_time_scheme() override
-    {
-        ExplicitFELinearProblem::set_up_time_scheme();
-    }
-
-    void
     allocate_mass_matrix()
     {
         ExplicitProblemInterface::allocate_mass_matrix();
@@ -312,16 +306,11 @@ TEST(ExplicitFELinearProblemTest, set_schemes)
     mesh.create();
     prob.create();
 
-    TS ts = prob.get_ts();
-    TSType type;
     std::vector<std::string> schemes = { "euler", "ssp-rk-2", "ssp-rk-3", "rk-2", "heun" };
     std::vector<TSType> types = { TSEULER, TSSSP, TSSSP, TSRK, TSRK };
     for (std::size_t i = 0; i < schemes.size(); i++) {
-        prob_pars.set<std::string>("scheme") = schemes[i];
-        prob.set_up_time_scheme();
-        TSGetType(ts, &type);
-        EXPECT_STREQ(type, types[i]);
-        EXPECT_EQ(prob.get_scheme(), schemes[i]);
+        prob.set_scheme(types[i]);
+        EXPECT_EQ(prob.get_scheme(), types[i]);
     }
 }
 

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -76,12 +76,6 @@ public:
     }
 
     void
-    set_up_time_scheme() override
-    {
-        ExplicitFVLinearProblem::set_up_time_scheme();
-    }
-
-    void
     compute_flux(const Real x[],
                  const Real n[],
                  const Scalar u_l[],
@@ -368,15 +362,17 @@ TEST(ExplicitFVLinearProblemTest, set_schemes)
     mesh.create();
     prob.create();
 
-    TS ts = prob.get_ts();
-    TSType type;
-    std::vector<std::string> schemes = { "euler", "ssp-rk-2", "ssp-rk-3", "rk-2", "heun" };
+    std::vector<TransientProblemInterface::TimeScheme> schemes = {
+        TransientProblemInterface::TimeScheme::EULER,
+        TransientProblemInterface::TimeScheme::SSP_RK_2,
+        TransientProblemInterface::TimeScheme::SSP_RK_3,
+        TransientProblemInterface::TimeScheme::RK_2,
+        TransientProblemInterface::TimeScheme::HEUN
+    };
     std::vector<TSType> types = { TSEULER, TSSSP, TSSSP, TSRK, TSRK };
     for (std::size_t i = 0; i < schemes.size(); i++) {
-        prob_pars.set<std::string>("scheme") = schemes[i];
-        prob.set_up_time_scheme();
-        TSGetType(ts, &type);
-        EXPECT_STREQ(type, types[i]);
+        prob.set_scheme(schemes[i]);
+        EXPECT_EQ(prob.get_scheme(), types[i]);
     }
 }
 

--- a/test/src/GTestImplicitFENonlinearProblem.h
+++ b/test/src/GTestImplicitFENonlinearProblem.h
@@ -10,12 +10,6 @@ public:
     explicit GTestImplicitFENonlinearProblem(const Parameters & params);
     void set_up_initial_guess() override;
 
-    void
-    set_scheme(const char * scheme)
-    {
-        ImplicitFENonlinearProblem::set_scheme(scheme);
-    }
-
 protected:
     void set_up_fields() override;
     void set_up_weak_form() override;

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -154,17 +154,14 @@ TEST_F(ImplicitFENonlinearProblemTest, set_schemes)
     this->mesh->create();
     this->prob->create();
 
-    TS ts = this->prob->get_ts();
-    TSType type;
-    std::vector<std::string> schemes = {
-        "beuler",
-        "cn",
+    std::vector<TransientProblemInterface::TimeScheme> schemes = {
+        TransientProblemInterface::TimeScheme::BEULER,
+        TransientProblemInterface::TimeScheme::CN,
     };
     std::vector<TSType> types = { TSBEULER, TSCN };
-    for (std::size_t i = 0; i < schemes.size(); i++) {
-        prob->set_scheme(types[i]);
-        TSGetType(ts, &type);
-        EXPECT_STREQ(type, types[i]);
+    for (std::size_t i = 0; i < types.size(); i++) {
+        prob->set_scheme(schemes[i]);
+        EXPECT_EQ(prob->get_scheme(), types[i]);
     }
 }
 


### PR DESCRIPTION
- Removing unneeded virtuals from `BoundaryCondition`
- Removing unneeded virtuals from `DependencyEvaluator`
- Removing unneeded virtuals from `EssentialBC`
- Moving `set_up_weak_form` into `DiscreteProblemInterface`
- Removing some virtuals in `DiscreteProblemInterface` and its child classes
- Removing unneeded virtuals from `InitialCondition`
- Removing unneeded virtuals from `Mesh`
- Removing unneeded virtuals from `NaturalBC`
- Removing unneeded virtuals from `NaturalRiemannBC`
- Refactoring `set_up_time_scheme`
- Removing unneeded virtuals from `UnstructuredMesh`
- `App::create_input_file` is private
