### PR TITLE
Adding wrapper API to `IndexSet`

### DIFF
--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -56,6 +56,11 @@ public:
     /// Destroys an index set
     void destroy();
 
+    /// Creates a duplicate copy of an index set
+    ///
+    /// @return The copy of the index set
+    [[nodiscard]] IndexSet duplicate() const;
+
     void get_indices();
 
     void restore_indices();

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -48,6 +48,11 @@ public:
     explicit IndexSet(IS is);
     ~IndexSet() = default;
 
+    /// Replace the content of this index set with the content of another index set
+    ///
+    /// @param src The index set to copy from
+    void assign(const IndexSet & src);
+
     /// Creates an index set object
     ///
     /// @param comm The MPI communicator
@@ -174,6 +179,12 @@ public:
     /// @param is2 The second index set
     /// @return The sorted intersection of `is1` and `is2`
     static IndexSet intersect(const IndexSet & is1, const IndexSet & is2);
+
+    /// Copies an index set
+    ///
+    /// @param src The index set to copy from
+    /// @param dest The index set to copy to
+    static void copy(const IndexSet & src, IndexSet & dest);
 };
 
 } // namespace godzilla

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -126,6 +126,11 @@ public:
     /// @return The PETSc ID
     [[nodiscard]] PetscObjectId get_id() const;
 
+    /// Shift all indices by given offset
+    ///
+    /// @param offset The offset to shift the indices by
+    void shift(Int offset);
+
     /// Checks the indices to determine whether they have been sorted
     ///
     /// @return `true` is index set is sorted

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -255,6 +255,13 @@ IndexSet::empty() const
     return this->is == nullptr;
 }
 
+void
+IndexSet::shift(Int offset)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(ISShift(this->is, offset, this->is));
+}
+
 IndexSet
 IndexSet::intersect_caching(const IndexSet & is1, const IndexSet & is2)
 {

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -262,6 +262,13 @@ IndexSet::shift(Int offset)
     PETSC_CHECK(ISShift(this->is, offset, this->is));
 }
 
+void
+IndexSet::assign(const IndexSet & src)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(ISCopy(src, this->is));
+}
+
 IndexSet
 IndexSet::intersect_caching(const IndexSet & is1, const IndexSet & is2)
 {
@@ -293,6 +300,13 @@ IndexSet::intersect(const IndexSet & is1, const IndexSet & is2)
     IS is;
     ISIntersect(is1, is2, &is);
     return IndexSet(is);
+}
+
+void
+IndexSet::copy(const IndexSet & src, IndexSet & dest)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(ISCopy(src, dest));
 }
 
 IndexSet::Iterator

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -148,6 +148,15 @@ IndexSet::get_local_size() const
     return n;
 }
 
+IndexSet
+IndexSet::duplicate() const
+{
+    CALL_STACK_MSG();
+    IS new_is;
+    PETSC_CHECK(ISDuplicate(this->is, &new_is));
+    return IndexSet(new_is);
+}
+
 void
 IndexSet::get_indices()
 {

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -203,3 +203,31 @@ TEST(IndexSetTest, shift)
     is.restore_indices();
     is.destroy();
 }
+
+TEST(IndexSetTest, assign)
+{
+    TestApp app;
+    auto src = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    auto dest = IndexSet::create_general(app.get_comm(), { 0, 0, 0, 0, 0, 0 });
+    dest.assign(src);
+    dest.get_indices();
+    auto vals = dest.to_std_vector();
+    EXPECT_THAT(vals, ElementsAre(1, 3, 4, 5, 8, 10));
+    dest.restore_indices();
+    dest.destroy();
+    src.destroy();
+}
+
+TEST(IndexSetTest, copy)
+{
+    TestApp app;
+    auto src = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    auto dest = IndexSet::create_general(app.get_comm(), { 0, 0, 0, 0, 0, 0 });
+    IndexSet::copy(src, dest);
+    dest.get_indices();
+    auto vals = dest.to_std_vector();
+    EXPECT_THAT(vals, ElementsAre(1, 3, 4, 5, 8, 10));
+    dest.restore_indices();
+    dest.destroy();
+    src.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -191,3 +191,15 @@ TEST(IndexSetTest, duplicate)
     dup.destroy();
     is.destroy();
 }
+
+TEST(IndexSetTest, shift)
+{
+    TestApp app;
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    is.shift(2);
+    is.get_indices();
+    auto vals = is.to_std_vector();
+    EXPECT_THAT(vals, ElementsAre(3, 5, 6, 7, 10, 12));
+    is.restore_indices();
+    is.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -178,3 +178,16 @@ TEST(IndexSetTest, view)
     EXPECT_THAT(out, HasSubstr("3 10"));
     is.destroy();
 }
+
+TEST(IndexSetTest, duplicate)
+{
+    TestApp app;
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    auto dup = is.duplicate();
+    dup.get_indices();
+    auto vals = dup.to_std_vector();
+    EXPECT_THAT(vals, ElementsAre(1, 3, 4, 5, 8, 10));
+    dup.restore_indices();
+    dup.destroy();
+    is.destroy();
+}


### PR DESCRIPTION
- Adding `IndexSet::duplicate()`
- Adding `IndexSet::shift`
- Adding `IndexSet::copy` and `IndexSet::assign`
