### PR TITLE
Adding assignment operator for `DynDenseMatrix`

### DIFF
--- a/test/src/DenseMatrix_test.cpp
+++ b/test/src/DenseMatrix_test.cpp
@@ -1104,3 +1104,20 @@ TEST(DynDenseMatrixTest, assign)
     EXPECT_DOUBLE_EQ(b(1, 1), 5.);
     EXPECT_DOUBLE_EQ(b(1, 2), 4.);
 }
+
+TEST(DynDenseMatrixTest, assign_into_empty)
+{
+    DynDenseMatrix<Real> m(2, 3);
+    m.set_row(0, { 1, 2, 3 });
+    m.set_row(1, { 6, 5, 4 });
+    DynDenseMatrix<Real> b;
+    b = m;
+    EXPECT_EQ(m.get_num_rows(), 2);
+    EXPECT_EQ(m.get_num_cols(), 3);
+    EXPECT_DOUBLE_EQ(b(0, 0), 1.);
+    EXPECT_DOUBLE_EQ(b(0, 1), 2.);
+    EXPECT_DOUBLE_EQ(b(0, 2), 3.);
+    EXPECT_DOUBLE_EQ(b(1, 0), 6.);
+    EXPECT_DOUBLE_EQ(b(1, 1), 5.);
+    EXPECT_DOUBLE_EQ(b(1, 2), 4.);
+}


### PR DESCRIPTION
It was not possible to assign a DynDenseMatrix into an empty one.
