### PR TITLE
Adding more wrapper API into `IndexSet`

### DIFF
--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -222,6 +222,13 @@ public:
     /// @param is2 Index values to be removed
     /// @return The difference between `is1` and `is2`
     static IndexSet difference(const IndexSet & is1, const IndexSet & is2);
+
+    /// Computes the union of two index sets, by concatenating 2 lists and removing duplicates.
+    ///
+    /// @param is1 The first index set
+    /// @param is2 The second index set
+    /// @return The union of `is1` and `is2`
+    static IndexSet expand(const IndexSet & is1, const IndexSet & is2);
 };
 
 } // namespace godzilla

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -80,6 +80,15 @@ public:
     /// @return `true` if the index sets are equal, `false` otherwise
     [[nodiscard]] bool equal(const IndexSet & other) const;
 
+    /// Compares if this index set has the same set of indices as the `other`
+    ///
+    /// @param other The index set to compare with
+    /// @return `true` if the index sets are equal, `false` otherwise
+    ///
+    /// @note This routine does NOT sort the contents of the index sets before the comparison is
+    /// made, i.e., the order of indices is important.
+    [[nodiscard]] bool equal_unsorted(const IndexSet & other) const;
+
     void get_indices();
 
     void restore_indices();

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -91,6 +91,11 @@ public:
 
     void get_indices();
 
+    /// Gets the index set type name
+    ///
+    /// @return The type name
+    [[nodiscard]] std::string get_type() const;
+
     void restore_indices();
 
     /// Returns a description of the points in an IndexSet suitable for traversal

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -168,6 +168,11 @@ public:
     /// Informs the index set that it is a permutation.
     void set_permutation();
 
+    /// Builds a index set, for a particular type
+    ///
+    /// @param type The type of index set to build
+    void set_type(const std::string & type);
+
     /// Increase reference of this object
     void inc_ref();
 

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -145,6 +145,14 @@ public:
     /// @return std::vector containing the indices
     std::vector<Int> to_std_vector();
 
+    /// Determines whether index set is the identity mapping.
+    ///
+    /// @return `true` if the index set is the identity mapping, `false` otherwise
+    [[nodiscard]] bool identity() const;
+
+    /// Sets the index set to be the identity mapping.
+    void set_identity();
+
     /// Increase reference of this object
     void inc_ref();
 

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -114,6 +114,11 @@ public:
     /// @param points The indices for the entire range, from `get_point_range`
     void get_point_subrange(Int start, Int end, const Int * points) const;
 
+    /// Gets the minimum and maximum values
+    ///
+    /// @return A tuple containing the minimum and maximum values
+    [[nodiscard]] std::tuple<Int, Int> get_min_max() const;
+
     /// Returns the global length of an index set.
     ///
     /// @return The global size of the index set

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -74,6 +74,12 @@ public:
     /// @return The copy of the index set
     [[nodiscard]] IndexSet duplicate() const;
 
+    /// Compares if this index set has the same set of indices as the `other`
+    ///
+    /// @param other The index set to compare with
+    /// @return `true` if the index sets are equal, `false` otherwise
+    [[nodiscard]] bool equal(const IndexSet & other) const;
+
     void get_indices();
 
     void restore_indices();

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -58,6 +58,14 @@ public:
     /// @param comm The MPI communicator
     void create(MPI_Comm comm);
 
+    /// Generates the complement index set. That is all indices that are NOT in the given set.
+    ///
+    /// @param nmin The first index desired in the local part of the complement
+    /// @param nmax The largest index desired in the local part of the complement (note that all
+    ///             indices in this indexs set must be greater or equal to `nmin` and less than
+    ///             `nmax`)
+    IndexSet complement(Int nmin, Int nmax) const;
+
     /// Destroys an index set
     void destroy();
 

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -193,6 +193,13 @@ public:
     /// @param src The index set to copy from
     /// @param dest The index set to copy to
     static void copy(const IndexSet & src, IndexSet & dest);
+
+    /// Forms a new IS by locally concatenating the indices from an IS list without reordering.
+    ///
+    /// @param comm The MPI communicator
+    /// @param is_list The list of index sets to concatenate
+    /// @return The concatenated index set
+    static IndexSet concatenate(MPI_Comm comm, const std::vector<IndexSet> & is_list);
 };
 
 } // namespace godzilla

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -200,6 +200,13 @@ public:
     /// @param is_list The list of index sets to concatenate
     /// @return The concatenated index set
     static IndexSet concatenate(MPI_Comm comm, const std::vector<IndexSet> & is_list);
+
+    /// Computes the difference between two index sets.
+    ///
+    /// @param is1 The first index set, to have items removed from it
+    /// @param is2 Index values to be removed
+    /// @return The difference between `is1` and `is2`
+    static IndexSet difference(const IndexSet & is1, const IndexSet & is2);
 };
 
 } // namespace godzilla

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -267,6 +267,13 @@ public:
     /// @param is2 The second index set
     /// @return The union of `is1` and `is2`
     static IndexSet expand(const IndexSet & is1, const IndexSet & is2);
+
+    /// Computes the sum (union) of two index sets.
+    ///
+    /// @param is1 The first index set
+    /// @param is2 The second index set
+    /// @return The sum of `is1` and `is2`
+    static IndexSet sum(const IndexSet & is1, const IndexSet & is2);
 };
 
 } // namespace godzilla

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -136,6 +136,13 @@ public:
 
     [[nodiscard]] const Int * data() const;
 
+    /// Determine the location of an index within the local component of an index set
+    ///
+    /// @param key The index to locate
+    /// @return if >= 0, a location within the index set that is equal to the key, otherwise the key
+    ///         is not in the index set
+    [[nodiscard]] Int locate(Int key) const;
+
     Int operator[](Int i) const;
 
     Int operator()(Int i) const;

--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -160,6 +160,14 @@ public:
     /// Sets the index set to be the identity mapping.
     void set_identity();
 
+    /// Determines whether index set is a permutation.
+    ///
+    /// @return `true` if the index set is a permutation, `false` otherwise
+    [[nodiscard]] bool permutation() const;
+
+    /// Informs the index set that it is a permutation.
+    void set_permutation();
+
     /// Increase reference of this object
     void inc_ref();
 

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -400,4 +400,20 @@ IndexSet::get_type() const
     return std::string(type);
 }
 
+void
+IndexSet::set_identity()
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(ISSetIdentity(this->is));
+}
+
+bool
+IndexSet::identity() const
+{
+    CALL_STACK_MSG();
+    PetscBool res;
+    PETSC_CHECK(ISIdentity(this->is, &res));
+    return res == PETSC_TRUE;
+}
+
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -363,4 +363,13 @@ IndexSet::equal(const IndexSet & other) const
     return res == PETSC_TRUE;
 }
 
+bool
+IndexSet::equal_unsorted(const IndexSet & other) const
+{
+    CALL_STACK_MSG();
+    PetscBool res;
+    PETSC_CHECK(ISEqualUnsorted(this->is, other, &res));
+    return res == PETSC_TRUE;
+}
+
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -372,4 +372,13 @@ IndexSet::equal_unsorted(const IndexSet & other) const
     return res == PETSC_TRUE;
 }
 
+IndexSet
+IndexSet::expand(const IndexSet & is1, const IndexSet & is2)
+{
+    CALL_STACK_MSG();
+    IS out;
+    PETSC_CHECK(ISExpand(is1, is2, &out));
+    return IndexSet(out);
+}
+
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -6,6 +6,7 @@
 #include "godzilla/Exception.h"
 #include "godzilla/CallStack.h"
 #include <cassert>
+#include <petscis.h>
 
 namespace godzilla {
 
@@ -388,6 +389,15 @@ IndexSet::get_min_max() const
     PetscInt min, max;
     PETSC_CHECK(ISGetMinMax(this->is, &min, &max));
     return std::make_tuple(min, max);
+}
+
+std::string
+IndexSet::get_type() const
+{
+    CALL_STACK_MSG();
+    ISType type;
+    PETSC_CHECK(ISGetType(this->is, &type));
+    return std::string(type);
 }
 
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -381,4 +381,13 @@ IndexSet::expand(const IndexSet & is1, const IndexSet & is2)
     return IndexSet(out);
 }
 
+std::tuple<Int, Int>
+IndexSet::get_min_max() const
+{
+    CALL_STACK_MSG();
+    PetscInt min, max;
+    PETSC_CHECK(ISGetMinMax(this->is, &min, &max));
+    return std::make_tuple(min, max);
+}
+
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -448,4 +448,13 @@ IndexSet::set_type(const std::string & type)
     PETSC_CHECK(ISSetType(this->is, type.c_str()));
 }
 
+IndexSet
+IndexSet::sum(const IndexSet & is1, const IndexSet & is2)
+{
+    CALL_STACK_MSG();
+    IS out;
+    PETSC_CHECK(ISSum(is1, is2, &out));
+    return IndexSet(out);
+}
+
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -441,4 +441,11 @@ IndexSet::permutation() const
     return res == PETSC_TRUE;
 }
 
+void
+IndexSet::set_type(const std::string & type)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(ISSetType(this->is, type.c_str()));
+}
+
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -324,4 +324,13 @@ IndexSet::end()
     return Iterator(*this, n);
 }
 
+IndexSet
+IndexSet::complement(Int nmin, Int nmax) const
+{
+    CALL_STACK_MSG();
+    IS out;
+    PETSC_CHECK(ISComplement(this->is, nmin, nmax, &out));
+    return IndexSet(out);
+}
+
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -425,4 +425,20 @@ IndexSet::locate(Int key) const
     return idx;
 }
 
+void
+IndexSet::set_permutation()
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(ISSetPermutation(this->is));
+}
+
+bool
+IndexSet::permutation() const
+{
+    CALL_STACK_MSG();
+    PetscBool res;
+    PETSC_CHECK(ISPermutation(this->is, &res));
+    return res == PETSC_TRUE;
+}
+
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -333,4 +333,16 @@ IndexSet::complement(Int nmin, Int nmax) const
     return IndexSet(out);
 }
 
+IndexSet
+IndexSet::concatenate(MPI_Comm comm, const std::vector<IndexSet> & is_list)
+{
+    CALL_STACK_MSG();
+    IS out;
+    std::vector<IS> is_vec(is_list.size());
+    for (size_t i = 0; i < is_list.size(); i++)
+        is_vec[i] = is_list[i];
+    PETSC_CHECK(ISConcatenate(comm, is_vec.size(), is_vec.data(), &out));
+    return IndexSet(out);
+}
+
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -345,4 +345,13 @@ IndexSet::concatenate(MPI_Comm comm, const std::vector<IndexSet> & is_list)
     return IndexSet(out);
 }
 
+IndexSet
+IndexSet::difference(const IndexSet & is1, const IndexSet & is2)
+{
+    CALL_STACK_MSG();
+    IS out;
+    PETSC_CHECK(ISDifference(is1, is2, &out));
+    return IndexSet(out);
+}
+
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -416,4 +416,13 @@ IndexSet::identity() const
     return res == PETSC_TRUE;
 }
 
+Int
+IndexSet::locate(Int key) const
+{
+    CALL_STACK_MSG();
+    PetscInt idx;
+    PETSC_CHECK(ISLocate(this->is, key, &idx));
+    return idx;
+}
+
 } // namespace godzilla

--- a/src/IndexSet.cpp
+++ b/src/IndexSet.cpp
@@ -354,4 +354,13 @@ IndexSet::difference(const IndexSet & is1, const IndexSet & is2)
     return IndexSet(out);
 }
 
+bool
+IndexSet::equal(const IndexSet & other) const
+{
+    CALL_STACK_MSG();
+    PetscBool res;
+    PETSC_CHECK(ISEqual(this->is, other, &res));
+    return res == PETSC_TRUE;
+}
+
 } // namespace godzilla

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -325,3 +325,10 @@ TEST(IndexSetTest, get_min_max)
     EXPECT_EQ(max, 10);
     is.destroy();
 }
+
+TEST(IndexSetTest, get_type)
+{
+    TestApp app;
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    EXPECT_EQ(is.get_type(), ISGENERAL);
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -300,3 +300,18 @@ TEST(IndexSetTest, equal_unsorted)
     is2.destroy();
     dup.destroy();
 }
+
+TEST(IndexSetTest, expand)
+{
+    TestApp app;
+    auto is1 = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    auto is2 = IndexSet::create_general(app.get_comm(), { 3, 5, 7, 9 });
+    auto dest = IndexSet::expand(is1, is2);
+    dest.get_indices();
+    auto vals = dest.to_std_vector();
+    EXPECT_THAT(vals, UnorderedElementsAre(1, 3, 4, 5, 7, 8, 9, 10));
+    dest.restore_indices();
+    is2.destroy();
+    is1.destroy();
+    dest.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -244,3 +244,18 @@ TEST(IndexSetTest, complement)
     dest.destroy();
     src.destroy();
 }
+
+TEST(IndexSetTest, concatenate)
+{
+    TestApp app;
+    auto is1 = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    auto is2 = IndexSet::create_general(app.get_comm(), { 2, 6, 7, 9 });
+    auto dest = IndexSet::concatenate(app.get_comm(), { is1, is2 });
+    dest.get_indices();
+    auto vals = dest.to_std_vector();
+    EXPECT_THAT(vals, ElementsAre(1, 3, 4, 5, 8, 10, 2, 6, 7, 9));
+    dest.restore_indices();
+    dest.destroy();
+    is1.destroy();
+    is2.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -361,3 +361,13 @@ TEST(IndexSetTest, permutation)
     EXPECT_TRUE(is.permutation());
     is.destroy();
 }
+
+TEST(IndexSetTest, set_type)
+{
+    TestApp app;
+    IndexSet is;
+    is.create(app.get_comm());
+    is.set_type(ISGENERAL);
+    EXPECT_EQ(is.get_type(), ISGENERAL);
+    is.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -351,3 +351,13 @@ TEST(IndexSetTest, locate)
     EXPECT_TRUE(is.locate(7) < 0);
     is.destroy();
 }
+
+TEST(IndexSetTest, permutation)
+{
+    TestApp app;
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    EXPECT_FALSE(is.permutation());
+    is.set_permutation();
+    EXPECT_TRUE(is.permutation());
+    is.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -332,3 +332,13 @@ TEST(IndexSetTest, get_type)
     auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
     EXPECT_EQ(is.get_type(), ISGENERAL);
 }
+
+TEST(IndexSetTest, identity)
+{
+    TestApp app;
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    EXPECT_FALSE(is.identity());
+    is.set_identity();
+    EXPECT_TRUE(is.identity());
+    is.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -231,3 +231,16 @@ TEST(IndexSetTest, copy)
     dest.destroy();
     src.destroy();
 }
+
+TEST(IndexSetTest, complement)
+{
+    TestApp app;
+    auto src = IndexSet::create_general(app.get_comm(), { 4, 5, 6 });
+    auto dest = src.complement(1, 10);
+    dest.get_indices();
+    auto vals = dest.to_std_vector();
+    EXPECT_THAT(vals, ElementsAre(1, 2, 3, 7, 8, 9));
+    dest.restore_indices();
+    dest.destroy();
+    src.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -274,3 +274,16 @@ TEST(IndexSetTest, difference)
     is1.destroy();
     is2.destroy();
 }
+
+TEST(IndexSetTest, equal)
+{
+    TestApp app;
+    auto is1 = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    auto is3 = IndexSet::create_general(app.get_comm(), { 4, 5, 1, 8, 10, 3 });
+    auto is2 = IndexSet::create_general(app.get_comm(), { 3, 5, 8 });
+    EXPECT_TRUE(is1.equal(is3));
+    EXPECT_FALSE(is1.equal(is2));
+    is1.destroy();
+    is2.destroy();
+    is3.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -315,3 +315,13 @@ TEST(IndexSetTest, expand)
     is1.destroy();
     dest.destroy();
 }
+
+TEST(IndexSetTest, get_min_max)
+{
+    TestApp app;
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    auto [min, max] = is.get_min_max();
+    EXPECT_EQ(min, 1);
+    EXPECT_EQ(max, 10);
+    is.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -371,3 +371,21 @@ TEST(IndexSetTest, set_type)
     EXPECT_EQ(is.get_type(), ISGENERAL);
     is.destroy();
 }
+
+TEST(IndexSetTest, sum)
+{
+    TestApp app;
+    if (app.get_comm().size() != 1)
+        return;
+
+    auto is1 = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    auto is2 = IndexSet::create_general(app.get_comm(), { 3, 5, 7, 9 });
+    auto dest = IndexSet::sum(is1, is2);
+    dest.get_indices();
+    auto vals = dest.to_std_vector();
+    EXPECT_THAT(vals, UnorderedElementsAre(1, 3, 4, 5, 7, 8, 9, 10));
+    dest.restore_indices();
+    dest.destroy();
+    is2.destroy();
+    is1.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -287,3 +287,16 @@ TEST(IndexSetTest, equal)
     is2.destroy();
     is3.destroy();
 }
+
+TEST(IndexSetTest, equal_unsorted)
+{
+    TestApp app;
+    auto is1 = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    auto dup = is1.duplicate();
+    auto is2 = IndexSet::create_general(app.get_comm(), { 4, 5, 1, 8, 10, 3 });
+    EXPECT_TRUE(is1.equal_unsorted(dup));
+    EXPECT_FALSE(is1.equal_unsorted(is2));
+    is1.destroy();
+    is2.destroy();
+    dup.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -342,3 +342,12 @@ TEST(IndexSetTest, identity)
     EXPECT_TRUE(is.identity());
     is.destroy();
 }
+
+TEST(IndexSetTest, locate)
+{
+    TestApp app;
+    auto is = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    EXPECT_EQ(is.locate(4), 2);
+    EXPECT_TRUE(is.locate(7) < 0);
+    is.destroy();
+}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -259,3 +259,18 @@ TEST(IndexSetTest, concatenate)
     is1.destroy();
     is2.destroy();
 }
+
+TEST(IndexSetTest, difference)
+{
+    TestApp app;
+    auto is1 = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    auto is2 = IndexSet::create_general(app.get_comm(), { 3, 5, 8 });
+    auto dest = IndexSet::difference(is1, is2);
+    dest.get_indices();
+    auto vals = dest.to_std_vector();
+    EXPECT_THAT(vals, ElementsAre(1, 4, 10));
+    dest.restore_indices();
+    dest.destroy();
+    is1.destroy();
+    is2.destroy();
+}


### PR DESCRIPTION
- Adding `IndexSet::complement`
- Adding `IndexSet::concatenate`
- Adding `IndexSet::difference`
- Adding `IndexSet::equal`
- Adding `IndexSet::equal_unsorted`
- Adding `IndexSet::expand`
- Adding `IndexSet::get_min_max`
- Adding `IndexSet::get_type`
- Adding `IndexSet::set_identity` and `IndexSet::identity`
- Adding `IndexSet::locate`
- Adding `IndexSet::set_permuation` and `IndexSet::permutation`
- Adding `IndexSet::set_type`
- Adding `IndexSet::sum`
