### PR TITLE
Allow iteration over empty `IndexSet`

### DIFF
--- a/include/godzilla/IndexSet.h
+++ b/include/godzilla/IndexSet.h
@@ -147,6 +147,8 @@ public:
 
     Int operator()(Int i) const;
 
+    operator bool() const;
+
     /// Convert indices from this index set into std::vector
     ///
     /// @return std::vector containing the indices

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -138,6 +138,18 @@ TEST(IndexSetTest, range)
     is.destroy();
 }
 
+TEST(IndexSetTest, range_over_null_set)
+{
+    TestApp app;
+    IndexSet is;
+    is.create(app.get_comm());
+    std::vector<Int> vals;
+    for (auto & i : is)
+        vals.push_back(i);
+    EXPECT_THAT(vals, ElementsAre());
+    is.destroy();
+}
+
 TEST(IndexSetTest, for_loop)
 {
     TestApp app;


### PR DESCRIPTION
Now, we can run a range-based for-loop over an empty `IndexSet` without
crashing. This is useful for cases where for example domain partitioning
produces an empty index set. Now, we do not have to check if the index set
is empty or not. We simply run an empty for loop. #quality-of-life
