### PR TITLE
DGProblemInterface: Components are stored next to each other per node

### DIFF
--- a/include/godzilla/DGProblemInterface.h
+++ b/include/godzilla/DGProblemInterface.h
@@ -75,19 +75,17 @@ public:
     ///
     /// @param elem Element ID
     /// @param local_node Local node index
-    /// @param comp Component
     /// @param fid Field ID
     /// @return Degree of freedom
-    [[nodiscard]] Int get_field_dof(Int elem, Int local_node, Int comp, Int fid) const;
+    [[nodiscard]] Int get_field_dof(Int elem, Int local_node, Int fid) const;
 
     /// Get auxiliary field degree of freedom
     ///
     /// @param elem Element ID
     /// @param local_node Local node index
-    /// @param comp Component
     /// @param fid Auxiliary field ID
     /// @return Degree of freedom
-    [[nodiscard]] Int get_aux_field_dof(Int elem, Int local_node, Int comp, Int fid) const;
+    [[nodiscard]] Int get_aux_field_dof(Int elem, Int local_node, Int fid) const;
 
 protected:
     [[nodiscard]] Int get_num_nodes_per_elem(Int c) const;

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -352,23 +352,25 @@ DGProblemInterface::get_num_nodes_per_elem(Int c) const
 }
 
 Int
-DGProblemInterface::get_field_dof(Int elem, Int local_node, Int comp, Int fid) const
+DGProblemInterface::get_field_dof(Int elem, Int local_node, Int fid) const
 {
     CALL_STACK_MSG();
     auto section = get_problem()->get_local_section();
     auto offset = section.get_field_offset(elem, fid);
     // FIXME: works only for order = 1
-    offset += (comp * get_num_nodes_per_elem(elem)) + local_node;
+    auto n_comps = get_field_num_components(fid);
+    offset += n_comps * local_node;
     return offset;
 }
 
 Int
-DGProblemInterface::get_aux_field_dof(Int elem, Int local_node, Int comp, Int fid) const
+DGProblemInterface::get_aux_field_dof(Int elem, Int local_node, Int fid) const
 {
     CALL_STACK_MSG();
     auto offset = get_local_section_aux().get_field_offset(elem, fid);
     // FIXME: works only for order = 1
-    offset += (comp * get_num_nodes_per_elem(elem)) + local_node;
+    auto n_comps = get_aux_field_num_components(fid);
+    offset += n_comps * local_node;
     return offset;
 }
 

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -697,12 +697,12 @@ ExodusIIOutput::write_nodal_variables_discontinuous()
             for (Int c = 0; c < nc; c++, exo_var_id++) {
                 for (Int lni = 0; lni < n_nodes_per_elem; lni++) {
                     Int exo_idx = (cid * n_nodes_per_elem + lni) + 1;
-                    Int offset = dgpi->get_field_dof(cid, lni, c, fid);
+                    Int offset = dgpi->get_field_dof(cid, lni, fid);
                     this->exo->write_partial_nodal_var(this->step_num,
                                                        exo_var_id,
                                                        1,
                                                        exo_idx,
-                                                       sln_vals[offset]);
+                                                       sln_vals[offset + c]);
                 }
             }
         }
@@ -712,12 +712,12 @@ ExodusIIOutput::write_nodal_variables_discontinuous()
                 for (Int c = 0; c < nc; c++, exo_var_id++) {
                     for (Int lni = 0; lni < n_nodes_per_elem; lni++) {
                         Int exo_idx = (cid * n_nodes_per_elem + lni) + 1;
-                        Int offset = dgpi->get_aux_field_dof(cid, lni, c, fid);
+                        Int offset = dgpi->get_aux_field_dof(cid, lni, fid);
                         this->exo->write_partial_nodal_var(this->step_num,
                                                            exo_var_id,
                                                            1,
                                                            exo_idx,
-                                                           aux_sln_vals[offset]);
+                                                           aux_sln_vals[offset + c]);
                     }
                 }
             }


### PR DESCRIPTION
- For given cell and local node, we assume that components are stored
  together.
- Removing component index from DGProblemInterface::get_field_dof
- Removing component index from DGProblemInterface::get_aux_field_dof
- This better matches the API for continuous Galerkin
- Modifying ExodusIIOutput to match the new API
