### PR TITLE
Maintenance in examples

### DIFF
--- a/examples/advect-eqn/include/InflowBC.h
+++ b/examples/advect-eqn/include/InflowBC.h
@@ -10,7 +10,7 @@ class InflowBC : public NaturalRiemannBC {
 public:
     InflowBC(const Parameters & params);
 
-    const std::vector<PetscInt> & get_components() const override;
+    const std::vector<Int> & get_components() const override;
     void evaluate(PetscReal time,
                   const PetscReal * c,
                   const PetscReal * n,
@@ -20,7 +20,7 @@ public:
 protected:
     /// Inlet velocity
     const PetscReal & inlet_vel;
-    std::vector<PetscInt> components;
+    std::vector<Int> components;
 
 public:
     static Parameters parameters();

--- a/examples/advect-eqn/include/InflowBC.h
+++ b/examples/advect-eqn/include/InflowBC.h
@@ -11,15 +11,15 @@ public:
     InflowBC(const Parameters & params);
 
     const std::vector<Int> & get_components() const override;
-    void evaluate(PetscReal time,
-                  const PetscReal * c,
-                  const PetscReal * n,
+    void evaluate(Real time,
+                  const Real * c,
+                  const Real * n,
                   const PetscScalar * xI,
                   PetscScalar * xG) override;
 
 protected:
     /// Inlet velocity
-    const PetscReal & inlet_vel;
+    const Real & inlet_vel;
     std::vector<Int> components;
 
 public:

--- a/examples/advect-eqn/include/InflowBC.h
+++ b/examples/advect-eqn/include/InflowBC.h
@@ -11,11 +11,8 @@ public:
     InflowBC(const Parameters & params);
 
     const std::vector<Int> & get_components() const override;
-    void evaluate(Real time,
-                  const Real * c,
-                  const Real * n,
-                  const PetscScalar * xI,
-                  PetscScalar * xG) override;
+    void
+    evaluate(Real time, const Real * c, const Real * n, const Scalar * xI, Scalar * xG) override;
 
 protected:
     /// Inlet velocity

--- a/examples/advect-eqn/include/OutflowBC.h
+++ b/examples/advect-eqn/include/OutflowBC.h
@@ -11,11 +11,8 @@ public:
     OutflowBC(const Parameters & params);
 
     const std::vector<Int> & get_components() const override;
-    void evaluate(Real time,
-                  const Real * c,
-                  const Real * n,
-                  const PetscScalar * xI,
-                  PetscScalar * xG) override;
+    void
+    evaluate(Real time, const Real * c, const Real * n, const Scalar * xI, Scalar * xG) override;
 
 protected:
     std::vector<Int> components;

--- a/examples/advect-eqn/include/OutflowBC.h
+++ b/examples/advect-eqn/include/OutflowBC.h
@@ -11,9 +11,9 @@ public:
     OutflowBC(const Parameters & params);
 
     const std::vector<Int> & get_components() const override;
-    void evaluate(PetscReal time,
-                  const PetscReal * c,
-                  const PetscReal * n,
+    void evaluate(Real time,
+                  const Real * c,
+                  const Real * n,
                   const PetscScalar * xI,
                   PetscScalar * xG) override;
 

--- a/examples/advect-eqn/include/OutflowBC.h
+++ b/examples/advect-eqn/include/OutflowBC.h
@@ -10,7 +10,7 @@ class OutflowBC : public NaturalRiemannBC {
 public:
     OutflowBC(const Parameters & params);
 
-    const std::vector<PetscInt> & get_components() const override;
+    const std::vector<Int> & get_components() const override;
     void evaluate(PetscReal time,
                   const PetscReal * c,
                   const PetscReal * n,
@@ -18,7 +18,7 @@ public:
                   PetscScalar * xG) override;
 
 protected:
-    std::vector<PetscInt> components;
+    std::vector<Int> components;
 
 public:
     static Parameters parameters();

--- a/examples/advect-eqn/src/InflowBC.cpp
+++ b/examples/advect-eqn/src/InflowBC.cpp
@@ -26,11 +26,7 @@ InflowBC::get_components() const
 }
 
 void
-InflowBC::evaluate(Real time,
-                   const Real * c,
-                   const Real * n,
-                   const PetscScalar * xI,
-                   PetscScalar * xG)
+InflowBC::evaluate(Real time, const Real * c, const Real * n, const Scalar * xI, Scalar * xG)
 {
     CALL_STACK_MSG();
     xG[0] = this->inlet_vel;

--- a/examples/advect-eqn/src/InflowBC.cpp
+++ b/examples/advect-eqn/src/InflowBC.cpp
@@ -6,13 +6,13 @@ Parameters
 InflowBC::parameters()
 {
     Parameters params = NaturalRiemannBC::parameters();
-    params.add_required_param<PetscReal>("vel", "Inlet velocity");
+    params.add_required_param<Real>("vel", "Inlet velocity");
     return params;
 }
 
 InflowBC::InflowBC(const Parameters & params) :
     NaturalRiemannBC(params),
-    inlet_vel(get_param<PetscReal>("vel")),
+    inlet_vel(get_param<Real>("vel")),
     components({ 0 })
 {
     CALL_STACK_MSG();
@@ -26,9 +26,9 @@ InflowBC::get_components() const
 }
 
 void
-InflowBC::evaluate(PetscReal time,
-                   const PetscReal * c,
-                   const PetscReal * n,
+InflowBC::evaluate(Real time,
+                   const Real * c,
+                   const Real * n,
                    const PetscScalar * xI,
                    PetscScalar * xG)
 {

--- a/examples/advect-eqn/src/InflowBC.cpp
+++ b/examples/advect-eqn/src/InflowBC.cpp
@@ -18,7 +18,7 @@ InflowBC::InflowBC(const Parameters & params) :
     CALL_STACK_MSG();
 }
 
-const std::vector<PetscInt> &
+const std::vector<Int> &
 InflowBC::get_components() const
 {
     CALL_STACK_MSG();

--- a/examples/advect-eqn/src/OutflowBC.cpp
+++ b/examples/advect-eqn/src/OutflowBC.cpp
@@ -14,7 +14,7 @@ OutflowBC::OutflowBC(const Parameters & params) : NaturalRiemannBC(params), comp
     CALL_STACK_MSG();
 }
 
-const std::vector<PetscInt> &
+const std::vector<Int> &
 OutflowBC::get_components() const
 {
     CALL_STACK_MSG();

--- a/examples/advect-eqn/src/OutflowBC.cpp
+++ b/examples/advect-eqn/src/OutflowBC.cpp
@@ -22,11 +22,7 @@ OutflowBC::get_components() const
 }
 
 void
-OutflowBC::evaluate(Real time,
-                    const Real * c,
-                    const Real * n,
-                    const PetscScalar * xI,
-                    PetscScalar * xG)
+OutflowBC::evaluate(Real time, const Real * c, const Real * n, const Scalar * xI, Scalar * xG)
 {
     CALL_STACK_MSG();
     xG[0] = xI[0];

--- a/examples/advect-eqn/src/OutflowBC.cpp
+++ b/examples/advect-eqn/src/OutflowBC.cpp
@@ -22,9 +22,9 @@ OutflowBC::get_components() const
 }
 
 void
-OutflowBC::evaluate(PetscReal time,
-                    const PetscReal * c,
-                    const PetscReal * n,
+OutflowBC::evaluate(Real time,
+                    const Real * c,
+                    const Real * n,
                     const PetscScalar * xI,
                     PetscScalar * xG)
 {

--- a/examples/burgers-eqn/include/BurgersEquation.h
+++ b/examples/burgers-eqn/include/BurgersEquation.h
@@ -17,7 +17,7 @@ protected:
     void set_up_fields() override;
     void set_up_weak_form() override;
 
-    PetscInt u_id;
+    Int u_id;
     const PetscReal & viscosity;
 
 public:

--- a/examples/burgers-eqn/include/BurgersEquation.h
+++ b/examples/burgers-eqn/include/BurgersEquation.h
@@ -11,14 +11,14 @@ public:
     explicit BurgersEquation(const Parameters & parameters);
     void create() override;
 
-    const PetscReal & get_viscosity() const;
+    const Real & get_viscosity() const;
 
 protected:
     void set_up_fields() override;
     void set_up_weak_form() override;
 
     Int u_id;
-    const PetscReal & viscosity;
+    const Real & viscosity;
 
 public:
     static Parameters parameters();

--- a/examples/burgers-eqn/src/BurgersEquation.cpp
+++ b/examples/burgers-eqn/src/BurgersEquation.cpp
@@ -26,7 +26,7 @@ public:
     }
 
 protected:
-    const PetscReal & visc;
+    const Real & visc;
     const FieldValue & u;
     const FieldGradient & u_x;
 };
@@ -39,13 +39,13 @@ Parameters
 BurgersEquation::parameters()
 {
     Parameters params = ExplicitFELinearProblem::parameters();
-    params.add_param<PetscReal>("viscosity", "Viscosity");
+    params.add_param<Real>("viscosity", "Viscosity");
     return params;
 }
 
 BurgersEquation::BurgersEquation(const Parameters & parameters) :
     ExplicitFELinearProblem(parameters),
-    viscosity(get_param<PetscReal>("viscosity"))
+    viscosity(get_param<Real>("viscosity"))
 {
     CALL_STACK_MSG();
 }
@@ -58,7 +58,7 @@ BurgersEquation::create()
     create_mass_matrix();
 }
 
-const PetscReal &
+const Real &
 BurgersEquation::get_viscosity() const
 {
     CALL_STACK_MSG();

--- a/examples/burgers-eqn/src/BurgersEquation.cpp
+++ b/examples/burgers-eqn/src/BurgersEquation.cpp
@@ -19,7 +19,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         f[0] = -this->visc * this->u_x(0) + 0.5 * this->u(0) * this->u(0);

--- a/examples/heat-eqn/include/ConvectiveHeatFluxBC.h
+++ b/examples/heat-eqn/include/ConvectiveHeatFluxBC.h
@@ -8,12 +8,12 @@ class ConvectiveHeatFluxBC : public NaturalBC {
 public:
     ConvectiveHeatFluxBC(const Parameters & params);
 
-    const std::vector<PetscInt> & get_components() const override;
+    const std::vector<Int> & get_components() const override;
 
 protected:
     void set_up_weak_form() override;
 
-    std::vector<PetscInt> components;
+    std::vector<Int> components;
 
 public:
     static Parameters parameters();

--- a/examples/heat-eqn/include/HeatEquationExplicit.h
+++ b/examples/heat-eqn/include/HeatEquationExplicit.h
@@ -17,10 +17,10 @@ protected:
     void set_up_fields() override;
     void set_up_weak_form() override;
 
-    PetscInt temp_id;
-    PetscInt ffn_aux_id;
+    Int temp_id;
+    Int ffn_aux_id;
     /// Polynomial order of the FE space
-    PetscInt order;
+    Int order;
 
 public:
     static Parameters parameters();

--- a/examples/heat-eqn/include/HeatEquationProblem.h
+++ b/examples/heat-eqn/include/HeatEquationProblem.h
@@ -14,12 +14,12 @@ protected:
     void set_up_fields() override;
     void set_up_weak_form() override;
 
-    PetscInt temp_id;
-    PetscInt q_ppp_id;
-    PetscInt htc_aux_id;
-    PetscInt T_ambient_aux_id;
+    Int temp_id;
+    Int q_ppp_id;
+    Int htc_aux_id;
+    Int T_ambient_aux_id;
     /// Polynomial order of the FE space
-    const PetscInt & p_order;
+    const Int & p_order;
 
 public:
     static Parameters parameters();

--- a/examples/heat-eqn/src/ConvectiveHeatFluxBC.cpp
+++ b/examples/heat-eqn/src/ConvectiveHeatFluxBC.cpp
@@ -62,7 +62,7 @@ ConvectiveHeatFluxBC::ConvectiveHeatFluxBC(const Parameters & params) :
     CALL_STACK_MSG();
 }
 
-const std::vector<PetscInt> &
+const std::vector<Int> &
 ConvectiveHeatFluxBC::get_components() const
 {
     return this->components;

--- a/examples/heat-eqn/src/ConvectiveHeatFluxBC.cpp
+++ b/examples/heat-eqn/src/ConvectiveHeatFluxBC.cpp
@@ -19,7 +19,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         f[0] = htc(0) * (T(0) - T_infinity(0));
@@ -36,7 +36,7 @@ public:
     explicit Jacobian0(const NaturalBC * nbc) : BndJacobianFunc(nbc), htc(get_field_value("htc")) {}
 
     void
-    evaluate(PetscScalar g[]) const override
+    evaluate(Scalar g[]) const override
     {
         CALL_STACK_MSG();
         g[0] = htc(0);

--- a/examples/heat-eqn/src/HeatEquationExplicit.cpp
+++ b/examples/heat-eqn/src/HeatEquationExplicit.cpp
@@ -40,12 +40,12 @@ public:
     evaluate(PetscScalar f[]) const override
     {
         CALL_STACK_MSG();
-        for (PetscInt d = 0; d < this->dim; ++d)
+        for (Int d = 0; d < this->dim; ++d)
             f[d] = -this->T_x(d);
     }
 
 protected:
-    const PetscInt & dim;
+    const Int & dim;
     const FieldGradient & T_x;
 };
 
@@ -55,13 +55,13 @@ Parameters
 HeatEquationExplicit::parameters()
 {
     Parameters params = ExplicitFELinearProblem::parameters();
-    params.add_param<PetscInt>("order", 1, "Polynomial order of the FE space");
+    params.add_param<Int>("order", 1, "Polynomial order of the FE space");
     return params;
 }
 
 HeatEquationExplicit::HeatEquationExplicit(const Parameters & parameters) :
     ExplicitFELinearProblem(parameters),
-    order(get_param<PetscInt>("order"))
+    order(get_param<Int>("order"))
 {
     CALL_STACK_MSG();
 }

--- a/examples/heat-eqn/src/HeatEquationExplicit.cpp
+++ b/examples/heat-eqn/src/HeatEquationExplicit.cpp
@@ -17,7 +17,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         f[0] = -this->ffn(0);
@@ -37,7 +37,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         for (Int d = 0; d < this->dim; ++d)

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -43,12 +43,12 @@ public:
     evaluate(PetscScalar f[]) const override
     {
         CALL_STACK_MSG();
-        for (PetscInt d = 0; d < this->dim; ++d)
+        for (Int d = 0; d < this->dim; ++d)
             f[d] = this->T_x(d);
     }
 
 protected:
-    const PetscInt & dim;
+    const Int & dim;
     const FieldGradient & T_x;
 };
 
@@ -79,12 +79,12 @@ public:
     evaluate(PetscScalar g[]) const override
     {
         CALL_STACK_MSG();
-        for (PetscInt d = 0; d < this->dim; ++d)
+        for (Int d = 0; d < this->dim; ++d)
             g[d * this->dim + d] = 1.0;
     }
 
 protected:
-    const PetscInt & dim;
+    const Int & dim;
 };
 
 } // namespace
@@ -93,13 +93,13 @@ Parameters
 HeatEquationProblem::parameters()
 {
     Parameters params = ImplicitFENonlinearProblem::parameters();
-    params.add_param<PetscInt>("p_order", 1, "Polynomial order of FE space");
+    params.add_param<Int>("p_order", 1, "Polynomial order of FE space");
     return params;
 }
 
 HeatEquationProblem::HeatEquationProblem(const Parameters & parameters) :
     ImplicitFENonlinearProblem(parameters),
-    p_order(get_param<PetscInt>("p_order"))
+    p_order(get_param<Int>("p_order"))
 {
     CALL_STACK_MSG();
 }

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -66,7 +66,7 @@ public:
     }
 
 protected:
-    const PetscReal & T_t_shift;
+    const Real & T_t_shift;
 };
 
 class Jacobian3 : public JacobianFunc {

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -19,7 +19,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         f[0] = this->T_t(0) - this->q_ppp(0);
@@ -40,7 +40,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         for (Int d = 0; d < this->dim; ++d)
@@ -59,7 +59,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar g[]) const override
+    evaluate(Scalar g[]) const override
     {
         CALL_STACK_MSG();
         g[0] = this->T_t_shift * 1.0;
@@ -76,7 +76,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar g[]) const override
+    evaluate(Scalar g[]) const override
     {
         CALL_STACK_MSG();
         for (Int d = 0; d < this->dim; ++d)

--- a/examples/ns-incomp/include/NSIncompressibleProblem.h
+++ b/examples/ns-incomp/include/NSIncompressibleProblem.h
@@ -10,7 +10,7 @@ class NSIncompressibleProblem : public ImplicitFENonlinearProblem {
 public:
     explicit NSIncompressibleProblem(const Parameters & parameters);
 
-    const PetscReal & get_reynolds_number() const;
+    const Real & get_reynolds_number() const;
 
 protected:
     void set_up_fields() override;
@@ -23,7 +23,7 @@ protected:
     Int pressure_id;
     Int ffn_aid;
     /// Reynolds number
-    const PetscReal & Re;
+    const Real & Re;
 
 public:
     static Parameters parameters();

--- a/examples/ns-incomp/include/NSIncompressibleProblem.h
+++ b/examples/ns-incomp/include/NSIncompressibleProblem.h
@@ -19,9 +19,9 @@ protected:
     void set_up_field_null_space(DM dm) override;
     Preconditioner create_preconditioner(PC pc) override;
 
-    PetscInt velocity_id;
-    PetscInt pressure_id;
-    PetscInt ffn_aid;
+    Int velocity_id;
+    Int pressure_id;
+    Int ffn_aid;
     /// Reynolds number
     const PetscReal & Re;
 

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -157,7 +157,7 @@ public:
 protected:
     const Int & dim;
     const FieldGradient & vel_x;
-    const PetscReal & u_t_shift;
+    const Real & u_t_shift;
 };
 
 class JacobianVV1 : public JacobianFunc {
@@ -257,7 +257,7 @@ public:
 protected:
     const Int & n_comp;
     const Int & dim;
-    const PetscReal & Re;
+    const Real & Re;
 };
 
 } // namespace
@@ -266,18 +266,18 @@ Parameters
 NSIncompressibleProblem::parameters()
 {
     Parameters params = ImplicitFENonlinearProblem::parameters();
-    params.add_required_param<PetscReal>("Re", "Reynolds number");
+    params.add_required_param<Real>("Re", "Reynolds number");
     return params;
 }
 
 NSIncompressibleProblem::NSIncompressibleProblem(const Parameters & parameters) :
     ImplicitFENonlinearProblem(parameters),
-    Re(get_param<PetscReal>("Re"))
+    Re(get_param<Real>("Re"))
 {
     CALL_STACK_MSG();
 }
 
-const PetscReal &
+const Real &
 NSIncompressibleProblem::get_reynolds_number() const
 {
     CALL_STACK_MSG();

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -29,7 +29,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         for (Int c = 0; c < this->n_comp; ++c) {
@@ -64,7 +64,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         for (Int comp = 0; comp < this->n_comp; ++comp) {
@@ -80,7 +80,7 @@ protected:
     const Int & dim;
     const FieldGradient & vel_x;
     const FieldValue & press;
-    const PetscScalar & Re;
+    const Scalar & Re;
 };
 
 class ResidualPress0 : public ResidualFunc {
@@ -93,7 +93,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         f[0] = 0.0;
@@ -115,7 +115,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         for (Int d = 0; d < this->dim; ++d)
@@ -137,7 +137,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar g[]) const override
+    evaluate(Scalar g[]) const override
     {
         CALL_STACK_MSG();
         Int nc_i = this->dim;
@@ -170,7 +170,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar g[]) const override
+    evaluate(Scalar g[]) const override
     {
         CALL_STACK_MSG();
         Int nc_i = this->dim;
@@ -201,7 +201,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar g[]) const override
+    evaluate(Scalar g[]) const override
     {
         CALL_STACK_MSG();
         for (Int d = 0; d < this->dim; ++d)
@@ -221,7 +221,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar g[]) const override
+    evaluate(Scalar g[]) const override
     {
         CALL_STACK_MSG();
         for (Int d = 0; d < this->dim; ++d)
@@ -243,7 +243,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar g[]) const override
+    evaluate(Scalar g[]) const override
     {
         CALL_STACK_MSG();
         for (Int comp_i = 0; comp_i < this->n_comp; ++comp_i) {

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -32,10 +32,10 @@ public:
     evaluate(PetscScalar f[]) const override
     {
         CALL_STACK_MSG();
-        for (PetscInt c = 0; c < this->n_comp; ++c) {
+        for (Int c = 0; c < this->n_comp; ++c) {
             f[c] = this->vel_t(c);
 
-            for (PetscInt d = 0; d < this->dim; ++d)
+            for (Int d = 0; d < this->dim; ++d)
                 f[c] += this->vel(d) * this->vel_x(c * this->dim + d);
 
             f[c] -= this->ffn(c);
@@ -43,8 +43,8 @@ public:
     }
 
 protected:
-    const PetscInt & n_comp;
-    const PetscInt & dim;
+    const Int & n_comp;
+    const Int & dim;
     const FieldValue & vel;
     const FieldValue & vel_t;
     const FieldGradient & vel_x;
@@ -67,8 +67,8 @@ public:
     evaluate(PetscScalar f[]) const override
     {
         CALL_STACK_MSG();
-        for (PetscInt comp = 0; comp < this->n_comp; ++comp) {
-            for (PetscInt d = 0; d < this->dim; ++d) {
+        for (Int comp = 0; comp < this->n_comp; ++comp) {
+            for (Int d = 0; d < this->dim; ++d) {
                 f[comp * this->dim + d] = 1.0 / this->Re * this->vel_x(comp * this->dim + d);
             }
             f[comp * this->dim + comp] -= this->press(0);
@@ -76,8 +76,8 @@ public:
     }
 
 protected:
-    const PetscInt & n_comp;
-    const PetscInt & dim;
+    const Int & n_comp;
+    const Int & dim;
     const FieldGradient & vel_x;
     const FieldValue & press;
     const PetscScalar & Re;
@@ -97,12 +97,12 @@ public:
     {
         CALL_STACK_MSG();
         f[0] = 0.0;
-        for (PetscInt d = 0; d < this->dim; ++d)
+        for (Int d = 0; d < this->dim; ++d)
             f[0] += this->vel_x(d * this->dim + d);
     }
 
 protected:
-    const PetscInt & dim;
+    const Int & dim;
     const FieldGradient & vel_x;
 };
 
@@ -118,12 +118,12 @@ public:
     evaluate(PetscScalar f[]) const override
     {
         CALL_STACK_MSG();
-        for (PetscInt d = 0; d < this->dim; ++d)
+        for (Int d = 0; d < this->dim; ++d)
             f[d] = 0.0;
     }
 
 protected:
-    const PetscInt & dim;
+    const Int & dim;
 };
 
 class JacobianVV0 : public JacobianFunc {
@@ -140,22 +140,22 @@ public:
     evaluate(PetscScalar g[]) const override
     {
         CALL_STACK_MSG();
-        PetscInt nc_i = this->dim;
-        PetscInt nc_j = this->dim;
+        Int nc_i = this->dim;
+        Int nc_j = this->dim;
 
-        for (PetscInt d = 0; d < this->dim; ++d) {
+        for (Int d = 0; d < this->dim; ++d) {
             g[d * this->dim + d] = this->u_t_shift;
         }
 
-        for (PetscInt fc = 0; fc < nc_i; ++fc) {
-            for (PetscInt gc = 0; gc < nc_j; ++gc) {
+        for (Int fc = 0; fc < nc_i; ++fc) {
+            for (Int gc = 0; gc < nc_j; ++gc) {
                 g[fc * nc_j + gc] += this->vel_x(fc * nc_j + gc);
             }
         }
     }
 
 protected:
-    const PetscInt & dim;
+    const Int & dim;
     const FieldGradient & vel_x;
     const PetscReal & u_t_shift;
 };
@@ -173,12 +173,12 @@ public:
     evaluate(PetscScalar g[]) const override
     {
         CALL_STACK_MSG();
-        PetscInt nc_i = this->dim;
-        PetscInt nc_j = this->dim;
+        Int nc_i = this->dim;
+        Int nc_j = this->dim;
 
-        for (PetscInt fc = 0; fc < nc_i; ++fc) {
-            for (PetscInt gc = 0; gc < nc_j; ++gc) {
-                for (PetscInt dg = 0; dg < this->dim; ++dg) {
+        for (Int fc = 0; fc < nc_i; ++fc) {
+            for (Int gc = 0; gc < nc_j; ++gc) {
+                for (Int dg = 0; dg < this->dim; ++dg) {
                     // kronecker delta
                     if (fc == gc)
                         g[(fc * nc_j + gc) * this->dim + dg] += this->vel(dg);
@@ -188,7 +188,7 @@ public:
     }
 
 protected:
-    const PetscInt & dim;
+    const Int & dim;
     const FieldValue & vel;
 };
 
@@ -204,12 +204,12 @@ public:
     evaluate(PetscScalar g[]) const override
     {
         CALL_STACK_MSG();
-        for (PetscInt d = 0; d < this->dim; ++d)
+        for (Int d = 0; d < this->dim; ++d)
             g[d * this->dim + d] = 1.0;
     }
 
 protected:
-    const PetscInt & dim;
+    const Int & dim;
 };
 
 class JacobianVP2 : public JacobianFunc {
@@ -224,12 +224,12 @@ public:
     evaluate(PetscScalar g[]) const override
     {
         CALL_STACK_MSG();
-        for (PetscInt d = 0; d < this->dim; ++d)
+        for (Int d = 0; d < this->dim; ++d)
             g[d * this->dim + d] = -1.0;
     }
 
 protected:
-    const PetscInt & dim;
+    const Int & dim;
 };
 
 class JacobianVV3 : public JacobianFunc {
@@ -246,8 +246,8 @@ public:
     evaluate(PetscScalar g[]) const override
     {
         CALL_STACK_MSG();
-        for (PetscInt comp_i = 0; comp_i < this->n_comp; ++comp_i) {
-            for (PetscInt d = 0; d < this->dim; ++d) {
+        for (Int comp_i = 0; comp_i < this->n_comp; ++comp_i) {
+            for (Int d = 0; d < this->dim; ++d) {
                 g[((comp_i * this->n_comp + comp_i) * this->dim + d) * this->dim + d] =
                     1.0 / this->Re;
             }
@@ -255,8 +255,8 @@ public:
     }
 
 protected:
-    const PetscInt & n_comp;
-    const PetscInt & dim;
+    const Int & n_comp;
+    const Int & dim;
     const PetscReal & Re;
 };
 
@@ -290,7 +290,7 @@ NSIncompressibleProblem::set_up_fields()
     CALL_STACK_MSG();
     const char * comp_name[] = { "velocity_x", "velocity_y", "velocity_z" };
 
-    PetscInt dim = this->get_dimension();
+    Int dim = this->get_dimension();
     velocity_id = add_field("velocity", dim, 2);
     for (unsigned int i = 0; i < dim; i++)
         set_field_component_name(velocity_id, i, comp_name[i]);
@@ -351,7 +351,7 @@ NSIncompressibleProblem::create_preconditioner(PC pc)
         PetscObjectCompose((PetscObject) (IS) fdecomp.is[1], "nullspace", (PetscObject) nsp));
     PETSC_CHECK(MatNullSpaceDestroy(&nsp));
     // TODO: fdecomp.is[1].attach_null_space("nullspace");
-    for (PetscInt i = 0; i < fdecomp.get_num_fields(); i++)
+    for (Int i = 0; i < fdecomp.get_num_fields(); i++)
         fsplit.set_is(fdecomp.field_name[i], fdecomp.is[i]);
     fdecomp.destroy();
 

--- a/examples/poisson/include/PoissonEquation.h
+++ b/examples/poisson/include/PoissonEquation.h
@@ -15,11 +15,11 @@ protected:
     void set_up_weak_form() override;
 
     /// Polynomial order of the FE space
-    PetscInt p_order;
+    Int p_order;
     /// ID for the "u" field
-    PetscInt iu;
+    Int iu;
     /// ID for the forcing function field
-    PetscInt affn;
+    Int affn;
 
 public:
     static Parameters parameters();

--- a/examples/poisson/include/PoissonPDE.h
+++ b/examples/poisson/include/PoissonPDE.h
@@ -11,7 +11,7 @@ public:
     Residual0(FEProblemInterface * fepi) : ResidualFunc(fepi), ffn(get_field_value("forcing_fn")) {}
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         f[0] = -this->ffn(0);
@@ -31,7 +31,7 @@ public:
     }
 
     void
-    evaluate(PetscScalar f[]) const override
+    evaluate(Scalar f[]) const override
     {
         CALL_STACK_MSG();
         for (Int d = 0; d < this->dim; ++d)
@@ -48,7 +48,7 @@ public:
     Jacobian3(FEProblemInterface * fepi) : JacobianFunc(fepi), dim(get_spatial_dimension()) {}
 
     void
-    evaluate(PetscScalar g[]) const override
+    evaluate(Scalar g[]) const override
     {
         CALL_STACK_MSG();
         for (Int d = 0; d < this->dim; ++d)

--- a/examples/poisson/include/PoissonPDE.h
+++ b/examples/poisson/include/PoissonPDE.h
@@ -34,12 +34,12 @@ public:
     evaluate(PetscScalar f[]) const override
     {
         CALL_STACK_MSG();
-        for (PetscInt d = 0; d < this->dim; ++d)
+        for (Int d = 0; d < this->dim; ++d)
             f[d] = this->u_x(d);
     }
 
 protected:
-    const PetscInt & dim;
+    const Int & dim;
     const FieldGradient & u_x;
 };
 
@@ -51,10 +51,10 @@ public:
     evaluate(PetscScalar g[]) const override
     {
         CALL_STACK_MSG();
-        for (PetscInt d = 0; d < this->dim; ++d)
+        for (Int d = 0; d < this->dim; ++d)
             g[d * this->dim + d] = 1.0;
     }
 
 protected:
-    const PetscInt & dim;
+    const Int & dim;
 };

--- a/examples/poisson/src/PoissonEquation.cpp
+++ b/examples/poisson/src/PoissonEquation.cpp
@@ -11,13 +11,13 @@ Parameters
 PoissonEquation::parameters()
 {
     Parameters params = FENonlinearProblem::parameters();
-    params.add_param<PetscInt>("p_order", 1., "Polynomial order of the FE space.");
+    params.add_param<Int>("p_order", 1., "Polynomial order of the FE space.");
     return params;
 }
 
 PoissonEquation::PoissonEquation(const Parameters & parameters) :
     FENonlinearProblem(parameters),
-    p_order(get_param<PetscInt>("p_order"))
+    p_order(get_param<Int>("p_order"))
 {
     CALL_STACK_MSG();
 }

--- a/src/PCFieldSplit.cpp
+++ b/src/PCFieldSplit.cpp
@@ -121,7 +121,7 @@ std::vector<KrylovSolver>
 PCFieldSplit::get_sub_ksp() const
 {
     CALL_STACK_MSG();
-    PetscInt n;
+    Int n;
     KSP * subksp;
     PETSC_CHECK(PCFieldSplitGetSubKSP(this->pc, &n, &subksp));
     std::vector<KrylovSolver> sks(n);
@@ -144,7 +144,7 @@ std::vector<KrylovSolver>
 PCFieldSplit::schur_get_sub_ksp() const
 {
     CALL_STACK_MSG();
-    PetscInt n;
+    Int n;
     KSP * subksp;
     PETSC_CHECK(PCFieldSplitSchurGetSubKSP(this->pc, &n, &subksp));
     std::vector<KrylovSolver> sks(n);

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -357,11 +357,11 @@ Problem::create_field_decomposition()
     IS * is;
     PETSC_CHECK(DMCreateFieldDecomposition(get_dm(), &n, &field_names, &is, nullptr));
     FieldDecomposition decomp(n);
-    for (PetscInt i = 0; i < n; i++) {
+    for (Int i = 0; i < n; i++) {
         decomp.field_name[i] = field_names[i];
         decomp.is[i] = IndexSet(is[i]);
     }
-    for (PetscInt i = 0; i < n; i++)
+    for (Int i = 0; i < n; i++)
         PetscFree(field_names[i]);
     PetscFree(field_names);
     PetscFree(is);

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -659,8 +659,8 @@ UnstructuredMesh::stratify()
 std::vector<Int>
 UnstructuredMesh::get_full_join(const std::vector<Int> & points)
 {
-    PetscInt n_covered_points;
-    const PetscInt * covered_points;
+    Int n_covered_points;
+    const Int * covered_points;
     PETSC_CHECK(DMPlexGetFullJoin(get_dm(),
                                   points.size(),
                                   points.data(),

--- a/test/src/PCFieldSplit_test.cpp
+++ b/test/src/PCFieldSplit_test.cpp
@@ -196,7 +196,7 @@ TEST(PCFieldSplit, schur)
     fs.set_dm_splits(true);
     EXPECT_TRUE(fs.get_dm_splits());
     std::vector<std::string> fld_name = { "split0", "split1" };
-    for (PetscInt i = 0; i < fdecomp.get_num_fields(); i++)
+    for (Int i = 0; i < fdecomp.get_num_fields(); i++)
         fs.set_is(fld_name[i], fdecomp.is[i]);
 
     auto is0 = fs.get_is("split0");


### PR DESCRIPTION
- Replace `PetscInt` with `Int`
- Replace `PetscInt` with `Int` in examples
- Replace `PetscReal` with `Real` in examples
- Replace `PetscScalar` with `Scalar` in examples
