### PR TITLE
Refactoring DenseVector/DenseMatrix

### DIFF
--- a/include/godzilla/DenseMatrix.h
+++ b/include/godzilla/DenseMatrix.h
@@ -71,12 +71,12 @@ public:
     ///
     /// @param idx Index of the column
     /// @return Column as a DenseVector
-    DenseVector<T, ROWS>
+    DenseMatrix<T, ROWS, 1>
     column(Int idx) const
     {
-        DenseVector<T, ROWS> col;
+        DenseMatrix<T, ROWS, 1> col;
         for (Int row = 0; row < ROWS; row++)
-            col(row) = get(row, idx);
+            col(row, 0) = get(row, idx);
         return col;
     }
 
@@ -84,12 +84,12 @@ public:
     ///
     /// @param idx Index of the column
     /// @return Column as a DenseVector
-    DenseVector<T, COLS>
+    DenseMatrix<T, 1, COLS>
     row(Int idx) const
     {
-        DenseVector<T, COLS> row;
+        DenseMatrix<T, 1, COLS> row;
         for (Int col = 0; col < COLS; col++)
-            row(col) = get(idx, col);
+            row(0, col) = get(idx, col);
         return row;
     }
 
@@ -142,6 +142,21 @@ public:
     {
         for (Int i = 0; i < COLS; i++)
             set(row, i) = vals(i);
+    }
+
+    void
+    set_row(Int row, const DenseMatrix<T, 1, COLS> & vals)
+    {
+        for (Int i = 0; i < COLS; i++)
+            set(row, i) = vals(0, i);
+    }
+
+    void
+    set_col(Int col, const std::vector<T> & vals)
+    {
+        assert(vals.size() == ROWS);
+        for (Int i = 0; i < ROWS; i++)
+            set(i, col) = vals[i];
     }
 
     /// Set a matrix column at once
@@ -274,22 +289,6 @@ public:
                 for (Int k = 0; k < COLS; k++)
                     prod += get(i, k) * x(k, j);
                 res(i, j) = prod;
-            }
-        }
-        return res;
-    }
-
-    template <Int M>
-    DenseVector<DenseVector<T, M>, ROWS>
-    mult(const DenseVector<DenseVector<T, M>, COLS> & x) const
-    {
-        DenseVector<DenseVector<T, M>, ROWS> res;
-        for (Int i = 0; i < ROWS; i++) {
-            for (Int j = 0; j < M; j++) {
-                T prod = 0.;
-                for (Int k = 0; k < COLS; k++)
-                    prod += get(i, k) * x(k)(j);
-                res(i)(j) = prod;
             }
         }
         return res;
@@ -495,13 +494,6 @@ public:
         return mult(x);
     }
 
-    template <Int M>
-    DenseVector<DenseVector<T, M>, ROWS>
-    operator*(const DenseVector<DenseVector<T, M>, COLS> & x) const
-    {
-        return mult(x);
-    }
-
     DenseMatrix<Real, ROWS> &
     operator=(const DenseMatrixSymm<Real, ROWS> & m)
     {
@@ -685,6 +677,24 @@ DenseMatrix<Real, 3>::inverse() const
     inv(2, 2) = (this->values[0] * this->values[4] - this->values[1] * this->values[3]);
     inv.scale(1. / det);
     return inv;
+}
+
+/// Transpose DenseMatrix<T, M, N>
+///
+/// @tparam T Data type
+/// @tparam N Number of rows in the input "matrix", but number of columns in the resulting matrix
+/// @tparam M Number of columns in the input "matrix", but number of rows in the resulting matrix
+/// @param a Input "matrix"
+/// @return Transposed version of DenseMatrix<T> with values from `a`
+template <typename T, Int N, Int M>
+inline DenseMatrix<T, N, M>
+transpose(const DenseMatrix<T, M, N> & a)
+{
+    DenseMatrix<T, N, M> res;
+    for (Int i = 0; i < N; i++)
+        for (Int j = 0; j < M; j++)
+            res(i, j) = a(j, i);
+    return res;
 }
 
 //

--- a/include/godzilla/DenseMatrix.h
+++ b/include/godzilla/DenseMatrix.h
@@ -294,24 +294,6 @@ public:
         return res;
     }
 
-    /// Compute inverse of this matrix
-    ///
-    /// @return Inverse of this matrix
-    [[deprecated("Use inverse() instead")]] DenseMatrix<Real, COLS>
-    inv() const
-    {
-        inverse();
-    }
-
-    /// Compute inverse of this matrix
-    ///
-    /// @return Inverse of this matrix
-    DenseMatrix<Real, COLS>
-    inverse() const
-    {
-        error("Inverse is not implemented for {}x{} matrices, yet.", ROWS, ROWS);
-    }
-
     /// Compute transpose
     ///
     /// @return Transposed matrix
@@ -633,50 +615,62 @@ determinant(const DenseMatrix<T, 3, 3> & mat)
 
 // Inversion
 
+/// Compute inverse of this matrix
+///
+/// @return Inverse of this matrix
+template <typename T, Int N>
+inline
+DenseMatrix<T, N>
+inverse(const DenseMatrix<T, N> & mat)
+{
+    error("Inverse is not implemented for {}x{} matrices, yet.", N, N);
+}
+
+
 template <>
 inline DenseMatrix<Real, 1>
-DenseMatrix<Real, 1>::inverse() const
+inverse(const DenseMatrix<Real, 1> & mat)
 {
     DenseMatrix<Real, 1> inv;
-    inv(0, 0) = 1. / this->values[0];
+    inv(0, 0) = 1. / mat.data()[0];
     return inv;
 }
 
 template <>
 inline DenseMatrix<Real, 2>
-DenseMatrix<Real, 2>::inverse() const
+inverse(const DenseMatrix<Real, 2> & mat)
 {
-    Real det = determinant(*this);
+    Real det = determinant(mat);
     if (det == 0.)
         throw Exception("Inverting of a matrix failed: matrix is singular.");
 
     DenseMatrix<Real, 2> inv;
-    inv.values[0] = this->values[3];
-    inv.values[1] = -this->values[1];
-    inv.values[2] = -this->values[2];
-    inv.values[3] = this->values[0];
+    inv.data()[0] =  mat.data()[3];
+    inv.data()[1] = -mat.data()[1];
+    inv.data()[2] = -mat.data()[2];
+    inv.data()[3] =  mat.data()[0];
     inv.scale(1. / det);
     return inv;
 }
 
 template <>
 inline DenseMatrix<Real, 3>
-DenseMatrix<Real, 3>::inverse() const
+inverse(const DenseMatrix<Real, 3> & mat)
 {
-    Real det = determinant(*this);
+    Real det = determinant(mat);
     if (det == 0.)
         throw Exception("Inverting of a matrix failed: matrix is singular.");
 
     DenseMatrix<Real, 3> inv;
-    inv(0, 0) = (this->values[4] * this->values[8] - this->values[5] * this->values[7]);
-    inv(1, 0) = -(this->values[3] * this->values[8] - this->values[5] * this->values[6]);
-    inv(2, 0) = (this->values[3] * this->values[7] - this->values[4] * this->values[6]);
-    inv(0, 1) = -(this->values[1] * this->values[8] - this->values[2] * this->values[7]);
-    inv(1, 1) = (this->values[0] * this->values[8] - this->values[2] * this->values[6]);
-    inv(2, 1) = -(this->values[0] * this->values[7] - this->values[1] * this->values[6]);
-    inv(0, 2) = (this->values[1] * this->values[5] - this->values[2] * this->values[4]);
-    inv(1, 2) = -(this->values[0] * this->values[5] - this->values[2] * this->values[3]);
-    inv(2, 2) = (this->values[0] * this->values[4] - this->values[1] * this->values[3]);
+    inv(0, 0) =  (mat.data()[4] * mat.data()[8] - mat.data()[5] * mat.data()[7]);
+    inv(1, 0) = -(mat.data()[3] * mat.data()[8] - mat.data()[5] * mat.data()[6]);
+    inv(2, 0) =  (mat.data()[3] * mat.data()[7] - mat.data()[4] * mat.data()[6]);
+    inv(0, 1) = -(mat.data()[1] * mat.data()[8] - mat.data()[2] * mat.data()[7]);
+    inv(1, 1) =  (mat.data()[0] * mat.data()[8] - mat.data()[2] * mat.data()[6]);
+    inv(2, 1) = -(mat.data()[0] * mat.data()[7] - mat.data()[1] * mat.data()[6]);
+    inv(0, 2) =  (mat.data()[1] * mat.data()[5] - mat.data()[2] * mat.data()[4]);
+    inv(1, 2) = -(mat.data()[0] * mat.data()[5] - mat.data()[2] * mat.data()[3]);
+    inv(2, 2) =  (mat.data()[0] * mat.data()[4] - mat.data()[1] * mat.data()[3]);
     inv.scale(1. / det);
     return inv;
 }

--- a/include/godzilla/DenseMatrix.h
+++ b/include/godzilla/DenseMatrix.h
@@ -294,13 +294,6 @@ public:
         return res;
     }
 
-    /// Compute determinant of the matrix
-    [[nodiscard]] Real
-    det() const
-    {
-        error("Determinant is not implemented for {}x{} matrices, yet.", ROWS, ROWS);
-    }
-
     /// Compute inverse of this matrix
     ///
     /// @return Inverse of this matrix
@@ -603,30 +596,39 @@ private:
 
 // ---
 
-template <>
-inline Real
-DenseMatrix<Real, 1>::det() const
+template <typename T, Int N>
+inline T
+determinant(const DenseMatrix<T, N, N> & mat)
 {
-    return this->values[0];
+    error("Determinant is not implemented for {}x{} matrices, yet.", N, N);
 }
 
-template <>
-inline Real
-DenseMatrix<Real, 2>::det() const
+template <typename T>
+inline T
+determinant(const DenseMatrix<T, 1, 1> & mat)
 {
-    return this->values[0] * this->values[3] - this->values[2] * this->values[1];
+    return mat.data()[0];
 }
 
-template <>
-inline Real
-DenseMatrix<Real, 3>::det() const
+template <typename T>
+inline T
+determinant(const DenseMatrix<T, 2, 2> & mat)
 {
-    return this->values[0] * this->values[4] * this->values[8] +
-           this->values[3] * this->values[7] * this->values[2] +
-           this->values[1] * this->values[5] * this->values[6] -
-           (this->values[6] * this->values[4] * this->values[2] +
-            this->values[1] * this->values[3] * this->values[8] +
-            this->values[5] * this->values[7] * this->values[0]);
+    const T * values = mat.data();
+    return values[0] * values[3] - values[2] * values[1];
+}
+
+template <typename T>
+inline T
+determinant(const DenseMatrix<T, 3, 3> & mat)
+{
+    const T * values = mat.data();
+    return values[0] * values[4] * values[8] +
+           values[3] * values[7] * values[2] +
+           values[1] * values[5] * values[6] -
+           (values[6] * values[4] * values[2] +
+            values[1] * values[3] * values[8] +
+            values[5] * values[7] * values[0]);
 }
 
 // Inversion
@@ -644,7 +646,7 @@ template <>
 inline DenseMatrix<Real, 2>
 DenseMatrix<Real, 2>::inverse() const
 {
-    Real det = this->det();
+    Real det = determinant(*this);
     if (det == 0.)
         throw Exception("Inverting of a matrix failed: matrix is singular.");
 
@@ -661,7 +663,7 @@ template <>
 inline DenseMatrix<Real, 3>
 DenseMatrix<Real, 3>::inverse() const
 {
-    Real det = this->det();
+    Real det = determinant(*this);
     if (det == 0.)
         throw Exception("Inverting of a matrix failed: matrix is singular.");
 

--- a/include/godzilla/DenseMatrixSymm.h
+++ b/include/godzilla/DenseMatrixSymm.h
@@ -178,13 +178,6 @@ public:
         return res;
     }
 
-    /// Compute determinant of the matrix
-    [[nodiscard]] Real
-    det() const
-    {
-        error("Determinant is not implemented for {}x{} matrices, yet.", DIM, DIM);
-    }
-
     /// Compute transpose
     ///
     /// @return Transposed matrix
@@ -378,30 +371,39 @@ private:
 
 // Determinant computation for small matrices
 
-template <>
-inline Real
-DenseMatrixSymm<Real, 1>::det() const
+template <typename T, Int N>
+inline T
+determinant(const DenseMatrixSymm<T, N> & mat)
 {
-    return this->values[0];
+    error("Determinant is not implemented for {}x{} matrices, yet.", N, N);
 }
 
-template <>
-inline Real
-DenseMatrixSymm<Real, 2>::det() const
+template <typename T>
+inline T
+determinant(const DenseMatrixSymm<T, 1> & mat)
 {
-    return this->values[0] * this->values[2] - this->values[1] * this->values[1];
+    return mat.data()[0];
 }
 
-template <>
-inline Real
-DenseMatrixSymm<Real, 3>::det() const
+template <typename T>
+inline T
+determinant(const DenseMatrixSymm<T, 2> & mat)
 {
-    return this->values[0] * this->values[2] * this->values[5] +
-           this->values[1] * this->values[4] * this->values[3] +
-           this->values[1] * this->values[4] * this->values[3] -
-           (this->values[3] * this->values[2] * this->values[3] +
-            this->values[0] * this->values[4] * this->values[4] +
-            this->values[1] * this->values[1] * this->values[5]);
+    const T * values = mat.data();
+    return values[0] * values[2] - values[1] * values[1];
+}
+
+template <typename T>
+inline T
+determinant(const DenseMatrixSymm<T, 3> & mat)
+{
+    const T * values = mat.data();
+    return values[0] * values[2] * values[5] +
+           values[1] * values[4] * values[3] +
+           values[1] * values[4] * values[3] -
+           (values[3] * values[2] * values[3] +
+            values[0] * values[4] * values[4] +
+            values[1] * values[1] * values[5]);
 }
 
 //

--- a/include/godzilla/DenseMatrixSymm.h
+++ b/include/godzilla/DenseMatrixSymm.h
@@ -178,22 +178,6 @@ public:
         return res;
     }
 
-    template <Int M>
-    DenseVector<DenseVector<T, M>, DIM>
-    mult(const DenseVector<DenseVector<T, M>, DIM> & x) const
-    {
-        DenseVector<DenseVector<T, M>, DIM> res;
-        for (Int i = 0; i < DIM; i++) {
-            for (Int j = 0; j < M; j++) {
-                T prod = 0.;
-                for (Int k = 0; k < DIM; k++)
-                    prod += get(i, k) * x(k)(j);
-                res(i)(j) = prod;
-            }
-        }
-        return res;
-    }
-
     /// Compute determinant of the matrix
     [[nodiscard]] Real
     det() const
@@ -328,13 +312,6 @@ public:
     operator*(const DenseMatrix<T, DIM, M> & x) const
     {
         return mult(x);
-    }
-
-    template <Int M>
-    DenseVector<DenseVector<T, M>, DIM>
-    operator*(const DenseVector<DenseVector<T, M>, DIM> & rhs) const
-    {
-        return mult(rhs);
     }
 
     [[deprecated("Use data() instead")]] T *

--- a/include/godzilla/DenseVector.h
+++ b/include/godzilla/DenseVector.h
@@ -287,20 +287,20 @@ public:
     }
 };
 
-/// Compute dot product of 2 vectors
+/// Compute dot product of 2 column-vectors
 ///
 /// @tparam T Data type
 /// @tparam N Size of the vector
-/// @param a First vector
-/// @param b Second vector
+/// @param a First column-vector
+/// @param b Second column-vector
 /// @return Dot product
 template <typename T, Int N>
 inline T
-dot(const DenseVector<T, N> & a, const DenseVector<T, N> & b)
+dot(const DenseMatrix<T, N, 1> & a, const DenseMatrix<T, N, 1> & b)
 {
     T dot = 0.;
     for (Int i = 0; i < N; i++)
-        dot += a(i) * b(i);
+        dot += a(i, 0) * b(i, 0);
     return dot;
 }
 
@@ -308,16 +308,16 @@ dot(const DenseVector<T, N> & a, const DenseVector<T, N> & b)
 ///
 /// @tparam T Data type
 /// @tparam N Size of the vector
-/// @param a First vector
-/// @param b Second vector
+/// @param a First row-vector
+/// @param b Second column-vector
 /// @return Dot product
 template <typename T, Int N>
 inline T
-dot(const DenseMatrix<T, 1, N> & a, const DenseVector<T, N> & b)
+dot(const DenseMatrix<T, 1, N> & a, const DenseMatrix<T, N, 1> & b)
 {
     T dot = 0.;
     for (Int i = 0; i < N; i++)
-        dot += a(0, i) * b(i);
+        dot += a(0, i) * b(i, 0);
     return dot;
 }
 
@@ -336,6 +336,17 @@ dot(const DenseMatrix<T, 1, N> & a, const DenseMatrix<T, 1, N> & b)
     for (Int i = 0; i < N; i++)
         dot += a(0, i) * b(0, i);
     return dot;
+}
+
+/// Dot product of 2 "scalars"
+///
+/// NOTE: This exists to avoid ambiguity between DenseMatrix<T, N, 1> and DenseMatrix<T, 1, N> for N
+/// = 1
+template <typename T>
+inline T
+dot(const DenseMatrix<T, 1, 1> & a, const DenseMatrix<T, 1, 1> & b)
+{
+    return a(0, 0) * b(0, 0);
 }
 
 /// Pointwise multiplication of 2 column-vectors

--- a/include/godzilla/DenseVector.h
+++ b/include/godzilla/DenseVector.h
@@ -113,12 +113,6 @@ public:
         return res / N;
     }
 
-    [[nodiscard]] DenseVector<Real, N>
-    cross(const DenseVector<Real, N> &) const
-    {
-        error("Cross product in {} dimensions is not unique.", N);
-    }
-
     /// Sum all vector elements, i.e \Sum_i vec[i]
     ///
     /// @return Sum of all elements
@@ -404,31 +398,6 @@ operator*(Real alpha, const DenseVector<T, N> & a)
 }
 
 // Cross product
-
-template <>
-inline DenseVector<Real, 1>
-DenseVector<Real, 1>::cross(const DenseVector<Real, 1> &) const
-{
-    error("Cross product of 1D vectors is not defined.");
-}
-
-template <>
-inline DenseVector<Real, 2>
-DenseVector<Real, 2>::cross(const DenseVector<Real, 2> &) const
-{
-    error("Cross product of 2D vectors is not defined.");
-}
-
-template <>
-inline DenseVector<Real, 3>
-DenseVector<Real, 3>::cross(const DenseVector<Real, 3> & a) const
-{
-    DenseVector<Real, 3> res;
-    res(0) = get(1) * a(2) - get(2) * a(1);
-    res(1) = -(get(0) * a(2) - get(2) * a(0));
-    res(2) = get(0) * a(1) - get(1) * a(0);
-    return res;
-}
 
 /// Compute cross product from 2 vectors
 ///

--- a/include/godzilla/DenseVector.h
+++ b/include/godzilla/DenseVector.h
@@ -32,7 +32,7 @@ public:
             set(i) = a[i];
     }
 
-    explicit DenseVector(const DenseMatrix<T, N, 1> & a)
+    DenseVector(const DenseMatrix<T, N, 1> & a)
     {
         for (Int i = 0; i < N; i++)
             set(i) = a(i, 0);
@@ -152,19 +152,6 @@ public:
         for (Int i = 0; i < N; i++)
             sum += get(i) * get(i);
         return std::sqrt(sum);
-    }
-
-    /// Point-wise multiplication of this vector with another one
-    ///
-    /// @param b Second vector
-    /// @return Vector with entries this[i]*b[i]
-    [[nodiscard]] DenseVector<T, N>
-    pointwise_mult(const DenseVector<T, N> & b) const
-    {
-        DenseVector<T, N> res;
-        for (Int i = 0; i < N; i++)
-            res(i) = get(i) * b(i);
-        return res;
     }
 
     /// Point-wise division of this vector with another one
@@ -351,20 +338,37 @@ dot(const DenseMatrix<T, 1, N> & a, const DenseMatrix<T, N, 1> & b)
     return dot;
 }
 
-/// Pointwise multiplication of 2 vectors
+/// Pointwise multiplication of 2 column-vectors
 ///
 /// @tparam T Data type
-/// @tparam N Size of the vector
-/// @param a First vector
-/// @param b Second vector
-/// @return Vector with vec[i] = a[i] * b[i]
+/// @tparam N Size of the column-vector
+/// @param a First column-vector
+/// @param b Second column-vector
+/// @return column-vector with vec[i] = a[i] * b[i]
 template <typename T, Int N>
-inline DenseVector<T, N>
-pointwise_mult(const DenseVector<T, N> & a, const DenseVector<T, N> & b)
+inline DenseMatrix<T, N, 1>
+pointwise_mult(const DenseMatrix<T, N, 1> & a, const DenseMatrix<T, N, 1> & b)
 {
-    DenseVector<T, N> res;
+    DenseMatrix<T, N, 1> res;
     for (Int i = 0; i < N; i++)
-        res(i) = a(i) * b(i);
+        res(i, 0) = a(i, 0) * b(i, 0);
+    return res;
+}
+
+/// Pointwise multiplication of 2 row-vectors
+///
+/// @tparam T Data type
+/// @tparam N Size of the row-vector
+/// @param a First row-vector
+/// @param b Second row-vector
+/// @return Row-vector with vec[i] = a[i] * b[i]
+template <typename T, Int N>
+inline DenseMatrix<T, 1, N>
+pointwise_mult(const DenseMatrix<T, 1, N> & a, const DenseMatrix<T, 1, N> & b)
+{
+    DenseMatrix<T, 1, N> res;
+    for (Int i = 0; i < N; i++)
+        res(0, i) = a(0, i) * b(0, i);
     return res;
 }
 

--- a/include/godzilla/DenseVector.h
+++ b/include/godzilla/DenseVector.h
@@ -5,12 +5,11 @@
 
 #include "godzilla/Types.h"
 #include "godzilla/Error.h"
+#include "godzilla/DenseMatrix.h"
 #include <cassert>
 
 namespace godzilla {
 
-template <typename T, Int ROWS, Int COLS>
-class DenseMatrix;
 template <typename T, Int ROWS>
 class DenseMatrixSymm;
 
@@ -19,7 +18,7 @@ class DenseMatrixSymm;
 /// @tparam T Data type of matrix entries
 /// @tparam N Number of entries
 template <typename T, Int N>
-class DenseVector {
+class DenseVector : public DenseMatrix<T, N, 1> {
 public:
     /// Create empty vector
     DenseVector() = default;
@@ -30,7 +29,13 @@ public:
     explicit DenseVector(const std::vector<T> & a)
     {
         for (Int i = 0; i < N; i++)
-            this->values[i] = a[i];
+            set(i) = a[i];
+    }
+
+    explicit DenseVector(const DenseMatrix<T, N, 1> & a)
+    {
+        for (Int i = 0; i < N; i++)
+            set(i) = a(i, 0);
     }
 
     /// Get an entry at location (i) for reading
@@ -41,7 +46,7 @@ public:
     get(Int i) const
     {
         assert((i >= 0) && (i < N));
-        return this->values[i];
+        return DenseMatrix<T, N, 1>::get(i, 0);
     }
 
     /// Get an entry at location (i) for writing
@@ -52,34 +57,7 @@ public:
     set(Int i)
     {
         assert((i >= 0) && (i < N));
-        return this->values[i];
-    }
-
-    /// Multiply all entries by a scalar `alpha`, i.e. vec[i] = alpha * vec[i]
-    ///
-    /// @param alpha Scalar value to multiply entries with
-    void
-    scale(Real alpha)
-    {
-        for (Int i = 0; i < N; i++)
-            this->values[i] *= alpha;
-    }
-
-    /// Set all vector elements to zero, i.e. vec[i] = 0.
-    void
-    zero()
-    {
-        zero_impl(std::is_fundamental<T>());
-    }
-
-    /// Set `alpha` into all vector elements, i.e. vec[i] = alpha
-    ///
-    /// @param alpha Constant to set into vector elements
-    void
-    set_values(const T & alpha)
-    {
-        for (Int i = 0; i < N; i++)
-            this->values[i] = alpha;
+        return DenseMatrix<T, N, 1>::set(i, 0);
     }
 
     /// Add `a` to this vector, i.e. vec[i] += a[i]
@@ -89,7 +67,7 @@ public:
     add(const DenseVector<T, N> & a)
     {
         for (Int i = 0; i < N; i++)
-            this->values[i] += a(i);
+            set(i) += a(i);
     }
 
     /// Add `a` to each element of this vector, i.e. vec[i] += a
@@ -99,7 +77,7 @@ public:
     add(T a)
     {
         for (Int i = 0; i < N; i++)
-            this->values[i] += a;
+            set(i) += a;
     }
 
     /// Subtract `a` from this vector, i.e. vec[i] -= a[i]
@@ -109,7 +87,7 @@ public:
     subtract(const DenseVector<T, N> & a)
     {
         for (Int i = 0; i < N; i++)
-            this->values[i] -= a(i);
+            set(i) -= a(i);
     }
 
     /// Normalize this vector
@@ -119,7 +97,7 @@ public:
         T mag = magnitude();
         if (mag > 0) {
             for (Int i = 0; i < N; i++)
-                this->values[i] /= mag;
+                set(i) /= mag;
         }
     }
 
@@ -131,21 +109,8 @@ public:
     {
         Real res = 0.;
         for (Int i = 0; i < N; i++)
-            res += this->values[i];
+            res += get(i);
         return res / N;
-    }
-
-    /// Compute dot product, i.e. \Sum_i vec[i] * a[i]
-    ///
-    /// @param a Dotted vector
-    /// @return Dot product
-    [[nodiscard]] T
-    dot(const DenseVector<T, N> & a) const
-    {
-        T dot = 0.;
-        for (Int i = 0; i < N; i++)
-            dot += this->values[i] * a(i);
-        return dot;
     }
 
     [[nodiscard]] DenseVector<Real, N>
@@ -173,7 +138,7 @@ public:
     {
         T sum = 0.;
         for (Int i = 0; i < N; i++)
-            sum += this->values[i];
+            sum += get(i);
         return sum;
     }
 
@@ -185,7 +150,7 @@ public:
     {
         T sum = 0.;
         for (Int i = 0; i < N; i++)
-            sum += this->values[i] * this->values[i];
+            sum += get(i) * get(i);
         return std::sqrt(sum);
     }
 
@@ -291,46 +256,14 @@ public:
     }
 
     template <Int M>
-    DenseVector<T, M>
-    operator*(const DenseMatrix<T, N, M> & a) const
+    DenseMatrix<T, N, M>
+    operator*(const DenseMatrix<T, 1, M> & a) const
     {
-        DenseVector<T, M> res;
-        for (Int j = 0; j < M; j++) {
-            T prod = 0;
-            for (Int i = 0; i < N; i++)
-                prod += get(i) * a(i, j);
-            res(j) = prod;
-        }
+        DenseMatrix<T, N, M> res;
+        for (Int i = 0; i < M; i++)
+            for (Int j = 0; j < N; j++)
+                res(j, i) = get(j) * a(0, i);
         return res;
-    }
-
-    DenseVector<T, N>
-    operator*(const DenseMatrixSymm<T, N> & a) const
-    {
-        DenseVector<T, N> res;
-        for (Int j = 0; j < N; j++) {
-            T prod = 0;
-            for (Int i = 0; i < N; i++)
-                prod += get(i) * a(i, j);
-            res(j) = prod;
-        }
-        return res;
-    }
-
-    template <Int M>
-    DenseVector<T, M>
-    operator*(const DenseVector<DenseVector<T, N>, M> & a) const
-    {
-        DenseVector<T, M> res;
-        for (Int j = 0; j < M; j++)
-            res(j) = *this * a(j);
-        return res;
-    }
-
-    T
-    operator*(const DenseVector<T, N> & a) const
-    {
-        return this->dot(a);
     }
 
     DenseVector<T, N>
@@ -365,47 +298,6 @@ public:
             set(i) -= a(i);
         return *this;
     }
-
-    [[deprecated("Use data() instead")]] T *
-    get_data()
-    {
-        return &this->values[0];
-    }
-
-    [[deprecated("Use data() instead")]] const T *
-    get_data() const
-    {
-        return &this->values[0];
-    }
-
-    T *
-    data()
-    {
-        return &this->values[0];
-    }
-
-    const T *
-    data() const
-    {
-        return &this->values[0];
-    }
-
-protected:
-    void
-    zero_impl(std::true_type)
-    {
-        set_values(0);
-    }
-
-    void
-    zero_impl(std::false_type)
-    {
-        for (Int i = 0; i < N; i++)
-            this->values[i].zero();
-    }
-
-private:
-    T values[N];
 };
 
 /// Compute dot product of 2 vectors
@@ -422,6 +314,40 @@ dot(const DenseVector<T, N> & a, const DenseVector<T, N> & b)
     T dot = 0.;
     for (Int i = 0; i < N; i++)
         dot += a(i) * b(i);
+    return dot;
+}
+
+/// Compute dot product of 2 vectors
+///
+/// @tparam T Data type
+/// @tparam N Size of the vector
+/// @param a First vector
+/// @param b Second vector
+/// @return Dot product
+template <typename T, Int N>
+inline T
+dot(const DenseMatrix<T, 1, N> & a, const DenseVector<T, N> & b)
+{
+    T dot = 0.;
+    for (Int i = 0; i < N; i++)
+        dot += a(0, i) * b(i);
+    return dot;
+}
+
+/// Compute dot product of 2 vectors
+///
+/// @tparam T Data type
+/// @tparam N Size of the vector
+/// @param a First vector
+/// @param b Second vector
+/// @return Dot product
+template <typename T, Int N>
+inline T
+dot(const DenseMatrix<T, 1, N> & a, const DenseMatrix<T, N, 1> & b)
+{
+    T dot = 0.;
+    for (Int i = 0; i < N; i++)
+        dot += a(0, i) * b(i, 0);
     return dot;
 }
 
@@ -540,16 +466,6 @@ mat_row(const DenseVector<DenseVector<T, M>, N> & a)
     return res;
 }
 
-template <typename T, Int N>
-inline DenseMatrix<T, N, 1>
-mat_row(const DenseVector<T, N> & a)
-{
-    DenseMatrix<T, N, 1> res;
-    for (Int i = 0; i < N; i++)
-        res(i, 0) = a(i);
-    return res;
-}
-
 /// Convert DenseVector<DenseVector, M>, N> into a DenseMatrix<M, N>
 ///
 /// @tparam T Data type
@@ -565,40 +481,6 @@ mat_col(const DenseVector<DenseVector<T, M>, N> & a)
     for (Int i = 0; i < N; i++)
         for (Int j = 0; j < M; j++)
             res(j, i) = a(i)(j);
-    return res;
-}
-
-/// Convert a DenseVector<T, N> into a column matrix
-///
-/// @tparam T Data type
-/// @tparam N Number of columns
-/// @param a Input vector
-/// @return Column matrix with values of `a`
-template <typename T, Int N>
-inline DenseMatrix<T, 1, N>
-mat_col(const DenseVector<T, N> & a)
-{
-    DenseMatrix<T, 1, N> res;
-    for (Int i = 0; i < N; i++)
-        res(0, i) = a(i);
-    return res;
-}
-
-/// Transpose DenseVector<DenseVector<T>>
-///
-/// @tparam T Data type
-/// @tparam N Number of rows in the input "matrix", but number of columns in the resulting matrix
-/// @tparam M Number of columns in the input "matrix", but number of rows in the resulting matrix
-/// @param a Input "matrix"
-/// @return Transposed version of DenseVector<DenseVector<T>> with values from `a`
-template <typename T, Int N, Int M>
-inline DenseVector<DenseVector<T, N>, M>
-transpose(const DenseVector<DenseVector<T, M>, N> & a)
-{
-    DenseVector<DenseVector<T, N>, M> res;
-    for (Int i = 0; i < N; i++)
-        for (Int j = 0; j < M; j++)
-            res(j)(i) = a(i)(j);
     return res;
 }
 

--- a/include/godzilla/DenseVector.h
+++ b/include/godzilla/DenseVector.h
@@ -321,20 +321,20 @@ dot(const DenseMatrix<T, 1, N> & a, const DenseVector<T, N> & b)
     return dot;
 }
 
-/// Compute dot product of 2 vectors
+/// Compute dot product of 2 row-vectors
 ///
 /// @tparam T Data type
-/// @tparam N Size of the vector
-/// @param a First vector
-/// @param b Second vector
+/// @tparam N Size of the row-vector
+/// @param a First row-vector
+/// @param b Second row-vector
 /// @return Dot product
 template <typename T, Int N>
 inline T
-dot(const DenseMatrix<T, 1, N> & a, const DenseMatrix<T, N, 1> & b)
+dot(const DenseMatrix<T, 1, N> & a, const DenseMatrix<T, 1, N> & b)
 {
     T dot = 0.;
     for (Int i = 0; i < N; i++)
-        dot += a(0, i) * b(i, 0);
+        dot += a(0, i) * b(0, i);
     return dot;
 }
 

--- a/include/godzilla/DenseVector.h
+++ b/include/godzilla/DenseVector.h
@@ -119,17 +119,6 @@ public:
         error("Cross product in {} dimensions is not unique.", N);
     }
 
-    template <Int M>
-    DenseMatrix<Real, N, M>
-    tensor_prod(const DenseVector<Real, M> & a) const
-    {
-        DenseMatrix<Real, N, M> res;
-        for (Int i = 0; i < N; i++)
-            for (Int j = 0; j < M; j++)
-                res(i, j) = get(i) * a(j);
-        return res;
-    }
-
     /// Sum all vector elements, i.e \Sum_i vec[i]
     ///
     /// @return Sum of all elements
@@ -450,17 +439,6 @@ cross_product(const DenseVector<Real, 3> & a, const DenseVector<Real, 3> & b)
     res(1) = -(a(0) * b(2) - a(2) * b(0));
     res(2) = a(0) * b(1) - a(1) * b(0);
     return res;
-}
-
-template <typename T, Int M, Int N>
-inline DenseMatrix<T, M, N>
-tensor_product(const DenseVector<T, M> & a, const DenseVector<T, N> & b)
-{
-    DenseMatrix<T, M, N> prod;
-    for (Int i = 0; i < M; i++)
-        for (Int j = 0; j < N; j++)
-            prod(i, j) = a(i) * b(j);
-    return prod;
 }
 
 /// Convert DenseVector<DenseVector, M>, N> into a DenseMatrix<N, M>

--- a/include/godzilla/DenseVector.h
+++ b/include/godzilla/DenseVector.h
@@ -143,19 +143,6 @@ public:
         return std::sqrt(sum);
     }
 
-    /// Point-wise division of this vector with another one
-    ///
-    /// @param b Second vector
-    /// @return Vector with entries this[i]/b[i]
-    [[nodiscard]] DenseVector<T, N>
-    pointwise_div(const DenseVector<T, N> & b) const
-    {
-        DenseVector<T, N> res;
-        for (Int i = 0; i < N; i++)
-            res(i) = get(i) / b(i);
-        return res;
-    }
-
     /// Find the minimum value of the elements
     ///
     /// @return The minimum value of the elements
@@ -372,20 +359,37 @@ pointwise_mult(const DenseMatrix<T, 1, N> & a, const DenseMatrix<T, 1, N> & b)
     return res;
 }
 
-/// Pointwise division of 2 vectors
+/// Pointwise division of 2 column-vectors
 ///
 /// @tparam T Data type
 /// @tparam N Size of the vector
-/// @param a First vector
-/// @param b Second vector
-/// @return Vector with vec[i] = a[i] / b[i]
+/// @param a First column-vector
+/// @param b Second column-vector
+/// @return Column-vector with vec[i] = a[i] / b[i]
 template <typename T, Int N>
-inline DenseVector<T, N>
-pointwise_div(const DenseVector<T, N> & a, const DenseVector<T, N> & b)
+inline DenseMatrix<T, N, 1>
+pointwise_div(const DenseMatrix<T, N, 1> & a, const DenseMatrix<T, N, 1> & b)
 {
-    DenseVector<T, N> res;
+    DenseMatrix<T, N, 1> res;
     for (Int i = 0; i < N; i++)
-        res(i) = a(i) / b(i);
+        res(i, 0) = a(i, 0) / b(i, 0);
+    return res;
+}
+
+/// Pointwise division of 2 row-vectors
+///
+/// @tparam T Data type
+/// @tparam N Size of the vector
+/// @param a First row-vector
+/// @param b Second row-vector
+/// @return Row-vector with vec[i] = a[i] / b[i]
+template <typename T, Int N>
+inline DenseMatrix<T, 1, N>
+pointwise_div(const DenseMatrix<T, 1, N> & a, const DenseMatrix<T, 1, N> & b)
+{
+    DenseMatrix<T, 1, N> res;
+    for (Int i = 0; i < N; i++)
+        res(0, i) = a(0, i) / b(0, i);
     return res;
 }
 

--- a/include/godzilla/FEBoundary.h
+++ b/include/godzilla/FEBoundary.h
@@ -152,7 +152,8 @@ private:
                 this->mesh->compute_cell_geometry(cell, &vol, nullptr, nullptr);
                 auto connect = this->mesh->get_connectivity(cell);
                 auto lnne = utils::index_of(connect, vertex);
-                auto inc = vol * (*this->grad_phi)(cell).row(lnne);
+                auto inc =
+                    DenseVector<Real, DIM>(transpose(vol * (*this->grad_phi)(cell).row(lnne)));
                 sum += inc;
             }
             auto mag = sum.magnitude();

--- a/include/godzilla/FEBoundary.h
+++ b/include/godzilla/FEBoundary.h
@@ -35,7 +35,7 @@ template <ElementType ELEM_TYPE, Int DIM, Int N_ELEM_NODES = get_num_element_nod
 class BoundaryInfo : public BoundaryInfoAbstract {
 public:
     BoundaryInfo(UnstructuredMesh * mesh,
-                 const Array1D<DenseMatrix<Real, N_ELEM_NODES, DIM>> * grad_phi,
+                 const Array1D<DenseMatrix<Real, DIM, N_ELEM_NODES>> * grad_phi,
                  const IndexSet & facets) :
         mesh(mesh),
         grad_phi(grad_phi),
@@ -121,7 +121,7 @@ private:
             auto elem_conn = this->mesh->get_connectivity(ie);
             Int local_idx = get_local_face_index(elem_conn, face_conn);
             auto edge_length = this->length(i);
-            auto grad = (*this->grad_phi)(ie).row(local_idx);
+            auto grad = DenseVector<Real, DIM>((*this->grad_phi)(ie).column(local_idx));
             this->normal(i) = fe::normal<ELEM_TYPE>(volume, edge_length, grad);
         }
     }
@@ -152,8 +152,7 @@ private:
                 this->mesh->compute_cell_geometry(cell, &vol, nullptr, nullptr);
                 auto connect = this->mesh->get_connectivity(cell);
                 auto lnne = utils::index_of(connect, vertex);
-                auto inc =
-                    DenseVector<Real, DIM>(transpose(vol * (*this->grad_phi)(cell).row(lnne)));
+                auto inc = DenseVector<Real, DIM>(vol * (*this->grad_phi)(cell).column(lnne));
                 sum += inc;
             }
             auto mag = sum.magnitude();
@@ -171,7 +170,7 @@ private:
     /// Mesh
     UnstructuredMesh * mesh;
     /// Gradients of shape functions
-    const Array1D<DenseMatrix<Real, N_ELEM_NODES, DIM>> * grad_phi;
+    const Array1D<DenseMatrix<Real, DIM, N_ELEM_NODES>> * grad_phi;
 
 public:
     /// IndexSet with boundary facets

--- a/include/godzilla/FEOps.h
+++ b/include/godzilla/FEOps.h
@@ -45,29 +45,6 @@ gradient(const DenseVector<Real, N_VALS> & vals, const DenseMatrix<Real, D, N_VA
 
 /// Compute gradient of a vector-valued quantity
 ///
-/// @tparam N_COMPS Number of vector component
-/// @tparam D Spatial dimension
-/// @tparam N_VALS Number of values per element
-/// @param vals Values
-/// @param grad_phi Gradient of test functions
-/// @return Computed gradient
-template <Int N_COMPS, Int D, Int N_VALS>
-inline DenseMatrix<Real, D, N_COMPS>
-gradient(const DenseVector<DenseVector<Real, N_COMPS>, N_VALS> & vals,
-         const DenseMatrix<Real, D, N_VALS> & grad_phi)
-{
-    DenseMatrix<Real, D, N_COMPS> grad;
-    grad.set_values(0.);
-    for (Int i = 0; i < D; i++) {
-        for (Int j = 0; j < N_COMPS; j++)
-            for (Int k = 0; k < N_VALS; k++)
-                grad(i, j) += vals(k)(j) * grad_phi(i, k);
-    }
-    return grad;
-}
-
-/// Compute gradient of a vector-valued quantity
-///
 /// @tparam C Number of vector component
 /// @tparam D Spatial dimension
 /// @tparam N Number of values per element

--- a/include/godzilla/FEOps.h
+++ b/include/godzilla/FEOps.h
@@ -37,10 +37,10 @@ linear_combination(const DenseVector<Real, N_VALS> & a, const DenseVector<T, N_V
 /// @param grad_phi Gradient of test functions
 /// @return Computed gradient
 template <Int D, Int N_VALS>
-inline DenseMatrix<Real, 1, D>
-gradient(const DenseVector<Real, N_VALS> & vals, const DenseMatrix<Real, N_VALS, D> & grad_phi)
+inline DenseVector<Real, D>
+gradient(const DenseVector<Real, N_VALS> & vals, const DenseMatrix<Real, D, N_VALS> & grad_phi)
 {
-    return transpose(vals) * grad_phi;
+    return grad_phi * vals;
 }
 
 /// Compute gradient of a vector-valued quantity
@@ -54,39 +54,31 @@ gradient(const DenseVector<Real, N_VALS> & vals, const DenseMatrix<Real, N_VALS,
 template <Int N_COMPS, Int D, Int N_VALS>
 inline DenseMatrix<Real, D, N_COMPS>
 gradient(const DenseVector<DenseVector<Real, N_COMPS>, N_VALS> & vals,
-         const DenseMatrix<Real, N_VALS, D> & grad_phi)
+         const DenseMatrix<Real, D, N_VALS> & grad_phi)
 {
     DenseMatrix<Real, D, N_COMPS> grad;
     grad.set_values(0.);
     for (Int i = 0; i < D; i++) {
         for (Int j = 0; j < N_COMPS; j++)
             for (Int k = 0; k < N_VALS; k++)
-                grad(i, j) += vals(k)(j) * grad_phi(k, i);
+                grad(i, j) += vals(k)(j) * grad_phi(i, k);
     }
     return grad;
 }
 
 /// Compute gradient of a vector-valued quantity
 ///
-/// @tparam N_COMPS Number of vector component
+/// @tparam C Number of vector component
 /// @tparam D Spatial dimension
-/// @tparam N_VALS Number of values per element
+/// @tparam N Number of values per element
 /// @param vals Values
 /// @param grad_phi Gradient of test functions
 /// @return Computed gradient
-template <Int N_COMPS, Int D, Int N_VALS>
-inline DenseMatrix<Real, D, N_COMPS>
-gradient(const DenseMatrix<Real, N_VALS, N_COMPS> & vals,
-         const DenseMatrix<Real, N_VALS, D> & grad_phi)
+template <Int C, Int D, Int N>
+inline DenseMatrix<Real, D, C>
+gradient(const DenseMatrix<Real, N, C> & vals, const DenseMatrix<Real, D, N> & grad_phi)
 {
-    DenseMatrix<Real, D, N_COMPS> grad;
-    grad.set_values(0.);
-    for (Int i = 0; i < D; i++) {
-        for (Int j = 0; j < N_COMPS; j++)
-            for (Int k = 0; k < N_VALS; k++)
-                grad(i, j) += vals(k, j) * grad_phi(k, i);
-    }
-    return grad;
+    return grad_phi * vals;
 }
 
 } // namespace fe

--- a/include/godzilla/FEOps.h
+++ b/include/godzilla/FEOps.h
@@ -37,10 +37,10 @@ linear_combination(const DenseVector<Real, N_VALS> & a, const DenseVector<T, N_V
 /// @param grad_phi Gradient of test functions
 /// @return Computed gradient
 template <Int D, Int N_VALS>
-inline DenseVector<Real, D>
+inline DenseMatrix<Real, 1, D>
 gradient(const DenseVector<Real, N_VALS> & vals, const DenseMatrix<Real, N_VALS, D> & grad_phi)
 {
-    return vals * grad_phi;
+    return transpose(vals) * grad_phi;
 }
 
 /// Compute gradient of a vector-valued quantity

--- a/test/src/DenseMatrixSymm_test.cpp
+++ b/test/src/DenseMatrixSymm_test.cpp
@@ -248,34 +248,6 @@ TEST(DenseMatrixSymmTest, op_mult_vec)
     EXPECT_EQ(res(2), 7.);
 }
 
-TEST(DenseMatrixSymmTest, op_mult_vec_vec)
-{
-    auto a = DenseMatrixSymm<Real, 3>();
-    a(0, 0) = 2;
-    a(0, 1) = -3;
-    a(0, 2) = 4;
-    a(1, 1) = 6;
-    a(1, 2) = -7;
-    a(2, 2) = 5;
-    auto b = DenseVector<DenseVector<Real, 4>, 3>();
-    b(0) = DenseVector<Real, 4>({ -1, 0, 2, 3 });
-    b(1) = DenseVector<Real, 4>({ -5, 1, -2, 1 });
-    b(2) = DenseVector<Real, 4>({ -4, 2, 0, 1 });
-    auto m = a * b;
-    EXPECT_EQ(m(0)(0), -3.);
-    EXPECT_EQ(m(0)(1), 5.);
-    EXPECT_EQ(m(0)(2), 10.);
-    EXPECT_EQ(m(0)(3), 7.);
-    EXPECT_EQ(m(1)(0), 1.);
-    EXPECT_EQ(m(1)(1), -8.);
-    EXPECT_EQ(m(1)(2), -18.);
-    EXPECT_EQ(m(1)(3), -10.);
-    EXPECT_EQ(m(2)(0), 11.);
-    EXPECT_EQ(m(2)(1), 3.);
-    EXPECT_EQ(m(2)(2), 22.);
-    EXPECT_EQ(m(2)(3), 10.);
-}
-
 TEST(DenseMatrixSymmTest, op_mult_mat_symm)
 {
     auto a = DenseMatrixSymm<Real, 3>();

--- a/test/src/DenseMatrixSymm_test.cpp
+++ b/test/src/DenseMatrixSymm_test.cpp
@@ -298,21 +298,21 @@ TEST(DenseMatrixSymmTest, det1)
 {
     auto m = DenseMatrixSymm<Real, 1>();
     m(0, 0) = 2.;
-    EXPECT_EQ(m.det(), 2.);
+    EXPECT_EQ(determinant(m), 2.);
 }
 
 TEST(DenseMatrixSymmTest, det2)
 {
     auto m = DenseMatrixSymm<Real, 2>();
     m.set_values({ 2, 3, 4 });
-    EXPECT_EQ(m.det(), -1.);
+    EXPECT_EQ(determinant(m), -1.);
 }
 
 TEST(DenseMatrixSymmTest, det3)
 {
     auto m = DenseMatrixSymm<Real, 3>();
     m.set_values({ 2, -3, 6, 4, 7, -1 });
-    EXPECT_EQ(m.det(), -365.);
+    EXPECT_EQ(determinant(m), -365.);
 }
 
 TEST(DenseMatrixSymmTest, det4)
@@ -324,7 +324,7 @@ TEST(DenseMatrixSymmTest, det4)
     //    m.set_row(2, { 0, 1, 0, 2 });
     //    m.set_row(3, { 1, -2, -3, 2 });
     //    EXPECT_EQ(m.det(), 21.);
-    EXPECT_DEATH({ auto d = m.det(); }, "Determinant is not implemented for 4x4 matrices, yet.");
+    EXPECT_DEATH({ auto d = determinant(m); }, "Determinant is not implemented for 4x4 matrices, yet.");
 }
 
 TEST(DenseMatrixSymmTest, transpose3)

--- a/test/src/DenseMatrix_test.cpp
+++ b/test/src/DenseMatrix_test.cpp
@@ -512,26 +512,6 @@ TEST(DenseMatrixTest, mult_mat)
     EXPECT_EQ(m(1, 3), -16.);
 }
 
-TEST(DenseMatrixTest, mult_vec_vec)
-{
-    auto a = DenseMatrix<Real, 2, 3>();
-    a.set_row(0, { 2, -3, 4 });
-    a.set_row(1, { -5, 6, -7 });
-    auto b = DenseVector<DenseVector<Real, 4>, 3>();
-    b(0) = DenseVector<Real, 4>({ -1, 0, 2, 3 });
-    b(1) = DenseVector<Real, 4>({ -5, 1, -2, 1 });
-    b(2) = DenseVector<Real, 4>({ -4, 2, 0, 1 });
-    auto m = a * b;
-    EXPECT_EQ(m(0)(0), -3.);
-    EXPECT_EQ(m(0)(1), 5.);
-    EXPECT_EQ(m(0)(2), 10.);
-    EXPECT_EQ(m(0)(3), 7.);
-    EXPECT_EQ(m(1)(0), 3.);
-    EXPECT_EQ(m(1)(1), -8.);
-    EXPECT_EQ(m(1)(2), -22.);
-    EXPECT_EQ(m(1)(3), -16.);
-}
-
 TEST(DenseMatrixTest, copy_ctor)
 {
     DenseMatrixSymm<Real, 3> symm({ 1, -1, 2, 3, -2, -1 });
@@ -588,17 +568,17 @@ TEST(DenseMatrixTest, column)
     m.set_row(1, { 3, -1, -2 });
     m.set_row(2, { 0, -3, 4 });
 
-    DenseVector<Real, 3> c0 = m.column(0);
+    DenseVector<Real, 3> c0(m.column(0));
     EXPECT_EQ(c0(0), 2.);
     EXPECT_EQ(c0(1), 3.);
     EXPECT_EQ(c0(2), 0.);
 
-    DenseVector<Real, 3> c1 = m.column(1);
+    DenseVector<Real, 3> c1(m.column(1));
     EXPECT_EQ(c1(0), 1.);
     EXPECT_EQ(c1(1), -1.);
     EXPECT_EQ(c1(2), -3.);
 
-    DenseVector<Real, 3> c2 = m.column(2);
+    DenseVector<Real, 3> c2(m.column(2));
     EXPECT_EQ(c2(0), 5.);
     EXPECT_EQ(c2(1), -2.);
     EXPECT_EQ(c2(2), 4.);
@@ -611,20 +591,20 @@ TEST(DenseMatrixTest, row)
     m.set_row(1, { 3, -1, -2 });
     m.set_row(2, { 0, -3, 4 });
 
-    DenseVector<Real, 3> r0 = m.row(0);
-    EXPECT_EQ(r0(0), 2.);
-    EXPECT_EQ(r0(1), 1.);
-    EXPECT_EQ(r0(2), 5.);
+    auto r0 = m.row(0);
+    EXPECT_EQ(r0(0, 0), 2.);
+    EXPECT_EQ(r0(0, 1), 1.);
+    EXPECT_EQ(r0(0, 2), 5.);
 
-    DenseVector<Real, 3> r1 = m.row(1);
-    EXPECT_EQ(r1(0), 3.);
-    EXPECT_EQ(r1(1), -1.);
-    EXPECT_EQ(r1(2), -2.);
+    auto r1 = m.row(1);
+    EXPECT_EQ(r1(0, 0), 3.);
+    EXPECT_EQ(r1(0, 1), -1.);
+    EXPECT_EQ(r1(0, 2), -2.);
 
-    DenseVector<Real, 3> r2 = m.row(2);
-    EXPECT_EQ(r2(0), 0.);
-    EXPECT_EQ(r2(1), -3.);
-    EXPECT_EQ(r2(2), 4.);
+    auto r2 = m.row(2);
+    EXPECT_EQ(r2(0, 0), 0.);
+    EXPECT_EQ(r2(0, 1), -3.);
+    EXPECT_EQ(r2(0, 2), 4.);
 }
 
 TEST(DenseMatrixTest, diagonal)
@@ -702,4 +682,23 @@ TEST(DenseMatrixTest, out)
     auto out = testing::internal::GetCapturedStdout();
     EXPECT_THAT(out, HasSubstr("(1, 2, 3)"));
     EXPECT_THAT(out, HasSubstr("(6, 5, 4)"));
+}
+
+TEST(DenseMatrixTest, transpose)
+{
+    DenseMatrix<Real, 2, 3> A;
+    A(0, 0) = -2;
+    A(0, 1) = 5;
+    A(0, 2) = 3;
+    A(1, 0) = 1;
+    A(1, 1) = -1;
+    A(1, 2) = 2;
+
+    auto m = transpose(A);
+    EXPECT_EQ(m(0, 0), -2.);
+    EXPECT_EQ(m(0, 1), 1.);
+    EXPECT_EQ(m(1, 0), 5.);
+    EXPECT_EQ(m(1, 1), -1.);
+    EXPECT_EQ(m(2, 0), 3.);
+    EXPECT_EQ(m(2, 1), 2.);
 }

--- a/test/src/DenseMatrix_test.cpp
+++ b/test/src/DenseMatrix_test.cpp
@@ -382,7 +382,7 @@ TEST(DenseMatrixTest, det1)
 {
     auto m = DenseMatrix<Real, 1>();
     m(0, 0) = 2.;
-    EXPECT_EQ(m.det(), 2.);
+    EXPECT_EQ(determinant(m), 2.);
 }
 
 TEST(DenseMatrixTest, det2)
@@ -390,7 +390,7 @@ TEST(DenseMatrixTest, det2)
     auto m = DenseMatrix<Real, 2>();
     m.set_row(0, { 2, 3 });
     m.set_row(1, { 4, 5 });
-    EXPECT_EQ(m.det(), -2.);
+    EXPECT_EQ(determinant(m), -2.);
 }
 
 TEST(DenseMatrixTest, det3)
@@ -399,7 +399,7 @@ TEST(DenseMatrixTest, det3)
     m.set_row(0, { 2, -3, 4 });
     m.set_row(1, { -5, 6, 7 });
     m.set_row(2, { 8, 9, -1 });
-    EXPECT_EQ(m.det(), -663.);
+    EXPECT_EQ(determinant(m), -663.);
 }
 
 TEST(DenseMatrixTest, det4)
@@ -410,7 +410,7 @@ TEST(DenseMatrixTest, det4)
     m.set_row(2, { 0, 1, 0, 2 });
     m.set_row(3, { 1, -2, -3, 2 });
     //    EXPECT_EQ(m.det(), 21.);
-    EXPECT_DEATH({ auto d = m.det(); }, "Determinant is not implemented for 4x4 matrices, yet.");
+    EXPECT_DEATH({ auto d = determinant(m); }, "Determinant is not implemented for 4x4 matrices, yet.");
 }
 
 TEST(DenseMatrixTest, inv1)

--- a/test/src/DenseMatrix_test.cpp
+++ b/test/src/DenseMatrix_test.cpp
@@ -417,7 +417,7 @@ TEST(DenseMatrixTest, inv1)
 {
     auto m = DenseMatrix<Real, 1>();
     m(0, 0) = 2.;
-    auto inv = m.inverse();
+    auto inv = inverse(m);
     EXPECT_EQ(inv(0, 0), 1. / 2.);
 }
 
@@ -426,7 +426,7 @@ TEST(DenseMatrixTest, inv2)
     auto m = DenseMatrix<Real, 2>();
     m.set_row(0, { 2, 3 });
     m.set_row(1, { 4, 5 });
-    auto inv = m.inverse();
+    auto inv = inverse(m);
     EXPECT_EQ(inv(0, 0), -5. / 2);
     EXPECT_EQ(inv(0, 1), 3. / 2.);
     EXPECT_EQ(inv(1, 0), 2.);
@@ -438,7 +438,7 @@ TEST(DenseMatrixDeathTest, inv2_singular)
     auto m = DenseMatrix<Real, 2>();
     m.set_row(0, { 1, 2 });
     m.set_row(1, { 2, 4 });
-    EXPECT_THROW_MSG(m.inverse(), "Inverting of a matrix failed: matrix is singular.");
+    EXPECT_THROW_MSG(inverse(m), "Inverting of a matrix failed: matrix is singular.");
 }
 
 TEST(DenseMatrixTest, inv3)
@@ -447,7 +447,7 @@ TEST(DenseMatrixTest, inv3)
     m.set_row(0, { 2, -3, 4 });
     m.set_row(1, { -5, 6, -7 });
     m.set_row(2, { 8, -1, -2 });
-    auto inv = m.inverse();
+    auto inv = inverse(m);
     EXPECT_DOUBLE_EQ(inv(0, 0), 19. / 12.);
     EXPECT_DOUBLE_EQ(inv(0, 1), 5. / 6.);
     EXPECT_DOUBLE_EQ(inv(0, 2), 1. / 4.);
@@ -465,13 +465,13 @@ TEST(DenseMatrixDeathTest, inv3_singular)
     m.set_row(0, { 1, 2, 3 });
     m.set_row(1, { 2, 4, 6 });
     m.set_row(2, { 1, 1, 1 });
-    EXPECT_THROW_MSG(m.inverse(), "Inverting of a matrix failed: matrix is singular.");
+    EXPECT_THROW_MSG(inverse(m), "Inverting of a matrix failed: matrix is singular.");
 }
 
 TEST(DenseMatrixDeathTest, inv4)
 {
     auto m = DenseMatrix<Real, 4>();
-    EXPECT_DEATH(m.inverse(), "Inverse is not implemented for 4x4 matrices, yet.");
+    EXPECT_DEATH(inverse(m), "Inverse is not implemented for 4x4 matrices, yet.");
 }
 
 TEST(DenseMatrixTest, transpose3)

--- a/test/src/DenseVector_test.cpp
+++ b/test/src/DenseVector_test.cpp
@@ -114,12 +114,12 @@ TEST(DenseVectorTest, dot_row_vec)
     EXPECT_EQ(dot(a, b), 10.);
 }
 
-TEST(DenseVectorTest, dot_row_col)
+TEST(DenseVectorTest, dot_row_row)
 {
     DenseMatrix<Real, 1, 3> a;
     a.set_row(0, { 2., 3., 4. });
-    DenseMatrix<Real, 3, 1> b;
-    b.set_col(0, { 4., 2., -1. });
+    DenseMatrix<Real, 1, 3> b;
+    b.set_row(0, { 4., 2., -1. });
     EXPECT_EQ(dot(a, b), 10.);
 }
 

--- a/test/src/DenseVector_test.cpp
+++ b/test/src/DenseVector_test.cpp
@@ -241,19 +241,6 @@ TEST(DenseVectorDeathTest, get_out_of_range)
 
 #endif
 
-TEST(DenseVectorTest, tensor_prod)
-{
-    DenseVector<Real, 3> a({ -2., 5., 1. });
-    DenseVector<Real, 2> b({ 3, 1 });
-    auto m = a.tensor_prod(b);
-    EXPECT_EQ(m(0, 0), -6.);
-    EXPECT_EQ(m(0, 1), -2.);
-    EXPECT_EQ(m(1, 0), 15.);
-    EXPECT_EQ(m(1, 1), 5.);
-    EXPECT_EQ(m(2, 0), 3.);
-    EXPECT_EQ(m(2, 1), 1.);
-}
-
 TEST(DenseVectorDeathTest, cross_prod_1_2)
 {
     DenseVector<Real, 1> a({ -2. });
@@ -373,9 +360,11 @@ TEST(DenseVectorTest, out)
 
 TEST(DenseVectorTest, tensor_product)
 {
-    DenseVector<Real, 3> a({ 1, 2, 3 });
-    DenseVector<Real, 2> b({ 5, 7 });
-    auto prod = tensor_product(a, b);
+    DenseMatrix<Real, 3, 1> a;
+    a.set_col(0, { 1, 2, 3 });
+    DenseMatrix<Real, 1, 2> b;
+    b.set_row(0, { 5, 7 });
+    auto prod = a * b;
     EXPECT_DOUBLE_EQ(prod(0, 0), 5.);
     EXPECT_DOUBLE_EQ(prod(1, 0), 10.);
     EXPECT_DOUBLE_EQ(prod(2, 0), 15.);

--- a/test/src/DenseVector_test.cpp
+++ b/test/src/DenseVector_test.cpp
@@ -243,29 +243,7 @@ TEST(DenseVectorDeathTest, get_out_of_range)
 
 #endif
 
-TEST(DenseVectorDeathTest, cross_prod_1_2)
-{
-    DenseVector<Real, 1> a({ -2. });
-    EXPECT_DEATH({ auto v = a.cross(a); }, "Cross product of 1D vectors is not defined.");
-
-    DenseVector<Real, 2> b({ -2., 5. });
-    EXPECT_DEATH({ auto v = b.cross(b); }, "Cross product of 2D vectors is not defined.");
-
-    DenseVector<Real, 4> c({ -2., 5., 5., 6. });
-    EXPECT_DEATH({ auto v = c.cross(c); }, "Cross product in 4 dimensions is not unique.");
-}
-
 TEST(DenseVectorTest, cross_prod_3)
-{
-    DenseVector<Real, 3> a({ -2., 5, 1. });
-    DenseVector<Real, 3> b({ 3, 1, 2 });
-    auto v = a.cross(b);
-    EXPECT_EQ(v(0), 9.);
-    EXPECT_EQ(v(1), 7.);
-    EXPECT_EQ(v(2), -17.);
-}
-
-TEST(DenseVectorTest, cross_prod_3_fn)
 {
     DenseVector<Real, 3> a({ -2., 5, 1. });
     DenseVector<Real, 3> b({ 3, 1, 2 });

--- a/test/src/DenseVector_test.cpp
+++ b/test/src/DenseVector_test.cpp
@@ -146,26 +146,28 @@ TEST(DenseVectorTest, magnitude)
     EXPECT_EQ(mag, 5.);
 }
 
-TEST(DenseVectorTest, pointwise_mult)
+TEST(DenseVectorTest, pointwise_mult_vec)
 {
     const Int N = 3;
     DenseVector<Real, N> a({ 2., 3., 4. });
     DenseVector<Real, N> b({ 4., 2., -1. });
-    DenseVector<Real, N> res = a.pointwise_mult(b);
+    DenseVector<Real, N> res = pointwise_mult(a, b);
     EXPECT_EQ(res(0), 8.);
     EXPECT_EQ(res(1), 6.);
     EXPECT_EQ(res(2), -4.);
 }
 
-TEST(DenseVectorTest, pointwise_mult_glob)
+TEST(DenseVectorTest, pointwise_mult_row)
 {
     const Int N = 3;
-    DenseVector<Real, N> a({ 2., 3., 4. });
-    DenseVector<Real, N> b({ 4., 2., -1. });
-    DenseVector<Real, N> res = pointwise_mult<Real, N>(a, b);
-    EXPECT_EQ(res(0), 8.);
-    EXPECT_EQ(res(1), 6.);
-    EXPECT_EQ(res(2), -4.);
+    DenseMatrix<Real, 1, N> a;
+    a.set_row(0, { 2., 3., 4. });
+    DenseMatrix<Real, 1, N> b;
+    b.set_row(0, { 4., 2., -1. });
+    DenseMatrix<Real, 1, N> res = pointwise_mult(a, b);
+    EXPECT_EQ(res(0, 0), 8.);
+    EXPECT_EQ(res(0, 1), 6.);
+    EXPECT_EQ(res(0, 2), -4.);
 }
 
 TEST(DenseVectorTest, pointwise_div)

--- a/test/src/DenseVector_test.cpp
+++ b/test/src/DenseVector_test.cpp
@@ -170,18 +170,7 @@ TEST(DenseVectorTest, pointwise_mult_row)
     EXPECT_EQ(res(0, 2), -4.);
 }
 
-TEST(DenseVectorTest, pointwise_div)
-{
-    const Int N = 3;
-    DenseVector<Real, N> a({ 2., 6., 4. });
-    DenseVector<Real, N> b({ 4., 2., -1. });
-    DenseVector<Real, N> res = a.pointwise_div(b);
-    EXPECT_EQ(res(0), 0.5);
-    EXPECT_EQ(res(1), 3.);
-    EXPECT_EQ(res(2), -4.);
-}
-
-TEST(DenseVectorTest, pointwise_div_glob)
+TEST(DenseVectorTest, pointwise_div_col_col)
 {
     const Int N = 3;
     DenseVector<Real, N> a({ 2., 6., 4. });
@@ -190,6 +179,19 @@ TEST(DenseVectorTest, pointwise_div_glob)
     EXPECT_EQ(res(0), 0.5);
     EXPECT_EQ(res(1), 3.);
     EXPECT_EQ(res(2), -4.);
+}
+
+TEST(DenseVectorTest, pointwise_div_row_row)
+{
+    const Int N = 3;
+    DenseMatrix<Real, 1, N> a;
+    a.set_row(0, { 2., 6., 4. });
+    DenseMatrix<Real, 1, N> b;
+    b.set_row(0, { 4., 2., -1. });
+    auto res = pointwise_div(a, b);
+    EXPECT_EQ(res(0, 0), 0.5);
+    EXPECT_EQ(res(0, 1), 3.);
+    EXPECT_EQ(res(0, 2), -4.);
 }
 
 TEST(DenseVectorTest, op_mult_scalar)

--- a/test/src/DenseVector_test.cpp
+++ b/test/src/DenseVector_test.cpp
@@ -99,12 +99,28 @@ TEST(DenseVectorTest, op_subtract)
     EXPECT_EQ(c(2), 5.);
 }
 
-TEST(DenseVectorTest, dot)
+TEST(DenseVectorTest, dot_vec_vec)
 {
     DenseVector<Real, 3> a({ 2., 3., 4. });
     DenseVector<Real, 3> b({ 4., 2., -1. });
-    Real dot = a.dot(b);
-    EXPECT_EQ(dot, 10.);
+    EXPECT_EQ(dot(a, b), 10.);
+}
+
+TEST(DenseVectorTest, dot_row_vec)
+{
+    DenseMatrix<Real, 1, 3> a;
+    a.set_row(0, { 2., 3., 4. });
+    DenseVector<Real, 3> b({ 4., 2., -1. });
+    EXPECT_EQ(dot(a, b), 10.);
+}
+
+TEST(DenseVectorTest, dot_row_col)
+{
+    DenseMatrix<Real, 1, 3> a;
+    a.set_row(0, { 2., 3., 4. });
+    DenseMatrix<Real, 3, 1> b;
+    b.set_col(0, { 4., 2., -1. });
+    EXPECT_EQ(dot(a, b), 10.);
 }
 
 TEST(DenseVectorTest, dot_glob)
@@ -174,51 +190,6 @@ TEST(DenseVectorTest, pointwise_div_glob)
     EXPECT_EQ(res(2), -4.);
 }
 
-TEST(DenseVectorTest, op_mult_mat)
-{
-    DenseVector<Real, 2> a({ 2., 3. });
-    DenseMatrix<Real, 2, 3> b;
-    b.set_row(0, { 4., 2., -1. });
-    b.set_row(1, { 0., -3., 1. });
-    DenseVector<Real, 3> x = a * b;
-    EXPECT_EQ(x(0), 8.);
-    EXPECT_EQ(x(1), -5.);
-    EXPECT_EQ(x(2), 1.);
-}
-
-TEST(DenseVectorTest, op_mult_mat_symm)
-{
-    DenseVector<Real, 2> a({ 2., 3. });
-    DenseMatrixSymm<Real, 2> b({ 4., 2., -3. });
-    DenseVector<Real, 2> x = a * b;
-    EXPECT_EQ(x(0), 14.);
-    EXPECT_EQ(x(1), -5.);
-}
-
-TEST(DenseVectorTest, op_mult_vecvec)
-{
-    DenseVector<Real, 2> a({ 2., 3. });
-    DenseVector<DenseVector<Real, 2>, 3> b;
-    b(0)(0) = 4.;
-    b(0)(1) = 0.;
-    b(1)(0) = 2.;
-    b(1)(1) = -3.;
-    b(2)(0) = -1.;
-    b(2)(1) = 1.;
-    DenseVector<Real, 3> x = a * b;
-    EXPECT_EQ(x(0), 8.);
-    EXPECT_EQ(x(1), -5.);
-    EXPECT_EQ(x(2), 1.);
-}
-
-TEST(DenseVectorTest, op_mult_vec)
-{
-    DenseVector<Real, 3> a({ 2., 3., 4. });
-    DenseVector<Real, 3> b({ 4., 2., -1. });
-    Real dot = a * b;
-    EXPECT_EQ(dot, 10.);
-}
-
 TEST(DenseVectorTest, op_mult_scalar)
 {
     DenseVector<Real, 3> a({ 2., 3., 4. });
@@ -235,6 +206,20 @@ TEST(DenseVectorTest, op_mult_scalar_post)
     EXPECT_EQ(b(0), 6.);
     EXPECT_EQ(b(1), 9.);
     EXPECT_EQ(b(2), 12.);
+}
+
+TEST(DenseVectorTest, op_mult_row_mat)
+{
+    DenseVector<Real, 3> a({ 1, 2, 3 });
+    DenseMatrix<Real, 1, 2> b;
+    b.set_row(0, { 5, 7 });
+    auto prod = a * b;
+    EXPECT_DOUBLE_EQ(prod(0, 0), 5.);
+    EXPECT_DOUBLE_EQ(prod(1, 0), 10.);
+    EXPECT_DOUBLE_EQ(prod(2, 0), 15.);
+    EXPECT_DOUBLE_EQ(prod(0, 1), 7.);
+    EXPECT_DOUBLE_EQ(prod(1, 1), 14.);
+    EXPECT_DOUBLE_EQ(prod(2, 1), 21.);
 }
 
 #ifndef NDEBUG
@@ -343,73 +328,6 @@ TEST(DenseVectorTest, op_unary_minus)
     EXPECT_EQ(b(2), -3.);
 }
 
-TEST(DenseVectorTest, mat_row)
-{
-    DenseVector<DenseVector<Real, 3>, 2> A;
-    A(0)(0) = -2;
-    A(0)(1) = 5;
-    A(0)(2) = 3;
-    A(1)(0) = 1;
-    A(1)(1) = -1;
-    A(1)(2) = 2;
-
-    DenseMatrix<Real, 2, 3> m = mat_row(A);
-    EXPECT_EQ(m(0, 0), -2.);
-    EXPECT_EQ(m(0, 1), 5.);
-    EXPECT_EQ(m(0, 2), 3.);
-    EXPECT_EQ(m(1, 0), 1.);
-    EXPECT_EQ(m(1, 1), -1.);
-    EXPECT_EQ(m(1, 2), 2.);
-}
-
-TEST(DenseVectorTest, mat_row_scalar)
-{
-    DenseVector<Real, 3> A;
-    A(0) = -2;
-    A(1) = 5;
-    A(2) = 3;
-
-    auto m = mat_row(A);
-
-    EXPECT_EQ(m(0, 0), -2.);
-    EXPECT_EQ(m(1, 0), 5.);
-    EXPECT_EQ(m(2, 0), 3.);
-}
-
-TEST(DenseVectorTest, mat_col)
-{
-    DenseVector<DenseVector<Real, 3>, 2> A;
-    A(0)(0) = -2;
-    A(0)(1) = 5;
-    A(0)(2) = 3;
-    A(1)(0) = 1;
-    A(1)(1) = -1;
-    A(1)(2) = 2;
-
-    DenseMatrix<Real, 3, 2> m = mat_col(A);
-
-    EXPECT_EQ(m(0, 0), -2.);
-    EXPECT_EQ(m(0, 1), 1.);
-    EXPECT_EQ(m(1, 0), 5.);
-    EXPECT_EQ(m(1, 1), -1.);
-    EXPECT_EQ(m(2, 0), 3.);
-    EXPECT_EQ(m(2, 1), 2.);
-}
-
-TEST(DenseVectorTest, mat_col_scalar)
-{
-    DenseVector<Real, 3> A;
-    A(0) = -2;
-    A(1) = 5;
-    A(2) = 3;
-
-    auto m = mat_col(A);
-
-    EXPECT_EQ(m(0, 0), -2.);
-    EXPECT_EQ(m(0, 1), 5.);
-    EXPECT_EQ(m(0, 2), 3.);
-}
-
 TEST(DenseVectorTest, min)
 {
     DenseVector<Real, 3> a({ 5, -2, 10 });
@@ -420,25 +338,6 @@ TEST(DenseVectorTest, max)
 {
     DenseVector<Real, 3> a({ 5, -2, 10 });
     EXPECT_EQ(a.max(), 10);
-}
-
-TEST(DenseVectorTest, transpose)
-{
-    DenseVector<DenseVector<Real, 3>, 2> A;
-    A(0)(0) = -2;
-    A(0)(1) = 5;
-    A(0)(2) = 3;
-    A(1)(0) = 1;
-    A(1)(1) = -1;
-    A(1)(2) = 2;
-
-    DenseVector<DenseVector<Real, 2>, 3> m = transpose(A);
-    EXPECT_EQ(m(0)(0), -2.);
-    EXPECT_EQ(m(0)(1), 1.);
-    EXPECT_EQ(m(1)(0), 5.);
-    EXPECT_EQ(m(1)(1), -1.);
-    EXPECT_EQ(m(2)(0), 3.);
-    EXPECT_EQ(m(2)(1), 2.);
 }
 
 TEST(DenseVectorTest, abs)

--- a/test/src/FEBoundary1D_test.cpp
+++ b/test/src/FEBoundary1D_test.cpp
@@ -79,7 +79,7 @@ public:
 class TestBoundary1D : public fe::BoundaryInfo<EDGE2, 1, 2> {
 public:
     TestBoundary1D(UnstructuredMesh * mesh,
-                   const Array1D<DenseMatrix<Real, 2, 1>> * grad_phi,
+                   const Array1D<DenseMatrix<Real, 1, 2>> * grad_phi,
                    const IndexSet & facets) :
         fe::BoundaryInfo<EDGE2, 1, 2>(mesh, grad_phi, facets)
     {

--- a/test/src/FEBoundary2D_test.cpp
+++ b/test/src/FEBoundary2D_test.cpp
@@ -82,7 +82,7 @@ public:
 class TestBoundary2D : public fe::BoundaryInfo<TRI3, 2, 3> {
 public:
     TestBoundary2D(UnstructuredMesh * mesh,
-                   const Array1D<DenseMatrix<Real, 3, 2>> * grad_phi,
+                   const Array1D<DenseMatrix<Real, 2, 3>> * grad_phi,
                    const IndexSet & facets) :
         fe::BoundaryInfo<TRI3, 2, 3>(mesh, grad_phi, facets)
     {

--- a/test/src/FEBoundary3D_test.cpp
+++ b/test/src/FEBoundary3D_test.cpp
@@ -83,7 +83,7 @@ public:
 class TestBoundary3D : public fe::BoundaryInfo<TET4, 3, 4> {
 public:
     TestBoundary3D(UnstructuredMesh * mesh,
-                   const Array1D<DenseMatrix<Real, 4, 3>> * grad_phi,
+                   const Array1D<DenseMatrix<Real, 3, 4>> * grad_phi,
                    const IndexSet & facets) :
         fe::BoundaryInfo<TET4, 3, 4>(mesh, grad_phi, facets)
     {

--- a/test/src/FEGeometry_test.cpp
+++ b/test/src/FEGeometry_test.cpp
@@ -1,4 +1,5 @@
 #include "gmock/gmock.h"
+#include "godzilla/DenseMatrix.h"
 #include "godzilla/FEGeometry.h"
 #include "godzilla/FEShapeFns.h"
 #include "ExceptionTestMacros.h"
@@ -76,7 +77,7 @@ TEST(FEGeometryTest, normal_tri3)
 
 TEST(FEGeometryTest, normal_hex8)
 {
-    DenseVector<Real, 10> grad;
+    DenseMatrix<Real, 1, 10> grad;
     EXPECT_DEATH(
         (fe::normal<EDGE2, 10>(1., 1., grad)),
         "Computation of a normal for element 'EDGE2' in 10 dimensions is not implemented.");

--- a/test/src/FEGeometry_test.cpp
+++ b/test/src/FEGeometry_test.cpp
@@ -38,11 +38,11 @@ TEST(FEGeometryTest, normal_edge2)
     coords(1) = DenseVector<Real, 1>({ 2 });
     auto grad = fe::grad_shape<EDGE2, 1>(coords, volume);
     {
-        auto n = fe::normal<EDGE2>(volume, 0, grad.row(1));
+        auto n = fe::normal<EDGE2>(volume, 0, DenseVector<Real, 1>(grad.column(1)));
         EXPECT_DOUBLE_EQ(n(0), -1);
     }
     {
-        auto n = fe::normal<EDGE2>(volume, 0., grad.row(0));
+        auto n = fe::normal<EDGE2>(volume, 0., DenseVector<Real, 1>(grad.column(0)));
         EXPECT_DOUBLE_EQ(n(0), 1);
     }
 }
@@ -57,19 +57,19 @@ TEST(FEGeometryTest, normal_tri3)
     auto grad = fe::grad_shape<TRI3, 2>(coords, volume);
     {
         Real edge_len = 1.;
-        auto n = fe::normal<TRI3>(volume, edge_len, grad.row(1));
+        auto n = fe::normal<TRI3>(volume, edge_len, DenseVector<Real, 2>(grad.column(1)));
         EXPECT_DOUBLE_EQ(n(0), -1.);
         EXPECT_DOUBLE_EQ(n(1), 0.);
     }
     {
         Real edge_len = 1.;
-        auto n = fe::normal<TRI3>(volume, edge_len, grad.row(2));
+        auto n = fe::normal<TRI3>(volume, edge_len, DenseVector<Real, 2>(grad.column(2)));
         EXPECT_DOUBLE_EQ(n(0), 0.);
         EXPECT_DOUBLE_EQ(n(1), -1.);
     }
     {
         Real edge_len = std::sqrt(2.);
-        auto n = fe::normal<TRI3>(volume, edge_len, grad.row(0));
+        auto n = fe::normal<TRI3>(volume, edge_len, DenseVector<Real, 2>(grad.column(0)));
         EXPECT_DOUBLE_EQ(n(0), 1. / std::sqrt(2.));
         EXPECT_DOUBLE_EQ(n(1), 1. / std::sqrt(2.));
     }
@@ -77,7 +77,7 @@ TEST(FEGeometryTest, normal_tri3)
 
 TEST(FEGeometryTest, normal_hex8)
 {
-    DenseMatrix<Real, 1, 10> grad;
+    DenseVector<Real, 10> grad;
     EXPECT_DEATH(
         (fe::normal<EDGE2, 10>(1., 1., grad)),
         "Computation of a normal for element 'EDGE2' in 10 dimensions is not implemented.");

--- a/test/src/FEOps_test.cpp
+++ b/test/src/FEOps_test.cpp
@@ -28,9 +28,9 @@ TEST(FEOpsTest, gradient_scalar)
     grad_phi.set_row(1, { 2, 1, 0 });
 
     auto grad_a = fe::gradient(a, grad_phi);
-    EXPECT_EQ(grad_a(0), 4.);
-    EXPECT_EQ(grad_a(1), 5.);
-    EXPECT_EQ(grad_a(2), -4.);
+    EXPECT_EQ(grad_a(0, 0), 4.);
+    EXPECT_EQ(grad_a(0, 1), 5.);
+    EXPECT_EQ(grad_a(0, 2), -4.);
 }
 
 TEST(FEOpsTest, gradient_vector)

--- a/test/src/FEOps_test.cpp
+++ b/test/src/FEOps_test.cpp
@@ -23,14 +23,14 @@ TEST(FEOpsTest, lin_comb)
 TEST(FEOpsTest, gradient_scalar)
 {
     DenseVector<Real, 2> a({ 2., 3. });
-    DenseMatrix<Real, 2, 3> grad_phi;
-    grad_phi.set_row(0, { -1, 1, -2 });
-    grad_phi.set_row(1, { 2, 1, 0 });
+    DenseMatrix<Real, 3, 2> grad_phi;
+    grad_phi.set_col(0, { -1, 1, -2 });
+    grad_phi.set_col(1, { 2, 1, 0 });
 
     auto grad_a = fe::gradient(a, grad_phi);
-    EXPECT_EQ(grad_a(0, 0), 4.);
-    EXPECT_EQ(grad_a(0, 1), 5.);
-    EXPECT_EQ(grad_a(0, 2), -4.);
+    EXPECT_EQ(grad_a(0), 4.);
+    EXPECT_EQ(grad_a(1), 5.);
+    EXPECT_EQ(grad_a(2), -4.);
 }
 
 TEST(FEOpsTest, gradient_vector)
@@ -40,8 +40,8 @@ TEST(FEOpsTest, gradient_vector)
     f(1) = DenseVector<Real, 3>({ -2, 1, -3 });
 
     DenseMatrix<Real, 2, 2> grad_phi;
-    grad_phi.set_row(0, { -1, -2 });
-    grad_phi.set_row(1, { 2, 0 });
+    grad_phi.set_col(0, { -1, -2 });
+    grad_phi.set_col(1, { 2, 0 });
 
     auto grad_F = fe::gradient(f, grad_phi);
     EXPECT_DOUBLE_EQ(grad_F(0, 0), -7.);
@@ -59,8 +59,8 @@ TEST(FEOpsTest, gradient_vector_mat)
     f.set_row(1, { -2, 1, -3 });
 
     DenseMatrix<Real, 2, 2> grad_phi;
-    grad_phi.set_row(0, { -1, -2 });
-    grad_phi.set_row(1, { 2, 0 });
+    grad_phi.set_col(0, { -1, -2 });
+    grad_phi.set_col(1, { 2, 0 });
 
     auto grad_F = fe::gradient(f, grad_phi);
     EXPECT_DOUBLE_EQ(grad_F(0, 0), -7.);

--- a/test/src/FEOps_test.cpp
+++ b/test/src/FEOps_test.cpp
@@ -33,25 +33,6 @@ TEST(FEOpsTest, gradient_scalar)
     EXPECT_EQ(grad_a(2), -4.);
 }
 
-TEST(FEOpsTest, gradient_vector)
-{
-    DenseVector<DenseVector<Real, 3>, 2> f;
-    f(0) = DenseVector<Real, 3>({ 3, -1, 2 });
-    f(1) = DenseVector<Real, 3>({ -2, 1, -3 });
-
-    DenseMatrix<Real, 2, 2> grad_phi;
-    grad_phi.set_col(0, { -1, -2 });
-    grad_phi.set_col(1, { 2, 0 });
-
-    auto grad_F = fe::gradient(f, grad_phi);
-    EXPECT_DOUBLE_EQ(grad_F(0, 0), -7.);
-    EXPECT_DOUBLE_EQ(grad_F(0, 1), 3.);
-    EXPECT_DOUBLE_EQ(grad_F(0, 2), -8.);
-    EXPECT_DOUBLE_EQ(grad_F(1, 0), -6.);
-    EXPECT_DOUBLE_EQ(grad_F(1, 1), 2.);
-    EXPECT_DOUBLE_EQ(grad_F(1, 2), -4.);
-}
-
 TEST(FEOpsTest, gradient_vector_mat)
 {
     DenseMatrix<Real, 2, 3> f;

--- a/test/src/FEShapeFns_test.cpp
+++ b/test/src/FEShapeFns_test.cpp
@@ -12,7 +12,7 @@ TEST(FEShapeFns, grad_shape_egde2)
     Real volume = fe::volume<EDGE2>(coords);
     auto grads = fe::grad_shape<EDGE2, 1>(coords, volume);
     EXPECT_DOUBLE_EQ(grads(0, 0), -0.5);
-    EXPECT_DOUBLE_EQ(grads(1, 0), 0.5);
+    EXPECT_DOUBLE_EQ(grads(0, 1), 0.5);
 }
 
 TEST(FEShapeFns, grad_shape_tri3)
@@ -24,11 +24,11 @@ TEST(FEShapeFns, grad_shape_tri3)
     Real volume = fe::volume<TRI3>(coords);
     auto grads = fe::grad_shape<TRI3, 2>(coords, volume);
     EXPECT_DOUBLE_EQ(grads(0, 0), -1);
-    EXPECT_DOUBLE_EQ(grads(0, 1), -1);
-    EXPECT_DOUBLE_EQ(grads(1, 0), 1);
+    EXPECT_DOUBLE_EQ(grads(1, 0), -1);
+    EXPECT_DOUBLE_EQ(grads(0, 1), 1);
     EXPECT_DOUBLE_EQ(grads(1, 1), 0);
-    EXPECT_DOUBLE_EQ(grads(2, 0), 0);
-    EXPECT_DOUBLE_EQ(grads(2, 1), 1);
+    EXPECT_DOUBLE_EQ(grads(0, 2), 0);
+    EXPECT_DOUBLE_EQ(grads(1, 2), 1);
 }
 
 TEST(FEShapeFns, calc_grad_shape_2d)
@@ -53,17 +53,17 @@ TEST(FEShapeFns, calc_grad_shape_2d)
     auto grad_sh = fe::calc_grad_shape<ELEM_TYPE, DIM>(coords, connect, volumes);
 
     EXPECT_DOUBLE_EQ(grad_sh(0)(0, 0), -1);
-    EXPECT_DOUBLE_EQ(grad_sh(0)(0, 1), -1);
-    EXPECT_DOUBLE_EQ(grad_sh(0)(1, 0), 1);
+    EXPECT_DOUBLE_EQ(grad_sh(0)(1, 0), -1);
+    EXPECT_DOUBLE_EQ(grad_sh(0)(0, 1), 1);
     EXPECT_DOUBLE_EQ(grad_sh(0)(1, 1), 0);
-    EXPECT_DOUBLE_EQ(grad_sh(0)(2, 0), 0);
-    EXPECT_DOUBLE_EQ(grad_sh(0)(2, 1), 1);
+    EXPECT_DOUBLE_EQ(grad_sh(0)(0, 2), 0);
+    EXPECT_DOUBLE_EQ(grad_sh(0)(1, 2), 1);
     EXPECT_DOUBLE_EQ(grad_sh(1)(0, 0), 0);
-    EXPECT_DOUBLE_EQ(grad_sh(1)(0, 1), -1);
-    EXPECT_DOUBLE_EQ(grad_sh(1)(1, 0), 1);
+    EXPECT_DOUBLE_EQ(grad_sh(1)(1, 0), -1);
+    EXPECT_DOUBLE_EQ(grad_sh(1)(0, 1), 1);
     EXPECT_DOUBLE_EQ(grad_sh(1)(1, 1), 1);
-    EXPECT_DOUBLE_EQ(grad_sh(1)(2, 0), -1);
-    EXPECT_DOUBLE_EQ(grad_sh(1)(2, 1), 0);
+    EXPECT_DOUBLE_EQ(grad_sh(1)(0, 2), -1);
+    EXPECT_DOUBLE_EQ(grad_sh(1)(1, 2), 0);
 
     grad_sh.destroy();
     volumes.destroy();
@@ -87,17 +87,17 @@ TEST(FEShapeFns, calc_grad_shape_2d_petsc)
     auto grad_sh = fe::calc_grad_shape<ELEM_TYPE, DIM>(*mesh, volumes);
 
     EXPECT_DOUBLE_EQ(grad_sh(0)(0, 0), -1);
-    EXPECT_DOUBLE_EQ(grad_sh(0)(0, 1), -1);
-    EXPECT_DOUBLE_EQ(grad_sh(0)(1, 0), 1);
+    EXPECT_DOUBLE_EQ(grad_sh(0)(1, 0), -1);
+    EXPECT_DOUBLE_EQ(grad_sh(0)(0, 1), 1);
     EXPECT_DOUBLE_EQ(grad_sh(0)(1, 1), 0);
-    EXPECT_DOUBLE_EQ(grad_sh(0)(2, 0), 0);
-    EXPECT_DOUBLE_EQ(grad_sh(0)(2, 1), 1);
+    EXPECT_DOUBLE_EQ(grad_sh(0)(0, 2), 0);
+    EXPECT_DOUBLE_EQ(grad_sh(0)(1, 2), 1);
     EXPECT_DOUBLE_EQ(grad_sh(1)(0, 0), 0);
-    EXPECT_DOUBLE_EQ(grad_sh(1)(0, 1), -1);
-    EXPECT_DOUBLE_EQ(grad_sh(1)(1, 0), 1);
+    EXPECT_DOUBLE_EQ(grad_sh(1)(1, 0), -1);
+    EXPECT_DOUBLE_EQ(grad_sh(1)(0, 1), 1);
     EXPECT_DOUBLE_EQ(grad_sh(1)(1, 1), 1);
-    EXPECT_DOUBLE_EQ(grad_sh(1)(2, 0), -1);
-    EXPECT_DOUBLE_EQ(grad_sh(1)(2, 1), 0);
+    EXPECT_DOUBLE_EQ(grad_sh(1)(0, 2), -1);
+    EXPECT_DOUBLE_EQ(grad_sh(1)(1, 2), 0);
 
     grad_sh.destroy();
     volumes.destroy();


### PR DESCRIPTION
- `DenseVector<N>` is implemented as `DenseMatrix<N, 1>`
- gradient phi is stored as DxN matrix
- Removing `gradient(DenseVector<DenseVector>)`
- Clean up pointwise_multiply
- Dot product of 2 row-vectors
- Refactoring `dot`
- Removing `tensor_product` function
- Refactoring `pointwise_div`
- Refactoring determinant
- Refactoring `inverse`
