### PR TITLE
Refactoring `PerfLog`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            python-version: '3.9'
+            python-version: "3.9"
             petsc: 3.20.6
     runs-on: ${{ matrix.os }}
     steps:
@@ -49,7 +49,6 @@ jobs:
         run: |
           cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DGODZILLA_WITH_PERF_LOG=YES \
             -DGODZILLA_BUILD_EXAMPLES=YES \
             -DGODZILLA_BUILD_TESTS=YES \
             -DGODZILLA_CODE_COVERAGE=YES

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Configure
         run: |
           cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build \
-            -DGODZILLA_WITH_PERF_LOG=YES \
             -DGODZILLA_BUILD_EXAMPLES=YES \
             -DGODZILLA_BUILD_TESTS=YES \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=on
@@ -44,10 +43,10 @@ jobs:
       - uses: cpp-linter/cpp-linter-action@v2
         with:
           style: file
-          tidy-checks: ''
+          tidy-checks: ""
           version: 14
           lines-changed-only: true
-          ignore: 'contrib'
+          ignore: "contrib"
           step-summary: true
           database: build
 
@@ -66,7 +65,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp' ]
+        language: ["cpp"]
 
     steps:
       - name: Set up miniconda
@@ -93,7 +92,6 @@ jobs:
       - name: Configure
         run: |
           cmake -S ${{ github.workspace }} -B ${{ github.workspace }}/build \
-            -DGODZILLA_WITH_PERF_LOG=YES \
             -DGODZILLA_BUILD_EXAMPLES=YES \
             -DGODZILLA_BUILD_TESTS=YES
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ endif()
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${BuildValues})
 
 option(GODZILLA_WITH_MPI "Build with MPI support" YES)
-option(GODZILLA_WITH_PERF_LOG "Build with performance logging" NO)
 option(GODZILLA_BUILD_EXAMPLES "Build examples" NO)
 option(GODZILLA_BUILD_TESTS "Build tests" NO)
 

--- a/include/godzilla/PerfLog.h
+++ b/include/godzilla/PerfLog.h
@@ -26,6 +26,10 @@ namespace godzilla {
 ///
 class PerfLog {
 public:
+    using EventID = PetscLogEvent;
+    using StageID = PetscLogStage;
+    using LogDouble = PetscLogDouble;
+
     /// Initialize performance logging
     static void init();
 
@@ -36,29 +40,29 @@ public:
     ///
     /// @param name Event name
     /// @return Event ID
-    static PetscLogEvent register_event(const char * name);
-    static PetscLogEvent register_event(const std::string & name);
+    static EventID register_event(const char * name);
+    static EventID register_event(const std::string & name);
 
     /// Get event ID
     ///
     /// @param name Event name
     /// @return Event ID
-    static PetscLogEvent get_event_id(const char * name);
-    static PetscLogEvent get_event_id(const std::string & name);
+    static EventID get_event_id(const char * name);
+    static EventID get_event_id(const std::string & name);
 
     /// Register a logging stage
     ///
     /// @param name Stage name
     /// @return
-    static PetscLogStage register_stage(const char * name);
-    static PetscLogStage register_stage(const std::string & name);
+    static StageID register_stage(const char * name);
+    static StageID register_stage(const std::string & name);
 
     /// Get stage ID
     ///
     /// @param name Stage name
     /// @return Stage ID
-    static PetscLogStage get_stage_id(const char * name);
-    static PetscLogStage get_stage_id(const std::string & name);
+    static StageID get_stage_id(const char * name);
+    static StageID get_stage_id(const std::string & name);
 
     /// Performance logging stage
     ///
@@ -73,7 +77,7 @@ public:
         /// Construct a performance logging stage from stage ID
         ///
         /// @param id ID of an stage previously registered in PerfLog class.
-        explicit Stage(PetscLogStage id);
+        explicit Stage(StageID id);
 
         /// Destroy a stage
         ///
@@ -83,26 +87,26 @@ public:
         /// Get ID of this stage
         ///
         /// @return ID of this stage
-        [[nodiscard]] PetscLogStage get_id() const;
+        [[nodiscard]] StageID get_id() const;
 
     private:
         /// Event ID
-        PetscLogStage id;
+        StageID id;
     };
 
     class EventInfo {
     public:
-        EventInfo(PetscLogEvent event_id, PetscLogStage stage_id);
+        EventInfo(EventID event_id, StageID stage_id);
 
         /// Get the number of FLOPS
         ///
         /// @return Number of FLOPS
-        [[nodiscard]] PetscLogDouble get_flops() const;
+        [[nodiscard]] LogDouble get_flops() const;
 
         /// Get total time spent on this event
         ///
         /// @return The total time spent on this event
-        [[nodiscard]] PetscLogDouble get_time() const;
+        [[nodiscard]] LogDouble get_time() const;
 
         /// Get number of times this event was called
         ///
@@ -127,8 +131,7 @@ public:
     /// @param event_id Event ID (registered via PerfLog)
     /// @param stage_id Stage ID (registered via PerfLog)
     /// @return Event information
-    static EventInfo get_event_info(PetscLogEvent event_id,
-                                    PetscLogStage stage_id = PETSC_DETERMINE);
+    static EventInfo get_event_info(EventID event_id, StageID stage_id = PETSC_DETERMINE);
 
     /// Event for performance logging
     ///
@@ -143,7 +146,7 @@ public:
         /// Construct a performance logging event from event ID
         ///
         /// @param id ID of an event previously registered in PerfLog class.
-        explicit Event(PetscLogEvent id);
+        explicit Event(EventID id);
 
         /// Destroy an event
         ///
@@ -153,14 +156,14 @@ public:
         /// Get ID of this event
         ///
         /// @return ID of this event
-        [[nodiscard]] PetscLogEvent get_id() const;
+        [[nodiscard]] EventID get_id() const;
 
         /// Log number of FLOPS
-        void log_flops(PetscLogDouble n);
+        void log_flops(LogDouble n);
 
     private:
         /// Event ID
-        PetscLogEvent id;
+        EventID id;
     };
 };
 

--- a/include/godzilla/PerfLog.h
+++ b/include/godzilla/PerfLog.h
@@ -7,11 +7,11 @@
 #include <map>
 
 #ifdef GODZILLA_WITH_PERF_LOG
-    #define GODZILLA_PERF_LOG_REGISTER_EVENT(name) PerfLog::register_event(name);
-    #define GODZILLA_PERF_LOG_EVENT(name) PerfLog::Event __event__(name);
+    #define GODZILLA_PERF_LOG_REGISTER_EVENT(name) perf_log::register_event(name);
+    #define GODZILLA_PERF_LOG_EVENT(name) perf_log::Event __event__(name);
 
-    #define GODZILLA_PERF_LOG_REGISTER_STAGE(name) PerfLog::register_stage(name);
-    #define GODZILLA_PERF_LOG_STAGE(name) PerfLog::Stage __stage__(name);
+    #define GODZILLA_PERF_LOG_REGISTER_STAGE(name) perf_log::register_stage(name);
+    #define GODZILLA_PERF_LOG_STAGE(name) perf_log::Stage __stage__(name);
 #else
     #define GODZILLA_PERF_LOG_REGISTER_EVENT(name)
     #define GODZILLA_PERF_LOG_EVENT(name)
@@ -20,151 +20,145 @@
     #define GODZILLA_PERF_LOG_STAGE(name)
 #endif
 
-namespace godzilla {
+namespace godzilla::perf_log {
 
-/// Performance logging
+using EventID = PetscLogEvent;
+using StageID = PetscLogStage;
+using LogDouble = PetscLogDouble;
+
+/// Initialize performance logging
+void init();
+
+bool is_event_registered(const char * name);
+bool is_event_registered(const std::string & name);
+
+/// Register a logging event
 ///
-class PerfLog {
+/// @param name Event name
+/// @return Event ID
+EventID register_event(const char * name);
+EventID register_event(const std::string & name);
+
+/// Get event ID
+///
+/// @param name Event name
+/// @return Event ID
+EventID get_event_id(const char * name);
+EventID get_event_id(const std::string & name);
+
+/// Register a logging stage
+///
+/// @param name Stage name
+/// @return
+StageID register_stage(const char * name);
+StageID register_stage(const std::string & name);
+
+/// Get stage ID
+///
+/// @param name Stage name
+/// @return Stage ID
+StageID get_stage_id(const char * name);
+StageID get_stage_id(const std::string & name);
+
+/// Performance logging stage
+///
+class Stage {
 public:
-    using EventID = PetscLogEvent;
-    using StageID = PetscLogStage;
-    using LogDouble = PetscLogDouble;
-
-    /// Initialize performance logging
-    static void init();
-
-    static bool is_event_registered(const char * name);
-    static bool is_event_registered(const std::string & name);
-
-    /// Register a logging event
+    /// Construct a performance logging stage
     ///
-    /// @param name Event name
-    /// @return Event ID
-    static EventID register_event(const char * name);
-    static EventID register_event(const std::string & name);
+    /// @param name Name of the stage. Must be registered in PerfLog class.
+    explicit Stage(const char * name);
+    explicit Stage(const std::string & name);
 
-    /// Get event ID
+    /// Construct a performance logging stage from stage ID
     ///
-    /// @param name Event name
-    /// @return Event ID
-    static EventID get_event_id(const char * name);
-    static EventID get_event_id(const std::string & name);
+    /// @param id ID of an stage previously registered in PerfLog class.
+    explicit Stage(StageID id);
 
-    /// Register a logging stage
+    /// Destroy a stage
     ///
-    /// @param name Stage name
-    /// @return
-    static StageID register_stage(const char * name);
-    static StageID register_stage(const std::string & name);
+    /// This will finish logging the stage
+    virtual ~Stage();
 
-    /// Get stage ID
+    /// Get ID of this stage
     ///
-    /// @param name Stage name
-    /// @return Stage ID
-    static StageID get_stage_id(const char * name);
-    static StageID get_stage_id(const std::string & name);
+    /// @return ID of this stage
+    [[nodiscard]] StageID get_id() const;
 
-    /// Performance logging stage
-    ///
-    class Stage {
-    public:
-        /// Construct a performance logging stage
-        ///
-        /// @param name Name of the stage. Must be registered in PerfLog class.
-        explicit Stage(const char * name);
-        explicit Stage(const std::string & name);
-
-        /// Construct a performance logging stage from stage ID
-        ///
-        /// @param id ID of an stage previously registered in PerfLog class.
-        explicit Stage(StageID id);
-
-        /// Destroy a stage
-        ///
-        /// This will finish logging the stage
-        virtual ~Stage();
-
-        /// Get ID of this stage
-        ///
-        /// @return ID of this stage
-        [[nodiscard]] StageID get_id() const;
-
-    private:
-        /// Event ID
-        StageID id;
-    };
-
-    class EventInfo {
-    public:
-        EventInfo(EventID event_id, StageID stage_id);
-
-        /// Get the number of FLOPS
-        ///
-        /// @return Number of FLOPS
-        [[nodiscard]] LogDouble get_flops() const;
-
-        /// Get total time spent on this event
-        ///
-        /// @return The total time spent on this event
-        [[nodiscard]] LogDouble get_time() const;
-
-        /// Get number of times this event was called
-        ///
-        /// @return Number of times this event was called
-        [[nodiscard]] int get_num_calls() const;
-
-    private:
-        /// Event information collected by PETSc
-        PetscEventPerfInfo info;
-    };
-
-    /// Get event information
-    ///
-    /// @param event_name Event name
-    /// @param stage_name Stage name
-    /// @return Event information
-    static EventInfo get_event_info(const std::string & event_name,
-                                    const std::string & stage_name = "");
-
-    /// Get event information
-    ///
-    /// @param event_id Event ID (registered via PerfLog)
-    /// @param stage_id Stage ID (registered via PerfLog)
-    /// @return Event information
-    static EventInfo get_event_info(EventID event_id, StageID stage_id = PETSC_DETERMINE);
-
-    /// Event for performance logging
-    ///
-    class Event {
-    public:
-        /// Construct a performance logging event
-        ///
-        /// @param name Name of the event. Must be registered in PerfLog class.
-        explicit Event(const char * name);
-        explicit Event(const std::string & name);
-
-        /// Construct a performance logging event from event ID
-        ///
-        /// @param id ID of an event previously registered in PerfLog class.
-        explicit Event(EventID id);
-
-        /// Destroy an event
-        ///
-        /// This will finish logging the event
-        virtual ~Event();
-
-        /// Get ID of this event
-        ///
-        /// @return ID of this event
-        [[nodiscard]] EventID get_id() const;
-
-        /// Log number of FLOPS
-        void log_flops(LogDouble n);
-
-    private:
-        /// Event ID
-        EventID id;
-    };
+private:
+    /// Event ID
+    StageID id;
 };
 
-} // namespace godzilla
+class EventInfo {
+public:
+    EventInfo(EventID event_id, StageID stage_id);
+
+    /// Get the number of FLOPS
+    ///
+    /// @return Number of FLOPS
+    [[nodiscard]] LogDouble get_flops() const;
+
+    /// Get total time spent on this event
+    ///
+    /// @return The total time spent on this event
+    [[nodiscard]] LogDouble get_time() const;
+
+    /// Get number of times this event was called
+    ///
+    /// @return Number of times this event was called
+    [[nodiscard]] int get_num_calls() const;
+
+private:
+    /// Event information collected by PETSc
+    PetscEventPerfInfo info;
+};
+
+/// Get event information
+///
+/// @param event_name Event name
+/// @param stage_name Stage name
+/// @return Event information
+EventInfo get_event_info(const std::string & event_name, const std::string & stage_name = "");
+
+/// Get event information
+///
+/// @param event_id Event ID (registered via perf_log::register_event)
+/// @param stage_id Stage ID (registered via perf_log::register_stage)
+/// @return Event information
+EventInfo get_event_info(EventID event_id, StageID stage_id = PETSC_DETERMINE);
+
+/// Event for performance logging
+///
+class Event {
+public:
+    /// Construct a performance logging event
+    ///
+    /// @param name Name of the event. Must be registered in PerfLog class.
+    explicit Event(const char * name);
+    explicit Event(const std::string & name);
+
+    /// Construct a performance logging event from event ID
+    ///
+    /// @param id ID of a previously registered event
+    explicit Event(EventID id);
+
+    /// Destroy an event
+    ///
+    /// This will finish logging the event
+    virtual ~Event();
+
+    /// Get ID of this event
+    ///
+    /// @return ID of this event
+    [[nodiscard]] EventID get_id() const;
+
+    /// Log number of FLOPS
+    void log_flops(LogDouble n);
+
+private:
+    /// Event ID
+    EventID id;
+};
+
+} // namespace godzilla::perf_log

--- a/include/godzilla/PerfLog.h
+++ b/include/godzilla/PerfLog.h
@@ -3,23 +3,14 @@
 
 #pragma once
 
-#include "godzilla/Label.h"
 #include "petsclog.h"
 #include <map>
 
-#ifdef GODZILLA_WITH_PERF_LOG
-    #define GODZILLA_PERF_LOG_REGISTER_EVENT(name) perf_log::register_event(name);
-    #define GODZILLA_PERF_LOG_EVENT(name) perf_log::ScopedEvent __event__(name);
+#define GODZILLA_PERF_LOG_REGISTER_EVENT(name) perf_log::register_event(name);
+#define GODZILLA_PERF_LOG_EVENT(name) perf_log::ScopedEvent __event__(name);
 
-    #define GODZILLA_PERF_LOG_REGISTER_STAGE(name) perf_log::register_stage(name);
-    #define GODZILLA_PERF_LOG_STAGE(name) perf_log::Stage __stage__(name);
-#else
-    #define GODZILLA_PERF_LOG_REGISTER_EVENT(name)
-    #define GODZILLA_PERF_LOG_EVENT(name)
-
-    #define GODZILLA_PERF_LOG_REGISTER_STAGE(name)
-    #define GODZILLA_PERF_LOG_STAGE(name)
-#endif
+#define GODZILLA_PERF_LOG_REGISTER_STAGE(name) perf_log::register_stage(name);
+#define GODZILLA_PERF_LOG_STAGE(name) perf_log::Stage __stage__(name);
 
 namespace godzilla::perf_log {
 

--- a/include/godzilla/PerfLog.h
+++ b/include/godzilla/PerfLog.h
@@ -3,12 +3,13 @@
 
 #pragma once
 
+#include "godzilla/Label.h"
 #include "petsclog.h"
 #include <map>
 
 #ifdef GODZILLA_WITH_PERF_LOG
     #define GODZILLA_PERF_LOG_REGISTER_EVENT(name) perf_log::register_event(name);
-    #define GODZILLA_PERF_LOG_EVENT(name) perf_log::Event __event__(name);
+    #define GODZILLA_PERF_LOG_EVENT(name) perf_log::ScopedEvent __event__(name);
 
     #define GODZILLA_PERF_LOG_REGISTER_STAGE(name) perf_log::register_stage(name);
     #define GODZILLA_PERF_LOG_STAGE(name) perf_log::Stage __stage__(name);
@@ -59,6 +60,9 @@ StageID register_stage(const std::string & name);
 /// @return Stage ID
 StageID get_stage_id(const char * name);
 StageID get_stage_id(const std::string & name);
+
+/// Adds floating point operations to the global counter.
+void log_flops(LogDouble n);
 
 /// Performance logging stage
 ///
@@ -134,7 +138,7 @@ class Event {
 public:
     /// Construct a performance logging event
     ///
-    /// @param name Name of the event. Must be registered in PerfLog class.
+    /// @param name Name of the event
     explicit Event(const char * name);
     explicit Event(const std::string & name);
 
@@ -148,17 +152,36 @@ public:
     /// This will finish logging the event
     virtual ~Event();
 
+    /// Log the beginning of the event
+    void begin();
+
+    /// Log the end of the event.
+    void end();
+
     /// Get ID of this event
     ///
     /// @return ID of this event
     [[nodiscard]] EventID get_id() const;
 
-    /// Log number of FLOPS
-    void log_flops(LogDouble n);
-
 private:
+    /// Get event ID from event name
+    EventID id_from_name(const char * name);
+
     /// Event ID
     EventID id;
+};
+
+/// Scoped event for performance logging
+///
+/// Event start at the construction time and ends at the destruction time
+class ScopedEvent : public Event {
+public:
+    /// Construct a scoped performance logging event
+    ///
+    /// @param name Name of the event
+    explicit ScopedEvent(const char * name);
+    explicit ScopedEvent(const std::string & name);
+    virtual ~ScopedEvent();
 };
 
 } // namespace godzilla::perf_log

--- a/include/godzilla/PerfLog.h
+++ b/include/godzilla/PerfLog.h
@@ -92,17 +92,17 @@ public:
     /// Get the number of FLOPS
     ///
     /// @return Number of FLOPS
-    [[nodiscard]] LogDouble get_flops() const;
+    [[nodiscard]] LogDouble flops() const;
 
     /// Get total time spent on this event
     ///
     /// @return The total time spent on this event
-    [[nodiscard]] LogDouble get_time() const;
+    [[nodiscard]] LogDouble time() const;
 
     /// Get number of times this event was called
     ///
     /// @return Number of times this event was called
-    [[nodiscard]] int get_num_calls() const;
+    [[nodiscard]] int num_calls() const;
 
 private:
     /// Event information collected by PETSc

--- a/include/godzilla/PrintInterface.h
+++ b/include/godzilla/PrintInterface.h
@@ -42,7 +42,7 @@ public:
     private:
         const PrintInterface * pi;
         unsigned int level;
-        PerfLog::Event * event;
+        perf_log::Event * event;
         PetscLogDouble start_time;
     };
 

--- a/include/godzilla/PrintInterface.h
+++ b/include/godzilla/PrintInterface.h
@@ -88,11 +88,8 @@ private:
     const std::string prefix;
 };
 
-#ifdef GODZILLA_WITH_PERF_LOG
-    #define TIMED_EVENT(level, event_name, ...) \
-        auto __timed_event_obj =                \
-            PrintInterface::TimedEvent::create(this, level, event_name, __VA_ARGS__)
-#else
-    #define TIMED_EVENT(level, event_name, ...) lprint(level, __VA_ARGS__)
-#endif
+#define TIMED_EVENT(level, event_name, ...) \
+    auto __timed_event_obj =                \
+        PrintInterface::TimedEvent::create(this, level, event_name, __VA_ARGS__)
+
 } // namespace godzilla

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,8 +18,6 @@ set_target_properties(
         SOVERSION ${PROJECT_VERSION_MAJOR}
 )
 
-target_compile_definitions(${PROJECT_NAME} PUBLIC -DGODZILLA_WITH_PERF_LOG)
-
 if (PETSC_HAVE_HYPRE)
     target_compile_definitions(${PROJECT_NAME} PRIVATE -DPETSC_HAVE_HYPRE)
 endif()

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -14,7 +14,7 @@ Init::Init()
     char ** argv = { nullptr };
     PetscInitialize(&argc, &argv, nullptr, nullptr);
 #ifdef GODZILLA_WITH_PERF_LOG
-    PerfLog::init();
+    perf_log::init();
 #endif
     // get rid of PETSc error handler
     PetscPopSignalHandler();
@@ -26,7 +26,7 @@ Init::Init(int argc, char * argv[])
 {
     PetscInitialize(&argc, &argv, nullptr, nullptr);
 #ifdef GODZILLA_WITH_PERF_LOG
-    PerfLog::init();
+    perf_log::init();
 #endif
     // get rid of PETSc error handler
     PetscPopSignalHandler();

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -13,9 +13,7 @@ Init::Init()
     int argc = 0;
     char ** argv = { nullptr };
     PetscInitialize(&argc, &argv, nullptr, nullptr);
-#ifdef GODZILLA_WITH_PERF_LOG
     perf_log::init();
-#endif
     // get rid of PETSc error handler
     PetscPopSignalHandler();
     PetscPopErrorHandler();
@@ -25,9 +23,7 @@ Init::Init()
 Init::Init(int argc, char * argv[])
 {
     PetscInitialize(&argc, &argv, nullptr, nullptr);
-#ifdef GODZILLA_WITH_PERF_LOG
     perf_log::init();
-#endif
     // get rid of PETSc error handler
     PetscPopSignalHandler();
     PetscPopErrorHandler();

--- a/src/PerfLog.cpp
+++ b/src/PerfLog.cpp
@@ -193,19 +193,19 @@ EventInfo::EventInfo(EventID event_id, StageID stage_id) : info()
 }
 
 LogDouble
-EventInfo::get_flops() const
+EventInfo::flops() const
 {
     return this->info.flops;
 }
 
 LogDouble
-EventInfo::get_time() const
+EventInfo::time() const
 {
     return this->info.time;
 }
 
 int
-EventInfo::get_num_calls() const
+EventInfo::num_calls() const
 {
     return this->info.count;
 }

--- a/src/PerfLog.cpp
+++ b/src/PerfLog.cpp
@@ -4,16 +4,16 @@
 #include "godzilla/PerfLog.h"
 #include "godzilla/Exception.h"
 
-namespace godzilla {
+namespace godzilla::perf_log {
 
 void
-PerfLog::init()
+init()
 {
     PetscLogDefaultBegin();
 }
 
 bool
-PerfLog::is_event_registered(const char * name)
+is_event_registered(const char * name)
 {
     EventID event_id;
     PetscLogEventGetId(name, &event_id);
@@ -21,13 +21,13 @@ PerfLog::is_event_registered(const char * name)
 }
 
 bool
-PerfLog::is_event_registered(const std::string & name)
+is_event_registered(const std::string & name)
 {
-    return PerfLog::is_event_registered(name.c_str());
+    return is_event_registered(name.c_str());
 }
 
-PerfLog::EventID
-PerfLog::register_event(const char * name)
+EventID
+register_event(const char * name)
 {
     EventID event_id;
     PetscLogEventGetId(name, &event_id);
@@ -39,14 +39,14 @@ PerfLog::register_event(const char * name)
         throw Exception("PerfLog event '{}' is already registered.", name);
 }
 
-PerfLog::EventID
-PerfLog::register_event(const std::string & name)
+EventID
+register_event(const std::string & name)
 {
-    return PerfLog::register_event(name.c_str());
+    return register_event(name.c_str());
 }
 
-PerfLog::EventID
-PerfLog::get_event_id(const char * name)
+EventID
+get_event_id(const char * name)
 {
     EventID event_id;
     PetscLogEventGetId(name, &event_id);
@@ -56,14 +56,14 @@ PerfLog::get_event_id(const char * name)
         throw Exception("Event '{}' was not registered.", name);
 }
 
-PerfLog::EventID
-PerfLog::get_event_id(const std::string & name)
+EventID
+get_event_id(const std::string & name)
 {
-    return PerfLog::get_event_id(name.c_str());
+    return get_event_id(name.c_str());
 }
 
-PerfLog::StageID
-PerfLog::register_stage(const char * name)
+StageID
+register_stage(const char * name)
 {
     StageID stage_id;
     PetscLogStageGetId(name, &stage_id);
@@ -75,14 +75,14 @@ PerfLog::register_stage(const char * name)
         throw Exception("PerfLog stage '{}' is already registered.", name);
 }
 
-PerfLog::StageID
-PerfLog::register_stage(const std::string & name)
+StageID
+register_stage(const std::string & name)
 {
-    return PerfLog::register_stage(name.c_str());
+    return register_stage(name.c_str());
 }
 
-PerfLog::StageID
-PerfLog::get_stage_id(const char * name)
+StageID
+get_stage_id(const char * name)
 {
     EventID stage_id;
     PetscLogStageGetId(name, &stage_id);
@@ -92,24 +92,23 @@ PerfLog::get_stage_id(const char * name)
         throw Exception("Stage '{}' was not registered.", name);
 }
 
-PerfLog::StageID
-PerfLog::get_stage_id(const std::string & name)
+StageID
+get_stage_id(const std::string & name)
 {
-    return PerfLog::get_stage_id(name.c_str());
+    return get_stage_id(name.c_str());
 }
 
-PerfLog::EventInfo
-PerfLog::get_event_info(const std::string & event_name, const std::string & stage_name)
+EventInfo
+get_event_info(const std::string & event_name, const std::string & stage_name)
 {
-    EventID event_id = PerfLog::get_event_id(event_name.c_str());
-    StageID stage_id =
-        stage_name.empty() ? PETSC_DETERMINE : PerfLog::get_stage_id(stage_name.c_str());
+    EventID event_id = get_event_id(event_name.c_str());
+    StageID stage_id = stage_name.empty() ? PETSC_DETERMINE : get_stage_id(stage_name.c_str());
     EventInfo info(event_id, stage_id);
     return info;
 }
 
-PerfLog::EventInfo
-PerfLog::get_event_info(EventID event_id, StageID stage_id)
+EventInfo
+get_event_info(EventID event_id, StageID stage_id)
 {
     EventInfo info(event_id, stage_id);
     return info;
@@ -117,89 +116,89 @@ PerfLog::get_event_info(EventID event_id, StageID stage_id)
 
 // Event
 
-PerfLog::Event::Event(const char * name) : id(PerfLog::get_event_id(name))
+Event::Event(const char * name) : id(get_event_id(name))
 {
     PetscLogEventBegin(this->id, 0, 0, 0, 0);
 }
 
-PerfLog::Event::Event(const std::string & name) : id(PerfLog::get_event_id(name.c_str()))
+Event::Event(const std::string & name) : id(get_event_id(name.c_str()))
 {
     PetscLogEventBegin(this->id, 0, 0, 0, 0);
 }
 
-PerfLog::Event::Event(EventID id) : id(id)
+Event::Event(EventID id) : id(id)
 {
     PetscLogEventBegin(this->id, 0, 0, 0, 0);
 }
 
-PerfLog::Event::~Event()
+Event::~Event()
 {
     PetscLogEventEnd(this->id, 0, 0, 0, 0);
 }
 
-PerfLog::EventID
-PerfLog::Event::get_id() const
+EventID
+Event::get_id() const
 {
     return this->id;
 }
 
 void
-PerfLog::Event::log_flops(LogDouble n)
+Event::log_flops(LogDouble n)
 {
     PetscLogFlops(n);
 }
 
 // Stage
 
-PerfLog::Stage::Stage(const char * name) : id(PerfLog::get_stage_id(name))
+Stage::Stage(const char * name) : id(get_stage_id(name))
 {
     PetscLogStagePush(this->id);
 }
 
-PerfLog::Stage::Stage(const std::string & name) : id(PerfLog::get_stage_id(name))
+Stage::Stage(const std::string & name) : id(get_stage_id(name))
 {
     PetscLogStagePush(this->id);
 }
 
-PerfLog::Stage::Stage(EventID id) : id(id)
+Stage::Stage(EventID id) : id(id)
 {
     PetscLogStagePush(this->id);
 }
 
-PerfLog::Stage::~Stage()
+Stage::~Stage()
 {
     PetscLogStagePop();
 }
 
-PerfLog::StageID
-PerfLog::Stage::get_id() const
+StageID
+Stage::get_id() const
 {
     return this->id;
 }
 
 // Event info
 
-PerfLog::EventInfo::EventInfo(EventID event_id, StageID stage_id) : info()
+EventInfo::EventInfo(EventID event_id, StageID stage_id) : info()
 {
     PetscLogEventGetPerfInfo(stage_id, event_id, &this->info);
 }
 
-PerfLog::LogDouble
-PerfLog::EventInfo::get_flops() const
+LogDouble
+EventInfo::get_flops() const
 {
     return this->info.flops;
 }
 
-PerfLog::LogDouble
-PerfLog::EventInfo::get_time() const
+LogDouble
+EventInfo::get_time() const
 {
     return this->info.time;
 }
 
 int
-PerfLog::EventInfo::get_num_calls() const
+EventInfo::get_num_calls() const
 {
     return this->info.count;
 }
 
-} // namespace godzilla
+} // namespace godzilla::perf_log

--- a/src/PerfLog.cpp
+++ b/src/PerfLog.cpp
@@ -15,7 +15,7 @@ PerfLog::init()
 bool
 PerfLog::is_event_registered(const char * name)
 {
-    PetscLogEvent event_id;
+    EventID event_id;
     PetscLogEventGetId(name, &event_id);
     return (event_id != -1);
 }
@@ -26,10 +26,10 @@ PerfLog::is_event_registered(const std::string & name)
     return PerfLog::is_event_registered(name.c_str());
 }
 
-PetscLogEvent
+PerfLog::EventID
 PerfLog::register_event(const char * name)
 {
-    PetscLogEvent event_id;
+    EventID event_id;
     PetscLogEventGetId(name, &event_id);
     if (event_id == -1) {
         PetscLogEventRegister(name, 0, &event_id);
@@ -39,16 +39,16 @@ PerfLog::register_event(const char * name)
         throw Exception("PerfLog event '{}' is already registered.", name);
 }
 
-PetscLogEvent
+PerfLog::EventID
 PerfLog::register_event(const std::string & name)
 {
     return PerfLog::register_event(name.c_str());
 }
 
-PetscLogEvent
+PerfLog::EventID
 PerfLog::get_event_id(const char * name)
 {
-    PetscLogEvent event_id;
+    EventID event_id;
     PetscLogEventGetId(name, &event_id);
     if (event_id != -1)
         return event_id;
@@ -56,16 +56,16 @@ PerfLog::get_event_id(const char * name)
         throw Exception("Event '{}' was not registered.", name);
 }
 
-PetscLogEvent
+PerfLog::EventID
 PerfLog::get_event_id(const std::string & name)
 {
     return PerfLog::get_event_id(name.c_str());
 }
 
-PetscLogStage
+PerfLog::StageID
 PerfLog::register_stage(const char * name)
 {
-    PetscLogStage stage_id;
+    StageID stage_id;
     PetscLogStageGetId(name, &stage_id);
     if (stage_id == -1) {
         PetscLogStageRegister(name, &stage_id);
@@ -75,16 +75,16 @@ PerfLog::register_stage(const char * name)
         throw Exception("PerfLog stage '{}' is already registered.", name);
 }
 
-PetscLogStage
+PerfLog::StageID
 PerfLog::register_stage(const std::string & name)
 {
     return PerfLog::register_stage(name.c_str());
 }
 
-PetscLogStage
+PerfLog::StageID
 PerfLog::get_stage_id(const char * name)
 {
-    PetscLogEvent stage_id;
+    EventID stage_id;
     PetscLogStageGetId(name, &stage_id);
     if (stage_id != -1)
         return stage_id;
@@ -92,7 +92,7 @@ PerfLog::get_stage_id(const char * name)
         throw Exception("Stage '{}' was not registered.", name);
 }
 
-PetscLogStage
+PerfLog::StageID
 PerfLog::get_stage_id(const std::string & name)
 {
     return PerfLog::get_stage_id(name.c_str());
@@ -101,15 +101,15 @@ PerfLog::get_stage_id(const std::string & name)
 PerfLog::EventInfo
 PerfLog::get_event_info(const std::string & event_name, const std::string & stage_name)
 {
-    PetscLogEvent event_id = PerfLog::get_event_id(event_name.c_str());
-    PetscLogStage stage_id =
+    EventID event_id = PerfLog::get_event_id(event_name.c_str());
+    StageID stage_id =
         stage_name.empty() ? PETSC_DETERMINE : PerfLog::get_stage_id(stage_name.c_str());
     EventInfo info(event_id, stage_id);
     return info;
 }
 
 PerfLog::EventInfo
-PerfLog::get_event_info(PetscLogEvent event_id, PetscLogStage stage_id)
+PerfLog::get_event_info(EventID event_id, StageID stage_id)
 {
     EventInfo info(event_id, stage_id);
     return info;
@@ -127,7 +127,7 @@ PerfLog::Event::Event(const std::string & name) : id(PerfLog::get_event_id(name.
     PetscLogEventBegin(this->id, 0, 0, 0, 0);
 }
 
-PerfLog::Event::Event(PetscLogEvent id) : id(id)
+PerfLog::Event::Event(EventID id) : id(id)
 {
     PetscLogEventBegin(this->id, 0, 0, 0, 0);
 }
@@ -137,14 +137,14 @@ PerfLog::Event::~Event()
     PetscLogEventEnd(this->id, 0, 0, 0, 0);
 }
 
-PetscLogEvent
+PerfLog::EventID
 PerfLog::Event::get_id() const
 {
     return this->id;
 }
 
 void
-PerfLog::Event::log_flops(PetscLogDouble n)
+PerfLog::Event::log_flops(LogDouble n)
 {
     PetscLogFlops(n);
 }
@@ -161,7 +161,7 @@ PerfLog::Stage::Stage(const std::string & name) : id(PerfLog::get_stage_id(name)
     PetscLogStagePush(this->id);
 }
 
-PerfLog::Stage::Stage(PetscLogEvent id) : id(id)
+PerfLog::Stage::Stage(EventID id) : id(id)
 {
     PetscLogStagePush(this->id);
 }
@@ -171,7 +171,7 @@ PerfLog::Stage::~Stage()
     PetscLogStagePop();
 }
 
-PetscLogStage
+PerfLog::StageID
 PerfLog::Stage::get_id() const
 {
     return this->id;
@@ -179,18 +179,18 @@ PerfLog::Stage::get_id() const
 
 // Event info
 
-PerfLog::EventInfo::EventInfo(PetscLogEvent event_id, PetscLogStage stage_id) : info()
+PerfLog::EventInfo::EventInfo(EventID event_id, StageID stage_id) : info()
 {
     PetscLogEventGetPerfInfo(stage_id, event_id, &this->info);
 }
 
-PetscLogDouble
+PerfLog::LogDouble
 PerfLog::EventInfo::get_flops() const
 {
     return this->info.flops;
 }
 
-PetscLogDouble
+PerfLog::LogDouble
 PerfLog::EventInfo::get_time() const
 {
     return this->info.time;

--- a/src/PrintInterface.cpp
+++ b/src/PrintInterface.cpp
@@ -20,7 +20,7 @@ PrintInterface::TimedEvent::TimedEvent(const PrintInterface * pi,
     if (!perf_log::is_event_registered(evt_name))
         perf_log::register_event(evt_name);
     this->event = new perf_log::Event(evt_name);
-    this->start_time = perf_log::get_event_info(evt_name).get_time();
+    this->start_time = perf_log::get_event_info(evt_name).time();
     if (level <= this->pi->verbosity_level && this->pi->proc_id == 0) {
         fmt::print("{}... ", text);
     }
@@ -33,7 +33,7 @@ PrintInterface::TimedEvent::~TimedEvent()
 
     if (level <= this->pi->verbosity_level && this->pi->proc_id == 0) {
         auto info = perf_log::get_event_info(event_id);
-        fmt::print("done [{}]\n", utils::human_time(info.get_time() - this->start_time));
+        fmt::print("done [{}]\n", utils::human_time(info.time() - this->start_time));
     }
 }
 

--- a/src/PrintInterface.cpp
+++ b/src/PrintInterface.cpp
@@ -17,10 +17,10 @@ PrintInterface::TimedEvent::TimedEvent(const PrintInterface * pi,
     level(level)
 {
     std::string evt_name = fmt::format("{}::{}", this->pi->pi_app->get_name(), event_name);
-    if (!PerfLog::is_event_registered(evt_name))
-        PerfLog::register_event(evt_name);
-    this->event = new PerfLog::Event(evt_name);
-    this->start_time = PerfLog::get_event_info(evt_name).get_time();
+    if (!perf_log::is_event_registered(evt_name))
+        perf_log::register_event(evt_name);
+    this->event = new perf_log::Event(evt_name);
+    this->start_time = perf_log::get_event_info(evt_name).get_time();
     if (level <= this->pi->verbosity_level && this->pi->proc_id == 0) {
         fmt::print("{}... ", text);
     }
@@ -32,7 +32,7 @@ PrintInterface::TimedEvent::~TimedEvent()
     delete this->event;
 
     if (level <= this->pi->verbosity_level && this->pi->proc_id == 0) {
-        auto info = PerfLog::get_event_info(event_id);
+        auto info = perf_log::get_event_info(event_id);
         fmt::print("done [{}]\n", utils::human_time(info.get_time() - this->start_time));
     }
 }

--- a/test/src/PerfLog_test.cpp
+++ b/test/src/PerfLog_test.cpp
@@ -12,107 +12,109 @@ TEST(PerfLogTest, event)
     const std::string event1_name = "event1";
     const std::string event2_name = "event2";
 
-    PerfLog::register_event(event1_name);
-    auto event2_id = PerfLog::register_event(event2_name);
+    perf_log::register_event(event1_name);
+    auto event2_id = perf_log::register_event(event2_name);
 
     for (int i = 0; i < 2; i++) {
         struct timespec remaining, request = { 0, 50000000 };
-        PerfLog::Event event(event1_name);
+        perf_log::Event event(event1_name);
         event.log_flops(4.);
         nanosleep(&request, &remaining);
     }
 
     {
         struct timespec remaining, request = { 0, 200000000 };
-        PerfLog::Event ev2(event2_id);
+        perf_log::Event ev2(event2_id);
         ev2.log_flops(16.);
         nanosleep(&request, &remaining);
     }
 
-    PerfLog::EventInfo info1 = PerfLog::get_event_info(event1_name);
+    perf_log::EventInfo info1 = perf_log::get_event_info(event1_name);
     EXPECT_DOUBLE_EQ(info1.get_flops(), 8.);
     EXPECT_EQ(info1.get_num_calls(), 2);
     EXPECT_NEAR(info1.get_time(), 0.1, 0.3);
 
-    PerfLog::EventInfo info2 = PerfLog::get_event_info(event2_id);
+    perf_log::EventInfo info2 = perf_log::get_event_info(event2_id);
     EXPECT_DOUBLE_EQ(info2.get_flops(), 16.);
     EXPECT_EQ(info2.get_num_calls(), 1);
 }
 
 TEST(PerfLogTest, error_existing_event)
 {
-    PerfLog::register_event("event_asdf");
-    EXPECT_THROW_MSG(PerfLog::register_event("event_asdf"),
+    perf_log::register_event("event_asdf");
+    EXPECT_THROW_MSG(perf_log::register_event("event_asdf"),
                      "PerfLog event 'event_asdf' is already registered.");
 }
 
 TEST(PerfLogTest, non_existent_event_id)
 {
-    EXPECT_THROW_MSG(PerfLog::get_event_id("event_none"), "Event 'event_none' was not registered.");
+    EXPECT_THROW_MSG(perf_log::get_event_id("event_none"),
+                     "Event 'event_none' was not registered.");
 
     const std::string no_event = "event_none";
-    EXPECT_THROW_MSG(PerfLog::get_event_id(no_event), "Event 'event_none' was not registered.");
+    EXPECT_THROW_MSG(perf_log::get_event_id(no_event), "Event 'event_none' was not registered.");
 }
 
 TEST(PerfLogTest, stage)
 {
     const std::string event_name = "event";
-    PerfLog::register_event(event_name);
+    perf_log::register_event(event_name);
 
     const std::string stage_name = "stage1";
-    PerfLog::register_stage(stage_name);
-    PetscLogStage stage2_id = PerfLog::register_stage("stage2");
+    perf_log::register_stage(stage_name);
+    PetscLogStage stage2_id = perf_log::register_stage("stage2");
 
     for (int i = 0; i < 3; i++) {
         struct timespec remaining, request = { 0, 50000000 };
-        PerfLog::Stage stage(stage_name);
-        PerfLog::Event ev(event_name);
+        perf_log::Stage stage(stage_name);
+        perf_log::Event ev(event_name);
         ev.log_flops(1.);
         nanosleep(&request, &remaining);
     }
 
     {
         struct timespec remaining, request = { 0, 100000000 };
-        PerfLog::Stage stage2(stage2_id);
-        PerfLog::Event ev("event");
+        perf_log::Stage stage2(stage2_id);
+        perf_log::Event ev("event");
         ev.log_flops(2.);
         nanosleep(&request, &remaining);
     }
 
-    PerfLog::Stage stage("stage1");
+    perf_log::Stage stage("stage1");
     #if (PETSC_VERSION_GE(3, 18, 0)) && (PETSC_VERSION_LT(3, 20, 0))
     EXPECT_EQ(stage.get_id(), 2);
     #else
     EXPECT_EQ(stage.get_id(), 1);
     #endif
 
-    PerfLog::EventInfo info1 = PerfLog::get_event_info(event_name, stage_name);
+    perf_log::EventInfo info1 = perf_log::get_event_info(event_name, stage_name);
     EXPECT_DOUBLE_EQ(info1.get_flops(), 3.);
     EXPECT_EQ(info1.get_num_calls(), 3);
 
-    PerfLog::Event ev(event_name);
-    PerfLog::EventInfo info2 = PerfLog::get_event_info(ev.get_id(), stage2_id);
+    perf_log::Event ev(event_name);
+    perf_log::EventInfo info2 = perf_log::get_event_info(ev.get_id(), stage2_id);
     EXPECT_DOUBLE_EQ(info2.get_flops(), 2.);
     EXPECT_EQ(info2.get_num_calls(), 1);
 }
 
 TEST(PerfLogTest, error_existing_stage)
 {
-    PerfLog::register_stage("stage_asdf");
-    EXPECT_THROW_MSG(PerfLog::register_stage("stage_asdf"),
+    perf_log::register_stage("stage_asdf");
+    EXPECT_THROW_MSG(perf_log::register_stage("stage_asdf"),
                      "PerfLog stage 'stage_asdf' is already registered.");
 }
 
 TEST(PerfLogTest, non_existent_stage_id)
 {
-    EXPECT_THROW_MSG(PerfLog::get_stage_id("stage_none"), "Stage 'stage_none' was not registered.");
+    EXPECT_THROW_MSG(perf_log::get_stage_id("stage_none"),
+                     "Stage 'stage_none' was not registered.");
 }
 
 TEST(PerfLogTest, is_event_registered)
 {
-    EXPECT_FALSE(PerfLog::is_event_registered("event3"));
-    PerfLog::register_event("event3");
-    EXPECT_TRUE(PerfLog::is_event_registered("event3"));
+    EXPECT_FALSE(perf_log::is_event_registered("event3"));
+    perf_log::register_event("event3");
+    EXPECT_TRUE(perf_log::is_event_registered("event3"));
 }
 
 #endif

--- a/test/src/PerfLog_test.cpp
+++ b/test/src/PerfLog_test.cpp
@@ -3,8 +3,6 @@
 #include "ExceptionTestMacros.h"
 #include <time.h>
 
-#ifdef GODZILLA_WITH_PERF_LOG
-
 using namespace godzilla;
 
 TEST(PerfLogTest, event)
@@ -12,7 +10,6 @@ TEST(PerfLogTest, event)
     const std::string event1_name = "event1";
     const std::string event2_name = "event2";
 
-    perf_log::register_event(event1_name);
     auto event2_id = perf_log::register_event(event2_name);
 
     for (int i = 0; i < 2; i++) {
@@ -83,11 +80,11 @@ TEST(PerfLogTest, stage)
     }
 
     perf_log::Stage stage("stage1");
-    #if (PETSC_VERSION_GE(3, 18, 0)) && (PETSC_VERSION_LT(3, 20, 0))
+#if (PETSC_VERSION_GE(3, 18, 0)) && (PETSC_VERSION_LT(3, 20, 0))
     EXPECT_EQ(stage.get_id(), 2);
-    #else
+#else
     EXPECT_EQ(stage.get_id(), 1);
-    #endif
+#endif
 
     perf_log::EventInfo info1 = perf_log::get_event_info(event_name, stage_name);
     EXPECT_DOUBLE_EQ(info1.get_flops(), 3.);
@@ -118,5 +115,3 @@ TEST(PerfLogTest, is_event_registered)
     perf_log::register_event("event3");
     EXPECT_TRUE(perf_log::is_event_registered("event3"));
 }
-
-#endif

--- a/test/src/PerfLog_test.cpp
+++ b/test/src/PerfLog_test.cpp
@@ -17,16 +17,18 @@ TEST(PerfLogTest, event)
 
     for (int i = 0; i < 2; i++) {
         struct timespec remaining, request = { 0, 50000000 };
-        perf_log::Event event(event1_name);
-        event.log_flops(4.);
+        perf_log::ScopedEvent event(event1_name);
+        perf_log::log_flops(4.);
         nanosleep(&request, &remaining);
     }
 
     {
-        struct timespec remaining, request = { 0, 200000000 };
         perf_log::Event ev2(event2_id);
-        ev2.log_flops(16.);
+        struct timespec remaining, request = { 0, 200000000 };
+        ev2.begin();
+        perf_log::log_flops(16.);
         nanosleep(&request, &remaining);
+        ev2.end();
     }
 
     perf_log::EventInfo info1 = perf_log::get_event_info(event1_name);
@@ -67,16 +69,16 @@ TEST(PerfLogTest, stage)
     for (int i = 0; i < 3; i++) {
         struct timespec remaining, request = { 0, 50000000 };
         perf_log::Stage stage(stage_name);
-        perf_log::Event ev(event_name);
-        ev.log_flops(1.);
+        perf_log::ScopedEvent ev(event_name);
+        perf_log::log_flops(1.);
         nanosleep(&request, &remaining);
     }
 
     {
         struct timespec remaining, request = { 0, 100000000 };
         perf_log::Stage stage2(stage2_id);
-        perf_log::Event ev("event");
-        ev.log_flops(2.);
+        perf_log::ScopedEvent ev("event");
+        perf_log::log_flops(2.);
         nanosleep(&request, &remaining);
     }
 

--- a/test/src/PerfLog_test.cpp
+++ b/test/src/PerfLog_test.cpp
@@ -29,13 +29,13 @@ TEST(PerfLogTest, event)
     }
 
     perf_log::EventInfo info1 = perf_log::get_event_info(event1_name);
-    EXPECT_DOUBLE_EQ(info1.get_flops(), 8.);
-    EXPECT_EQ(info1.get_num_calls(), 2);
-    EXPECT_NEAR(info1.get_time(), 0.1, 0.3);
+    EXPECT_DOUBLE_EQ(info1.flops(), 8.);
+    EXPECT_EQ(info1.num_calls(), 2);
+    EXPECT_NEAR(info1.time(), 0.1, 0.3);
 
     perf_log::EventInfo info2 = perf_log::get_event_info(event2_id);
-    EXPECT_DOUBLE_EQ(info2.get_flops(), 16.);
-    EXPECT_EQ(info2.get_num_calls(), 1);
+    EXPECT_DOUBLE_EQ(info2.flops(), 16.);
+    EXPECT_EQ(info2.num_calls(), 1);
 }
 
 TEST(PerfLogTest, error_existing_event)
@@ -87,13 +87,13 @@ TEST(PerfLogTest, stage)
 #endif
 
     perf_log::EventInfo info1 = perf_log::get_event_info(event_name, stage_name);
-    EXPECT_DOUBLE_EQ(info1.get_flops(), 3.);
-    EXPECT_EQ(info1.get_num_calls(), 3);
+    EXPECT_DOUBLE_EQ(info1.flops(), 3.);
+    EXPECT_EQ(info1.num_calls(), 3);
 
     perf_log::Event ev(event_name);
     perf_log::EventInfo info2 = perf_log::get_event_info(ev.get_id(), stage2_id);
-    EXPECT_DOUBLE_EQ(info2.get_flops(), 2.);
-    EXPECT_EQ(info2.get_num_calls(), 1);
+    EXPECT_DOUBLE_EQ(info2.flops(), 2.);
+    EXPECT_EQ(info2.num_calls(), 1);
 }
 
 TEST(PerfLogTest, error_existing_stage)

--- a/test/src/PrintInterface_test.cpp
+++ b/test/src/PrintInterface_test.cpp
@@ -65,10 +65,6 @@ TEST(PrintInterfaceTest, timed_event)
     TestObject obj(pars);
 
     obj.create();
-#ifdef GODZILLA_WITH_PERF_LOG
     EXPECT_THAT(testing::internal::GetCapturedStdout(),
                 testing::ContainsRegex("Print text... done \\[.+\\]"));
-#else
-    EXPECT_THAT(testing::internal::GetCapturedStdout(), testing::ContainsRegex("Print text"));
-#endif
 }


### PR DESCRIPTION
- Using godzilla types for PerfLog
- Turning `PerfLog` class into a namespace
- Refactoring `Event`
- Performance logging is always available for applications
- Renaming methods to extract data from `EventInfo`
