### PR TITLE
Less delegates and less virtuals

### DIFF
--- a/include/godzilla/Delegate.h
+++ b/include/godzilla/Delegate.h
@@ -44,6 +44,12 @@ public:
         return this->fn(args...);
     }
 
+    void
+    reset()
+    {
+        this->fn = nullptr;
+    }
+
     /// Check whether delegates is callable
     operator bool() const { return static_cast<bool>(this->fn); }
 

--- a/include/godzilla/ExplicitDGLinearProblem.h
+++ b/include/godzilla/ExplicitDGLinearProblem.h
@@ -18,8 +18,8 @@ public:
     ~ExplicitDGLinearProblem() override;
 
     void create() override;
-    bool converged() override;
-    void solve() override;
+    void run() override;
+    bool converged();
     [[nodiscard]] Real get_time() const override;
     [[nodiscard]] Int get_step_num() const override;
     void compute_solution_vector_local() override;
@@ -31,6 +31,10 @@ protected:
     void set_up_initial_guess() override;
     void set_up_monitors() override;
     void post_step() override;
+
+private:
+    void compute_residual(const Vector & x, Vector & f) final;
+    void compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp) final;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/ExplicitFELinearProblem.h
+++ b/include/godzilla/ExplicitFELinearProblem.h
@@ -18,8 +18,8 @@ public:
     [[nodiscard]] Real get_time() const override;
     [[nodiscard]] Int get_step_num() const override;
     void create() override;
-    bool converged() override;
-    void solve() override;
+    void run() override;
+    bool converged();
     void compute_solution_vector_local() override;
 
 protected:

--- a/include/godzilla/ExplicitFVLinearProblem.h
+++ b/include/godzilla/ExplicitFVLinearProblem.h
@@ -17,8 +17,8 @@ public:
     explicit ExplicitFVLinearProblem(const Parameters & params);
 
     void create() override;
-    bool converged() override;
-    void solve() override;
+    void run() override;
+    bool converged();
     [[nodiscard]] Real get_time() const override;
     [[nodiscard]] Int get_step_num() const override;
     void compute_solution_vector_local() override;
@@ -33,6 +33,8 @@ protected:
 
 private:
     void compute_rhs_local(Real time, const Vector & x, Vector & F) override;
+    void compute_residual(const Vector & x, Vector & f) final;
+    void compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp) final;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/ExplicitProblemInterface.h
+++ b/include/godzilla/ExplicitProblemInterface.h
@@ -32,23 +32,24 @@ protected:
     void create_mass_matrix();
     void create_mass_matrix_lumped();
 
-private:
-    void set_up_time_scheme() override;
-
-    /// Form the global residual 'F' from the global input 'x' using pointwise functions specified
-    /// by the user
-    /// @param time The time
-    /// @param x Global solution
-    /// @param F Global output vector
-    void compute_rhs(Real time, const Vector & x, Vector & F);
-
     /// Form the local residual 'F' from the local input 'x' using pointwise functions specified by
     /// the user
     ///
     /// @param time The time
     /// @param x Local solution
     /// @param F Local output vector
-    virtual void compute_rhs_local(Real time, const Vector & x, Vector & F) = 0;
+    virtual void compute_rhs_local(Real time, const Vector & x, Vector & F);
+
+private:
+    void set_up_time_scheme() override;
+
+    /// Form the global residual 'F' from the global input 'x' using pointwise functions specified
+    /// by the user
+    ///
+    /// @param time The time
+    /// @param x Global solution
+    /// @param F Global output vector
+    void compute_rhs_function(Real time, const Vector & x, Vector & F);
 
     /// Nonlinear problem
     NonlinearProblem * nl_problem;

--- a/include/godzilla/FENonlinearProblem.h
+++ b/include/godzilla/FENonlinearProblem.h
@@ -117,8 +117,8 @@ protected:
                                               const IndexSet & facets);
 
 private:
-    void compute_residual(const Vector & x, Vector & f);
-    void compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp);
+    void compute_residual(const Vector & x, Vector & f) override;
+    void compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp) override;
 
     enum State { INITIAL, FINAL } state;
     /// Delegate for compute_boundary

--- a/include/godzilla/FENonlinearProblem.h
+++ b/include/godzilla/FENonlinearProblem.h
@@ -68,7 +68,6 @@ protected:
 
     void compute_boundary(Vector & x);
 
-    void compute_residual(const Vector & x, Vector & f);
     void compute_residual_internal(DM dm,
                                    PetscFormKey key,
                                    const IndexSet & cells,
@@ -87,7 +86,6 @@ protected:
                                               DMField coord_field,
                                               const IndexSet & facets);
 
-    void compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp);
     void compute_jacobian_internal(DM dm,
                                    PetscFormKey key,
                                    const IndexSet & cell_is,
@@ -119,6 +117,9 @@ protected:
                                               const IndexSet & facets);
 
 private:
+    void compute_residual(const Vector & x, Vector & f);
+    void compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp);
+
     enum State { INITIAL, FINAL } state;
     /// Delegate for compute_boundary
     Delegate<void(Vector &)> compute_boundary_delegate;

--- a/include/godzilla/ImplicitFENonlinearProblem.h
+++ b/include/godzilla/ImplicitFENonlinearProblem.h
@@ -14,8 +14,8 @@ public:
     ~ImplicitFENonlinearProblem() override;
 
     void create() override;
-    bool converged() override;
-    void solve() override;
+    void run() override;
+    bool converged();
     [[nodiscard]] Real get_time() const override;
     [[nodiscard]] Int get_step_num() const override;
     void compute_solution_vector_local() override;

--- a/include/godzilla/LinearProblem.h
+++ b/include/godzilla/LinearProblem.h
@@ -52,7 +52,7 @@ private:
     virtual void compute_operators(Matrix & A, Matrix & B) = 0;
 
     /// Monitor callback
-    void monitor(Int it, Real rnorm);
+    virtual void monitor(Int it, Real rnorm);
 
     /// KSP object
     KrylovSolver ks;

--- a/include/godzilla/LinearProblem.h
+++ b/include/godzilla/LinearProblem.h
@@ -11,53 +11,58 @@
 
 namespace godzilla {
 
-/// PETSc Linear problem
+/// Linear problem
 ///
 class LinearProblem : public Problem {
 public:
     explicit LinearProblem(const Parameters & parameters);
     ~LinearProblem() override;
-
     void create() override;
     void run() override;
 
-    /// true if solve converged, otherwise false
-    virtual bool converged();
-    /// Method to compute right-hand side. Called from the PETsc callback
-    virtual void compute_rhs(Vector & b);
-    /// Method to compute operators. Called from the PETsc callback
-    virtual void compute_operators(Matrix & A, Matrix & B);
-    /// Monitor callback
-    void monitor(Int it, Real rnorm);
-
-protected:
-    /// Initialize the problem
-    virtual void init();
-    /// Allocate Jacobian/residual objects
-    void allocate_objects() override;
-    /// Setup computation of residual and Jacobian callbacks
-    virtual void set_up_callbacks();
-    /// Setup monitors
-    virtual void set_up_monitors();
-    /// Setup solver parameters
-    virtual void set_up_solver_parameters();
-    /// Method for setting matrix properties
-    virtual void set_up_matrix_properties();
-    /// Method for creating a preconditioner
-    virtual Preconditioner create_preconditioner(PC pc);
     /// Solve the problem
-    virtual void solve();
+    void solve();
+
+    /// true if solve converged, otherwise false
+    bool converged();
 
 private:
-    void set_up_preconditioning();
+    /// Initialize the problem
+    virtual void init();
+
+    /// Allocate Jacobian/residual objects
+    void allocate_objects() override;
+
+    /// Setup computation of residual and Jacobian callbacks
+    virtual void set_up_callbacks();
+
+    /// Setup monitors
+    virtual void set_up_monitors();
+
+    /// Setup solver parameters
+    virtual void set_up_solver_parameters();
+
+    /// Method for setting matrix properties
+    virtual void set_up_matrix_properties();
+
+    /// Method for creating a preconditioner
+    virtual Preconditioner create_preconditioner(PC pc);
+
+    /// Method to compute right-hand side
+    virtual void compute_rhs(Vector & b) = 0;
+
+    /// Method to compute operators
+    virtual void compute_operators(Matrix & A, Matrix & B) = 0;
+
+    /// Monitor callback
+    void monitor(Int it, Real rnorm);
 
     /// KSP object
     KrylovSolver ks;
     /// The right-hand side vector
     Vector b;
     /// Preconditioner
-    Preconditioner precond;
-
+    Preconditioner pc;
     /// Relative convergence tolerance for the linear solver
     Real lin_rel_tol;
     /// Absolute convergence tolerance for the linear solver

--- a/include/godzilla/LinearProblem.h
+++ b/include/godzilla/LinearProblem.h
@@ -20,9 +20,6 @@ public:
     void create() override;
     void run() override;
 
-    /// Solve the problem
-    void solve();
-
     /// true if solve converged, otherwise false
     bool converged();
 

--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -11,7 +11,7 @@
 
 namespace godzilla {
 
-/// PETSc non-linear problem
+/// Nonlinear problem
 ///
 class NonlinearProblem : public Problem {
 public:
@@ -23,12 +23,15 @@ public:
 
     /// Get underlying KSP
     [[nodiscard]] KrylovSolver get_ksp() const;
+
     /// Set KSP operators
     void set_ksp_operators(const Matrix & A, const Matrix & B);
+
     /// Get Jacobian matrix
     [[nodiscard]] const Matrix & get_jacobian() const;
+
     /// true if solve converged, otherwise false
-    virtual bool converged();
+    bool converged();
 
     /// Use matrix free finite difference matrix vector products to apply the Jacobian
     ///
@@ -39,69 +42,68 @@ public:
 protected:
     /// Get underlying non-linear solver
     [[nodiscard]] SNESolver get_snes() const;
+
     /// Set non-linear solver
     void set_snes(const SNESolver & snes);
+
     /// Set residual vector
     void set_residual_vector(const Vector & f);
+
     /// Set Jacobian matrix
     void set_jacobian_matrix(const Matrix & J);
+
     /// Initialize the problem
     virtual void init();
+
     /// Set up initial guess
     virtual void set_up_initial_guess();
+
     /// Allocate Jacobian/residual objects
     void allocate_objects() override;
-    /// Set up line search
-    virtual void set_up_line_search();
+
     /// Set up computation of residual and Jacobian callbacks
     virtual void set_up_callbacks();
+
     /// Set up monitors
     virtual void set_up_monitors();
+
     /// Set up solve type
     virtual void set_up_solve_type();
-    /// Set up solver parameters
-    virtual void set_up_solver_parameters();
-    /// Set the function evaluation routine
-    template <class T>
-    void
-    set_function(T * instance, void (T::*callback)(const Vector &, Vector &))
-    {
-        this->snes.set_function(this->r, instance, callback);
-    }
-    /// Set the function to compute Jacobian
-    template <class T>
-    void
-    set_jacobian(T * instance, void (T::*callback)(const Vector &, Matrix &, Matrix &))
-    {
-        this->snes.set_jacobian(this->J, this->J, instance, callback);
-    }
+
     /// SNES monitor
     void snes_monitor(Int it, Real norm);
+
     /// KSP monitor
     void ksp_monitor(Int it, Real rnorm);
-    /// Method for setting matrix properties
-    virtual void set_up_matrix_properties();
-    /// Method for creating a preconditioner
-    virtual Preconditioner create_preconditioner(PC pc);
-    /// Solve the problem
-    virtual void solve();
 
 private:
-    void set_up_preconditioning();
+    /// Set up line search
+    virtual void set_up_line_search();
+
+    /// Set up solver parameters
+    virtual void set_up_solver_parameters();
+
+    /// Method for creating a preconditioner
+    virtual Preconditioner create_preconditioner(PC pc);
+
+    /// Method for setting matrix properties
+    virtual void set_up_matrix_properties();
+
+    virtual void compute_residual(const Vector & x, Vector & f) = 0;
+    virtual void compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp) = 0;
 
     /// Nonlinear solver
     SNESolver snes;
     /// Linear solver
     KrylovSolver ksp;
-    /// The residual vector
+    /// Residual vector
     Vector r;
     /// Jacobian matrix
     Matrix J;
     /// Converged reason
     SNESolver::ConvergedReason converged_reason;
     /// Preconditioner
-    Preconditioner precond;
-
+    Preconditioner pc;
     /// The type of line search to be used
     std::string line_search_type;
     /// Relative convergence tolerance for the non-linear solver

--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -71,10 +71,10 @@ protected:
     virtual void set_up_solve_type();
 
     /// SNES monitor
-    void snes_monitor(Int it, Real norm);
+    virtual void snes_monitor(Int it, Real norm);
 
     /// KSP monitor
-    void ksp_monitor(Int it, Real rnorm);
+    virtual void ksp_monitor(Int it, Real rnorm);
 
 private:
     /// Set up line search

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -44,15 +44,20 @@ public:
 
     /// Build the problem to solve
     void create() override;
+
     /// Run the problem
     virtual void run() = 0;
+
     /// Provide DM for this problem
     [[nodiscard]] DM get_dm() const;
+
     /// Return solution vector
     [[nodiscard]] const Vector & get_solution_vector() const;
     Vector & get_solution_vector();
+
     /// Get mesh this problem is using
     [[nodiscard]] virtual Mesh * get_mesh() const;
+
     /// Get problem spatial dimension
     [[nodiscard]] virtual Int get_dimension() const;
 
@@ -74,36 +79,36 @@ public:
     /// Add a function object
     ///
     /// @param fn Function object to add
-    virtual void add_function(Function * fn);
+    void add_function(Function * fn);
 
     /// Add and output object
     ///
     /// @param output Output object to add
-    virtual void add_output(Output * output);
+    void add_output(Output * output);
 
     /// Add a postprocessor object
     ///
     /// @param pp Postprocessor object to add
-    virtual void add_postprocessor(Postprocessor * pp);
+    void add_postprocessor(Postprocessor * pp);
 
     /// Get postprocessor by name
     ///
     /// @param name The name of the postprocessor
     /// @return Pointer to the postprocessor with name 'name' if it exists, otherwise `nullptr`
-    [[nodiscard]] virtual Postprocessor * get_postprocessor(const std::string & name) const;
+    [[nodiscard]] Postprocessor * get_postprocessor(const std::string & name) const;
 
     /// Get postprocessor names
     ///
     /// @return List of postprocessor names
-    [[nodiscard]] virtual const std::vector<std::string> & get_postprocessor_names() const;
+    [[nodiscard]] const std::vector<std::string> & get_postprocessor_names() const;
 
     /// Compute all postprocessors
-    virtual void compute_postprocessors();
+    void compute_postprocessors();
 
     /// Output
     ///
     /// @param mask Bit mask for an output event, see `Output` for valid options.
-    virtual void output(ExecuteOnFlag flag);
+    void output(ExecuteOnFlag flag);
 
     /// Gets the type of vector created with `create_local_vector` and `create_global_vector`
     ///
@@ -219,12 +224,16 @@ public:
 protected:
     /// Set vector/matrix types
     virtual void set_up_types();
+
     /// Allocate objects
     virtual void allocate_objects();
+
     /// Called before solving starts
     virtual void on_initial();
+
     /// Called after solve has successfully finished
     virtual void on_final();
+
     /// Set solution vector
     void set_solution_vector(const Vector & x);
 
@@ -253,8 +262,7 @@ private:
     /// List of postprocessor objects
     std::map<std::string, Postprocessor *> pps;
 
-    /// List of
-    /// postprocessor names
+    /// List of postprocessor names
     std::vector<std::string> pps_names;
 
 public:

--- a/include/godzilla/TSAbstract.h
+++ b/include/godzilla/TSAbstract.h
@@ -26,6 +26,24 @@ public:
     virtual void rollback() = 0;
     virtual void view(PetscViewer viewer) = 0;
 
+    void set_status(TSStepStatus status);
+    TSStepStatus get_status() const;
+
+    Real get_time_step() const;
+    void set_time_step(Real h);
+
+    Real get_ptime() const;
+    void advance_ptime(Real h);
+
+    Real get_ptime_prev() const;
+
+    Real get_max_reject() const;
+
+    Int get_steps() const;
+
+    const Vector & get_solution_vector() const;
+    Vector & get_solution_vector();
+
     [[nodiscard]] const std::vector<Vector> & get_stage_vectors() const;
     std::vector<Vector> & get_stage_vectors();
 
@@ -55,6 +73,16 @@ public:
     void compute_rhs(Real t, const Vector & U, Vector & y);
 
 protected:
+    TS get_ts();
+
+    TimeStepAdapt & get_adapt();
+
+    TSConvergedReason get_reason() const;
+    void set_reason(TSConvergedReason reason);
+
+    void inc_reject();
+
+private:
     /// PETSc TS object
     TS ts;
     /// Transient problem

--- a/include/godzilla/TSAbstract.h
+++ b/include/godzilla/TSAbstract.h
@@ -52,7 +52,7 @@ public:
     /// @param t Current time
     /// @param U State vector
     /// @param y Right-hand side
-    void compute_rhs_function(Real t, const Vector & U, Vector & y);
+    void compute_rhs(Real t, const Vector & U, Vector & y);
 
 protected:
     /// PETSc TS object

--- a/include/godzilla/TimeStepAdapt.h
+++ b/include/godzilla/TimeStepAdapt.h
@@ -21,7 +21,7 @@ public:
     };
 
     TimeStepAdapt();
-    explicit TimeStepAdapt(TSAdapt tsadapt);
+    TimeStepAdapt(TS ts, TSAdapt tsadapt);
 
     /// Add a candidate scheme for the adaptive controller to select from
     ///
@@ -54,7 +54,7 @@ public:
     /// @param t Current simulation time
     /// @param Y Current solution vector
     /// @return `true` to accept the stage, `false` to reject
-    bool check_stage(TS ts, Real t, const Vector & Y) const;
+    bool check_stage(Real t, const Vector & Y) const;
 
     /// Choose which method and step size to use for the next step
     ///
@@ -65,7 +65,7 @@ public:
     /// - next_h: step size to use for the next step
     /// - accept: `true` to accept the current step, `false` to repeat the current step with the
     ///   new step size
-    std::tuple<Int, Real, bool> choose(TS ts, Real h);
+    std::tuple<Int, Real, bool> choose(Real h);
 
     /// Gets the admissible decrease/increase factor in step size in the time step adapter
     ///
@@ -152,6 +152,7 @@ public:
     void set_type(Type type);
 
 private:
+    TS ts;
     TSAdapt tsadapt;
 
 public:

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -132,20 +132,24 @@ public:
 protected:
     /// Get underlying non-linear solver
     [[nodiscard]] SNESolver get_snes() const;
+
     /// Get time
     [[nodiscard]] Real get_time() const;
+
     /// Get step number
     [[nodiscard]] Int get_step_number() const;
+
     /// Initialize
     void init();
+
     /// Create
     void create();
+
     /// Set up callbacks
     void set_up_callbacks();
+
     /// Set up monitors
     void set_up_monitors();
-    /// Default TS monitor
-    void default_monitor(Int stepi, Real time, const Vector & x);
 
     /// Solve
     void solve(Vector & x);
@@ -215,6 +219,9 @@ protected:
     virtual void compute_boundary_local(Real time, Vector & x);
 
 private:
+    /// Monitor
+    virtual void monitor(Int stepi, Real time, const Vector & x);
+
     /// Set up time integration scheme
     virtual void set_up_time_scheme() = 0;
 

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -146,10 +146,7 @@ protected:
     void set_up_monitors();
     /// Default TS monitor
     void default_monitor(Int stepi, Real time, const Vector & x);
-    /// Check if problem converged
-    ///
-    /// @return `true` if solve converged, otherwise `false`
-    [[nodiscard]] bool converged() const;
+
     /// Solve
     void solve(Vector & x);
 

--- a/src/ExplicitDGLinearProblem.cpp
+++ b/src/ExplicitDGLinearProblem.cpp
@@ -60,19 +60,23 @@ ExplicitDGLinearProblem::create()
     ExplicitProblemInterface::create();
 }
 
+void
+ExplicitDGLinearProblem::run()
+{
+    CALL_STACK_MSG();
+    set_up_initial_guess();
+    on_initial();
+    lprint(9, "Solving");
+    TransientProblemInterface::solve(get_solution_vector());
+    if (converged())
+        on_final();
+}
+
 bool
 ExplicitDGLinearProblem::converged()
 {
     CALL_STACK_MSG();
-    return ExplicitProblemInterface::converged();
-}
-
-void
-ExplicitDGLinearProblem::solve()
-{
-    CALL_STACK_MSG();
-    lprint(9, "Solving");
-    ExplicitProblemInterface::solve(get_solution_vector());
+    return TransientProblemInterface::get_converged_reason() > 0;
 }
 
 void
@@ -123,6 +127,16 @@ ExplicitDGLinearProblem::post_step()
     update_aux_vector();
     compute_postprocessors();
     output(EXECUTE_ON_TIMESTEP);
+}
+
+void
+ExplicitDGLinearProblem::compute_residual(const Vector & x, Vector & f)
+{
+}
+
+void
+ExplicitDGLinearProblem::compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp)
+{
 }
 
 } // namespace godzilla

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -96,19 +96,23 @@ ExplicitFELinearProblem::create()
     ExplicitProblemInterface::create();
 }
 
+void
+ExplicitFELinearProblem::run()
+{
+    CALL_STACK_MSG();
+    set_up_initial_guess();
+    on_initial();
+    lprint(9, "Solving");
+    TransientProblemInterface::solve(get_solution_vector());
+    if (converged())
+        on_final();
+}
+
 bool
 ExplicitFELinearProblem::converged()
 {
     CALL_STACK_MSG();
-    return ExplicitProblemInterface::converged();
-}
-
-void
-ExplicitFELinearProblem::solve()
-{
-    CALL_STACK_MSG();
-    lprint(9, "Solving");
-    ExplicitProblemInterface::solve(get_solution_vector());
+    return TransientProblemInterface::get_converged_reason() > 0;
 }
 
 void

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -58,19 +58,23 @@ ExplicitFVLinearProblem::create()
     ExplicitProblemInterface::create();
 }
 
+void
+ExplicitFVLinearProblem::run()
+{
+    CALL_STACK_MSG();
+    set_up_initial_guess();
+    on_initial();
+    lprint(9, "Solving");
+    TransientProblemInterface::solve(get_solution_vector());
+    if (converged())
+        on_final();
+}
+
 bool
 ExplicitFVLinearProblem::converged()
 {
     CALL_STACK_MSG();
-    return ExplicitProblemInterface::converged();
-}
-
-void
-ExplicitFVLinearProblem::solve()
-{
-    CALL_STACK_MSG();
-    lprint(9, "Solving");
-    ExplicitProblemInterface::solve(get_solution_vector());
+    return TransientProblemInterface::get_converged_reason() > 0;
 }
 
 void
@@ -118,6 +122,16 @@ ExplicitFVLinearProblem::compute_rhs_local(Real time, const Vector & x, Vector &
 {
     CALL_STACK_MSG();
     PETSC_CHECK(DMPlexTSComputeRHSFunctionFVM(get_dm(), time, x, F, this));
+}
+
+void
+ExplicitFVLinearProblem::compute_residual(const Vector & x, Vector & f)
+{
+}
+
+void
+ExplicitFVLinearProblem::compute_jacobian(const Vector & x, Matrix & J, Matrix & Jp)
+{
 }
 
 void

--- a/src/ExplicitProblemInterface.cpp
+++ b/src/ExplicitProblemInterface.cpp
@@ -69,7 +69,7 @@ ExplicitProblemInterface::set_up_callbacks()
 {
     CALL_STACK_MSG();
     TransientProblemInterface::set_up_callbacks();
-    set_rhs_function(this, &ExplicitProblemInterface::compute_rhs);
+    set_rhs_function(this, &ExplicitProblemInterface::compute_rhs_function);
 }
 
 void
@@ -122,7 +122,7 @@ ExplicitProblemInterface::create_mass_matrix_lumped()
 }
 
 void
-ExplicitProblemInterface::compute_rhs(Real time, const Vector & x, Vector & F)
+ExplicitProblemInterface::compute_rhs_function(Real time, const Vector & x, Vector & F)
 {
     CALL_STACK_MSG();
     auto dm = this->nl_problem->get_dm();
@@ -143,6 +143,11 @@ ExplicitProblemInterface::compute_rhs(Real time, const Vector & x, Vector & F)
         Vector::pointwise_mult(F, this->M_lumped_inv, F);
     this->nl_problem->restore_local_vector(loc_x);
     this->nl_problem->restore_local_vector(loc_F);
+}
+
+void
+ExplicitProblemInterface::compute_rhs_local(Real time, const Vector & x, Vector & F)
+{
 }
 
 } // namespace godzilla

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -92,15 +92,19 @@ bool
 ImplicitFENonlinearProblem::converged()
 {
     CALL_STACK_MSG();
-    return TransientProblemInterface::converged();
+    return TransientProblemInterface::get_converged_reason() > 0;
 }
 
 void
-ImplicitFENonlinearProblem::solve()
+ImplicitFENonlinearProblem::run()
 {
     CALL_STACK_MSG();
+    set_up_initial_guess();
+    on_initial();
     lprint(9, "Solving");
     TransientProblemInterface::solve(get_solution_vector());
+    if (converged())
+        on_final();
 }
 
 void

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -14,6 +14,23 @@
 
 namespace godzilla {
 
+ErrorCode
+ImplicitFENonlinearProblem::invoke_compute_boundary_delegate(DM,
+                                                             Real time,
+                                                             Vec x,
+                                                             Vec x_t,
+                                                             void * context)
+{
+    CALL_STACK_MSG();
+    auto * method = static_cast<Delegate<void(Real time, Vector & x, Vector & x_t)> *>(context);
+    Vector vec_x(x);
+    Vector vec_x_t(x_t);
+    method->invoke(time, vec_x, vec_x_t);
+    return 0;
+}
+
+//
+
 Parameters
 ImplicitFENonlinearProblem::parameters()
 {
@@ -91,9 +108,9 @@ ImplicitFENonlinearProblem::set_up_callbacks()
 {
     CALL_STACK_MSG();
     TransientProblemInterface::set_up_callbacks();
-    set_time_boundary_local(this, &ImplicitFENonlinearProblem::compute_boundary_local);
-    set_ifunction_local(this, &ImplicitFENonlinearProblem::compute_ifunction_local);
-    set_ijacobian_local(this, &ImplicitFENonlinearProblem::compute_ijacobian_local);
+    set_time_boundary_local(this, &ImplicitFENonlinearProblem::compute_boundary_fem);
+    set_ifunction_local(this, &ImplicitFENonlinearProblem::compute_ifunction_fem);
+    set_ijacobian_local(this, &ImplicitFENonlinearProblem::compute_ijacobian_fem);
 }
 
 void
@@ -120,14 +137,14 @@ ImplicitFENonlinearProblem::compute_solution_vector_local()
     CALL_STACK_MSG();
     auto loc_sln = get_solution_vector_local();
     PETSC_CHECK(DMGlobalToLocal(get_dm(), get_solution_vector(), INSERT_VALUES, loc_sln));
-    TransientProblemInterface::compute_boundary_local(get_time(), loc_sln);
+    compute_boundary_local(get_time(), loc_sln);
 }
 
 void
-ImplicitFENonlinearProblem::compute_ifunction_local(Real time,
-                                                    const Vector & x,
-                                                    const Vector & x_t,
-                                                    Vector & F)
+ImplicitFENonlinearProblem::compute_ifunction_fem(Real time,
+                                                  const Vector & x,
+                                                  const Vector & x_t,
+                                                  Vector & F)
 {
     // this is based on DMSNESComputeResidual() and DMPlexTSComputeIFunctionFEM()
     CALL_STACK_MSG();
@@ -151,12 +168,12 @@ ImplicitFENonlinearProblem::compute_ifunction_local(Real time,
 }
 
 void
-ImplicitFENonlinearProblem::compute_ijacobian_local(Real time,
-                                                    const Vector & x,
-                                                    const Vector & x_t,
-                                                    Real x_t_shift,
-                                                    Matrix & J,
-                                                    Matrix & Jp)
+ImplicitFENonlinearProblem::compute_ijacobian_fem(Real time,
+                                                  const Vector & x,
+                                                  const Vector & x_t,
+                                                  Real x_t_shift,
+                                                  Matrix & J,
+                                                  Matrix & Jp)
 {
     // this is based on DMPlexSNESComputeJacobianFEM(), DMSNESComputeJacobianAction() and
     // DMPlexTSComputeIJacobianFEM()
@@ -183,10 +200,11 @@ ImplicitFENonlinearProblem::compute_ijacobian_local(Real time,
 }
 
 void
-ImplicitFENonlinearProblem::compute_boundary_local(Real time, Vector & x, Vector & x_t)
+ImplicitFENonlinearProblem::compute_boundary_fem(Real time, Vector & x, Vector & x_t)
 {
     CALL_STACK_MSG();
-    TransientProblemInterface::compute_boundary_local(time, x, x_t);
+    auto dm = get_dm();
+    PETSC_CHECK(DMPlexTSComputeBoundary(dm, time, x, x_t, this));
 }
 
 void

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -119,7 +119,7 @@ void
 LinearProblem::run()
 {
     CALL_STACK_MSG();
-    solve();
+    this->ks.solve(this->b, get_solution_vector());
     if (converged())
         on_final();
 }
@@ -135,13 +135,6 @@ LinearProblem::create_preconditioner(PC pc)
 {
     CALL_STACK_MSG();
     return Preconditioner(pc);
-}
-
-void
-LinearProblem::solve()
-{
-    CALL_STACK_MSG();
-    this->ks.solve(this->b, get_solution_vector());
 }
 
 } // namespace godzilla

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -26,7 +26,7 @@ LinearProblem::parameters()
 
 LinearProblem::LinearProblem(const Parameters & parameters) :
     Problem(parameters),
-    precond(nullptr),
+    pc(nullptr),
     lin_rel_tol(get_param<Real>("lin_rel_tol")),
     lin_abs_tol(get_param<Real>("lin_abs_tol")),
     lin_max_iter(get_param<Int>("lin_max_iter"))
@@ -50,14 +50,11 @@ LinearProblem::create()
     init();
     allocate_objects();
     set_up_matrix_properties();
-    set_up_preconditioning();
-
+    this->pc = create_preconditioner(this->ks.get_pc());
     set_up_solver_parameters();
     set_up_monitors();
     set_up_callbacks();
-
     Problem::create();
-
     this->ks.set_from_options();
 }
 
@@ -75,7 +72,6 @@ LinearProblem::allocate_objects()
 {
     CALL_STACK_MSG();
     Problem::allocate_objects();
-
     this->b = get_solution_vector().duplicate();
     this->b.set_name("rhs");
 }
@@ -134,14 +130,6 @@ LinearProblem::set_up_matrix_properties()
     CALL_STACK_MSG();
 }
 
-void
-LinearProblem::set_up_preconditioning()
-{
-    CALL_STACK_MSG();
-    auto pc = this->ks.get_pc();
-    this->precond = create_preconditioner(pc);
-}
-
 Preconditioner
 LinearProblem::create_preconditioner(PC pc)
 {
@@ -154,18 +142,6 @@ LinearProblem::solve()
 {
     CALL_STACK_MSG();
     this->ks.solve(this->b, get_solution_vector());
-}
-
-void
-LinearProblem::compute_rhs(Vector &)
-{
-    CALL_STACK_MSG();
-}
-
-void
-LinearProblem::compute_operators(Matrix &, Matrix &)
-{
-    CALL_STACK_MSG();
 }
 
 } // namespace godzilla

--- a/src/TSAbstract.cpp
+++ b/src/TSAbstract.cpp
@@ -75,10 +75,10 @@ TSAbstract::set_cfl_time_local(Real cfl)
 }
 
 void
-TSAbstract::compute_rhs_function(Real t, const Vector & U, Vector & y)
+TSAbstract::compute_rhs(Real t, const Vector & U, Vector & y)
 {
     CALL_STACK_MSG();
-    this->tpi->compute_rhs_function(t, U, y);
+    this->tpi->compute_rhs(t, U, y);
 }
 
 //

--- a/src/TSAbstract.cpp
+++ b/src/TSAbstract.cpp
@@ -32,6 +32,83 @@ TSAbstract::TSAbstract(TS ts) :
         throw InternalError("TS context is nullptr");
 }
 
+void
+TSAbstract::set_status(TSStepStatus status)
+{
+    CALL_STACK_MSG();
+    this->status = status;
+}
+
+TSStepStatus
+TSAbstract::get_status() const
+{
+    CALL_STACK_MSG();
+    return this->status;
+}
+
+Real
+TSAbstract::get_time_step() const
+{
+    CALL_STACK_MSG();
+    return this->time_step;
+}
+
+void
+TSAbstract::set_time_step(Real h)
+{
+    CALL_STACK_MSG();
+    this->time_step = h;
+}
+
+Real
+TSAbstract::get_ptime() const
+{
+    CALL_STACK_MSG();
+    return this->ptime;
+}
+
+void
+TSAbstract::advance_ptime(Real h)
+{
+    CALL_STACK_MSG();
+    this->ptime += h;
+}
+
+Real
+TSAbstract::get_ptime_prev() const
+{
+    CALL_STACK_MSG();
+    return this->ptime_prev;
+}
+
+Real
+TSAbstract::get_max_reject() const
+{
+    CALL_STACK_MSG();
+    return this->max_reject;
+}
+
+Int
+TSAbstract::get_steps() const
+{
+    CALL_STACK_MSG();
+    return this->steps;
+}
+
+const Vector &
+TSAbstract::get_solution_vector() const
+{
+    CALL_STACK_MSG();
+    return this->vec_sol;
+}
+
+Vector &
+TSAbstract::get_solution_vector()
+{
+    CALL_STACK_MSG();
+    return this->vec_sol;
+}
+
 const std::vector<Vector> &
 TSAbstract::get_stage_vectors() const
 {
@@ -79,6 +156,41 @@ TSAbstract::compute_rhs(Real t, const Vector & U, Vector & y)
 {
     CALL_STACK_MSG();
     this->tpi->compute_rhs(t, U, y);
+}
+
+TS
+TSAbstract::get_ts()
+{
+    CALL_STACK_MSG();
+    return this->ts;
+}
+
+TimeStepAdapt &
+TSAbstract::get_adapt()
+{
+    CALL_STACK_MSG();
+    return this->adapt;
+}
+
+TSConvergedReason
+TSAbstract::get_reason() const
+{
+    CALL_STACK_MSG();
+    return this->reason;
+}
+
+void
+TSAbstract::set_reason(TSConvergedReason reason)
+{
+    CALL_STACK_MSG();
+    this->reason = reason;
+}
+
+void
+TSAbstract::inc_reject()
+{
+    CALL_STACK_MSG();
+    this->reject++;
 }
 
 //

--- a/src/TimeStepAdapt.cpp
+++ b/src/TimeStepAdapt.cpp
@@ -10,7 +10,7 @@ namespace godzilla {
 
 TimeStepAdapt::TimeStepAdapt() : tsadapt(nullptr) {}
 
-TimeStepAdapt::TimeStepAdapt(TSAdapt tsadapt) : tsadapt(tsadapt) {}
+TimeStepAdapt::TimeStepAdapt(TS ts, TSAdapt tsadapt) : ts(ts), tsadapt(tsadapt) {}
 
 void
 TimeStepAdapt::add_candidate(const std::string & name,
@@ -58,22 +58,22 @@ TimeStepAdapt::get_candidates() const
 }
 
 bool
-TimeStepAdapt::check_stage(TS ts, Real t, const Vector & Y) const
+TimeStepAdapt::check_stage(Real t, const Vector & Y) const
 {
     CALL_STACK_MSG();
     PetscBool accept;
-    PETSC_CHECK(TSAdaptCheckStage(this->tsadapt, ts, t, Y, &accept));
+    PETSC_CHECK(TSAdaptCheckStage(this->tsadapt, this->ts, t, Y, &accept));
     return accept == PETSC_TRUE;
 }
 
 std::tuple<Int, Real, bool>
-TimeStepAdapt::choose(TS ts, Real h)
+TimeStepAdapt::choose(Real h)
 {
     CALL_STACK_MSG();
     Int next_sc;
     Real next_h;
     PetscBool accept;
-    PETSC_CHECK(TSAdaptChoose(this->tsadapt, ts, h, &next_sc, &next_h, &accept));
+    PETSC_CHECK(TSAdaptChoose(this->tsadapt, this->ts, h, &next_sc, &next_h, &accept));
     return { next_sc, next_h, accept == PETSC_TRUE };
 }
 
@@ -213,7 +213,7 @@ TimeStepAdapt::from_ts(TS ts)
     CALL_STACK_MSG();
     TSAdapt adapt;
     PETSC_CHECK(TSGetAdapt(ts, &adapt));
-    return TimeStepAdapt(adapt);
+    return TimeStepAdapt(ts, adapt);
 }
 
 } // namespace godzilla

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -265,7 +265,7 @@ void
 TransientProblemInterface::set_up_monitors()
 {
     CALL_STACK_MSG();
-    monitor_set(this, &TransientProblemInterface::default_monitor);
+    monitor_set(this, &TransientProblemInterface::monitor);
 }
 
 void
@@ -285,7 +285,7 @@ TransientProblemInterface::post_step()
 }
 
 void
-TransientProblemInterface::default_monitor(Int stepi, Real time, const Vector & x)
+TransientProblemInterface::monitor(Int stepi, Real time, const Vector & x)
 {
     CALL_STACK_MSG();
     Real dt = get_time_step();
@@ -392,6 +392,7 @@ TransientProblemInterface::monitor_cancel()
 {
     CALL_STACK_MSG();
     PETSC_CHECK(TSMonitorCancel(this->ts));
+    this->monitor_method.reset();
 }
 
 void

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -343,13 +343,6 @@ TransientProblemInterface::set_converged_reason(TSConvergedReason reason)
     PETSC_CHECK(TSSetConvergedReason(this->ts, reason));
 }
 
-bool
-TransientProblemInterface::converged() const
-{
-    CALL_STACK_MSG();
-    return get_converged_reason() > 0;
-}
-
 void
 TransientProblemInterface::set_scheme(TimeScheme scheme)
 {

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -57,21 +57,6 @@ TransientProblemInterface::invoke_compute_rhs_delegate(TS, Real time, Vec x, Vec
 }
 
 ErrorCode
-TransientProblemInterface::invoke_compute_rhs_local_delegate(DM,
-                                                             Real time,
-                                                             Vec x,
-                                                             Vec F,
-                                                             void * ctx)
-{
-    CALL_STACK_MSG();
-    auto * method = static_cast<Delegate<void(Real time, const Vector & x, Vector & F)> *>(ctx);
-    Vector vec_x(x);
-    Vector vec_F(F);
-    method->invoke(time, vec_x, vec_F);
-    return 0;
-}
-
-ErrorCode
 TransientProblemInterface::invoke_compute_ifunction_delegate(DM,
                                                              Real time,
                                                              Vec x,
@@ -112,22 +97,6 @@ TransientProblemInterface::invoke_compute_ijacobian_delegate(DM,
     Matrix mat_J(J);
     Matrix mat_Jp(Jp);
     method->invoke(time, vec_x, vec_x_t, x_t_shift, mat_J, mat_Jp);
-    return 0;
-}
-
-ErrorCode
-TransientProblemInterface::invoke_compute_boundary_delegate(DM,
-                                                            Real time,
-                                                            Vec x,
-                                                            Vec x_t,
-                                                            void * context)
-{
-    CALL_STACK_MSG();
-    auto * method =
-        static_cast<Delegate<void(Real time, const Vector & x, const Vector & x_t)> *>(context);
-    Vector vec_x(x);
-    Vector vec_x_t(x_t);
-    method->invoke(time, vec_x, vec_x_t);
     return 0;
 }
 
@@ -360,11 +329,11 @@ TransientProblemInterface::post_stage(Real stage_time,
 }
 
 void
-TransientProblemInterface::compute_rhs_function(Real time, const Vector & x, Vector & F)
+TransientProblemInterface::compute_rhs(Real time, const Vector & x, Vector & F)
 {
     CALL_STACK_MSG();
     if (this->compute_rhs_method)
-        this->compute_rhs_method.invoke(time, x, F);
+        this->compute_rhs_method(time, x, F);
 }
 
 void
@@ -438,14 +407,6 @@ TransientProblemInterface::compute_boundary_local(Real time, Vector & x)
     CALL_STACK_MSG();
     auto dm = this->problem->get_dm();
     PETSC_CHECK(DMPlexTSComputeBoundary(dm, time, x, nullptr, this));
-}
-
-void
-TransientProblemInterface::compute_boundary_local(Real time, Vector & x, Vector & x_t)
-{
-    CALL_STACK_MSG();
-    auto dm = this->problem->get_dm();
-    PETSC_CHECK(DMPlexTSComputeBoundary(dm, time, x, x_t, this));
 }
 
 } // namespace godzilla

--- a/test/src/FENonlinearProblemJFNK_test.cpp
+++ b/test/src/FENonlinearProblemJFNK_test.cpp
@@ -18,8 +18,6 @@ class GTestFENonlinearProblemJFNK : public FENonlinearProblem {
 public:
     explicit GTestFENonlinearProblemJFNK(const Parameters & params);
 
-    void solve() override;
-
 protected:
     void set_up_fields() override;
     void set_up_weak_form() override;
@@ -113,12 +111,6 @@ GTestFENonlinearProblemJFNK::create_preconditioner(PC pc)
     return p;
 }
 
-void
-GTestFENonlinearProblemJFNK::solve()
-{
-    FENonlinearProblem::solve();
-}
-
 } // namespace
 
 TEST(FENonlinearProblemJFNKTest, solve)
@@ -155,7 +147,7 @@ TEST(FENonlinearProblemJFNKTest, solve)
     mesh.create();
     prob.create();
 
-    prob.solve();
+    prob.run();
 
     bool conv = prob.converged();
     EXPECT_EQ(conv, true);
@@ -163,5 +155,5 @@ TEST(FENonlinearProblemJFNKTest, solve)
     auto x = prob.get_solution_vector();
     std::vector<Scalar> vals(1);
     x.get_values({ 0 }, vals);
-    EXPECT_DOUBLE_EQ(vals[0], 0.25);
+    EXPECT_NEAR(vals[0], 0.25, 1e-9);
 }

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -217,7 +217,7 @@ TEST_F(FENonlinearProblemTest, solve)
     ASSERT_EQ(ess_bcs.size(), 1);
     EXPECT_EQ(bcs[0], &bc);
 
-    this->prob->solve();
+    this->prob->run();
 
     bool conv = this->prob->converged();
     EXPECT_EQ(conv, true);

--- a/test/src/GTestFENonlinearProblem.cpp
+++ b/test/src/GTestFENonlinearProblem.cpp
@@ -81,12 +81,6 @@ GTestFENonlinearProblem::get_ds()
 }
 
 void
-GTestFENonlinearProblem::compute_postprocessors()
-{
-    FENonlinearProblem::compute_postprocessors();
-}
-
-void
 GTestFENonlinearProblem::set_up_fields()
 {
     Int order = 1;

--- a/test/src/GTestFENonlinearProblem.cpp
+++ b/test/src/GTestFENonlinearProblem.cpp
@@ -68,12 +68,6 @@ GTestFENonlinearProblem::set_up_initial_guess()
     FENonlinearProblem::set_up_initial_guess();
 }
 
-void
-GTestFENonlinearProblem::solve()
-{
-    FENonlinearProblem::solve();
-}
-
 PetscDS
 GTestFENonlinearProblem::get_ds()
 {

--- a/test/src/GTestFENonlinearProblem.h
+++ b/test/src/GTestFENonlinearProblem.h
@@ -10,7 +10,6 @@ public:
     explicit GTestFENonlinearProblem(const Parameters & params);
 
     PetscDS get_ds();
-    void compute_postprocessors() override;
     void set_up_initial_guess() override;
     void solve() override;
 

--- a/test/src/GTestFENonlinearProblem.h
+++ b/test/src/GTestFENonlinearProblem.h
@@ -11,7 +11,6 @@ public:
 
     PetscDS get_ds();
     void set_up_initial_guess() override;
-    void solve() override;
 
     const std::vector<BoundaryCondition *> &
     get_boundary_conditions() const

--- a/test/src/L2Diff_test.cpp
+++ b/test/src/L2Diff_test.cpp
@@ -47,7 +47,7 @@ TEST(L2DiffTest, compute)
     mesh.create();
     prob.create();
 
-    prob.solve();
+    prob.run();
     prob.compute_postprocessors();
 
     Real l2_err = ps.get_value();

--- a/test/src/LinearProblem_test.cpp
+++ b/test/src/LinearProblem_test.cpp
@@ -15,7 +15,7 @@ TEST_F(LinearProblemTest, solve)
     mesh->create();
     auto prob = gProblem1d(mesh);
     prob->create();
-    prob->solve();
+    prob->run();
 
     bool conv = prob->converged();
     EXPECT_EQ(conv, true);

--- a/test/src/LinearProblem_test.cpp
+++ b/test/src/LinearProblem_test.cpp
@@ -42,14 +42,8 @@ TEST_F(LinearProblemTest, run)
     public:
         explicit MockLinearProblem(const Parameters & params) : LinearProblem(params) {}
 
-        MOCK_METHOD(void, solve, ());
-        MOCK_METHOD(void, on_final, ());
-
-        bool
-        converged() override
-        {
-            return true;
-        }
+        MOCK_METHOD(void, compute_rhs, (Vector & b));
+        MOCK_METHOD(void, compute_operators, (Matrix & A, Matrix & B));
     };
 
     auto mesh = gMesh1d();
@@ -60,14 +54,10 @@ TEST_F(LinearProblemTest, run)
     prob_pars.set<MeshObject *>("_mesh_obj") = mesh;
     MockLinearProblem prob(prob_pars);
 
-    EXPECT_CALL(prob, solve);
-    EXPECT_CALL(prob, on_final);
+    prob.create();
+    EXPECT_CALL(prob, compute_rhs);
+    EXPECT_CALL(prob, compute_operators);
     prob.run();
-
-    Vector b;
-    prob.compute_rhs(b);
-    Matrix A;
-    prob.compute_operators(A, A);
 }
 
 // 1D
@@ -88,12 +78,6 @@ G1DTestLinearProblem::create()
     this->s = Section::create(get_dm(), nc, n_dofs, 0, nullptr, nullptr, nullptr, nullptr);
     set_local_section(this->s);
     LinearProblem::create();
-}
-
-void
-G1DTestLinearProblem::solve()
-{
-    LinearProblem::solve();
 }
 
 void
@@ -133,12 +117,6 @@ G2DTestLinearProblem::create()
 }
 
 void
-G2DTestLinearProblem::solve()
-{
-    LinearProblem::solve();
-}
-
-void
 G2DTestLinearProblem::compute_rhs(Vector & b)
 {
     b.set_values({ 0, 1, 2, 3 }, { 2, 3, 5, 8 });
@@ -171,12 +149,6 @@ G3DTestLinearProblem::create()
     this->s = Section::create(get_dm(), nc, n_dofs, 0, nullptr, nullptr, nullptr, nullptr);
     set_local_section(this->s);
     LinearProblem::create();
-}
-
-void
-G3DTestLinearProblem::solve()
-{
-    LinearProblem::solve();
 }
 
 void

--- a/test/src/LinearProblem_test.h
+++ b/test/src/LinearProblem_test.h
@@ -12,7 +12,6 @@ public:
     G1DTestLinearProblem(const Parameters & params);
     virtual ~G1DTestLinearProblem();
     virtual void create() override;
-    virtual void solve() override;
     virtual void compute_rhs(Vector & b) override;
     virtual void compute_operators(Matrix & A, Matrix & B) override;
 
@@ -27,7 +26,6 @@ public:
     G2DTestLinearProblem(const Parameters & params);
     virtual ~G2DTestLinearProblem();
     virtual void create() override;
-    virtual void solve() override;
     virtual void compute_rhs(Vector & b) override;
     virtual void compute_operators(Matrix & A, Matrix & B) override;
 
@@ -42,7 +40,6 @@ public:
     G3DTestLinearProblem(const Parameters & params);
     virtual ~G3DTestLinearProblem();
     virtual void create() override;
-    virtual void solve() override;
     virtual void compute_rhs(Vector & b) override;
     virtual void compute_operators(Matrix & A, Matrix & B) override;
 

--- a/test/src/NeumannProblem_test.cpp
+++ b/test/src/NeumannProblem_test.cpp
@@ -16,7 +16,6 @@ namespace {
 class TestNeumannProblem : public FENonlinearProblem {
 public:
     explicit TestNeumannProblem(const Parameters & params);
-    void solve() override;
 
 protected:
     void set_up_fields() override;
@@ -96,12 +95,6 @@ TestNeumannProblem::TestNeumannProblem(const Parameters & params) :
     FENonlinearProblem(params),
     iu(0)
 {
-}
-
-void
-TestNeumannProblem::solve()
-{
-    FENonlinearProblem::solve();
 }
 
 void
@@ -202,7 +195,7 @@ TEST(NeumannProblemTest, solve)
     mesh.create();
     prob.create();
 
-    prob.solve();
+    prob.run();
 
     bool conv = prob.converged();
     EXPECT_EQ(conv, true);

--- a/test/src/TSAbstract_test.cpp
+++ b/test/src/TSAbstract_test.cpp
@@ -20,12 +20,6 @@ public:
     MOCK_METHOD(void, rollback, ());
     MOCK_METHOD(void, view, (PetscViewer viewer));
 
-    const Vector &
-    get_vec_sol()
-    {
-        return this->vec_sol;
-    }
-
 public:
     static const std::string name;
 };

--- a/test/src/TSAbstract_test.cpp
+++ b/test/src/TSAbstract_test.cpp
@@ -83,7 +83,7 @@ public:
 
         auto U = Vector::create_seq(comm, 3);
         auto y = Vector::create_seq(comm, 3);
-        scheme->compute_rhs_function(0., U, y);
+        scheme->compute_rhs(0., U, y);
     }
 
     void

--- a/test/src/TimeStepAdapt_test.cpp
+++ b/test/src/TimeStepAdapt_test.cpp
@@ -71,10 +71,10 @@ TEST(TimeStepAdapt, test)
     EXPECT_DOUBLE_EQ(candidates[1].cost, 2.);
 
     auto X = prob.get_solution();
-    auto accept_stage = adapt.check_stage(ts, 0., X);
+    auto accept_stage = adapt.check_stage(0., X);
     EXPECT_TRUE(accept_stage);
 
-    auto [next_sc, next_h, accept] = adapt.choose(ts, 0.5);
+    auto [next_sc, next_h, accept] = adapt.choose(0.5);
     EXPECT_EQ(next_sc, 0);
     EXPECT_DOUBLE_EQ(next_h, 0.5);
     EXPECT_TRUE(accept);

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -92,6 +92,11 @@ TEST_F(VTKOutputTest, wrong_mesh_type)
     class TestProblem : public LinearProblem {
     public:
         explicit TestProblem(const Parameters & params) : LinearProblem(params) {}
+        void
+        compute_rhs(Vector & b) override
+        {
+        }
+        void compute_operators(Matrix & A, Matrix & B) override {};
     };
 
     testing::internal::CaptureStderr();

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -133,7 +133,7 @@ TEST_F(VTKOutputTest, output_1d_step)
 
     this->app->check_integrity();
 
-    this->prob->solve();
+    this->prob->run();
     EXPECT_EQ(this->prob->converged(), true);
     out->output_step();
 }


### PR DESCRIPTION
- Refactoring delegates related to transient problems
- `TimeStepAdapt` is tied to a `TS`
- `TSAbstract` has private data
- `LinearProblem` has more non-virtual interface
- `Problem` has more non-virtual interface
- Refactoring in `NonlinearProblem`
- Monitors are virtual again
