### PR TITLE
Adding `Vector::set_values` using C-style parameter

### DIFF
--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -147,6 +147,17 @@ public:
 
     /// Inserts or adds values into certain locations of a vector
     ///
+    /// @param n Number of elements to insert
+    /// @param ix Indices where to add/insert
+    /// @param y Values
+    /// @param mode Insertion mode
+    void set_values(Int n,
+                    const Int * ix,
+                    const Scalar * y,
+                    InsertMode mode = INSERT_VALUES);
+
+    /// Inserts or adds values into certain locations of a vector
+    ///
     /// @param ix Indices where to add/insert
     /// @param y Values
     /// @param mode Insertion mode

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -310,6 +310,13 @@ Vector::set_value_local(Int row, Scalar value, InsertMode mode)
 }
 
 void
+Vector::set_values(Int n, const Int * ix, const Scalar * y, InsertMode mode)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecSetValues(this->vec, n, ix, y, mode));
+}
+
+void
 Vector::set_values(const std::vector<Int> & ix, const std::vector<Scalar> & y, InsertMode mode)
 {
     CALL_STACK_MSG();

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -96,6 +96,18 @@ TEST(VectorTest, set_value_local)
     v.destroy();
 }
 
+TEST(VectorTest, set_values_c)
+{
+    Vector v = Vector::create_seq(MPI_COMM_WORLD, 3);
+    Int ix[3] = { 0, 1, 2 };
+    Real vals[3] = { 3, 5, 9 };
+    v.set_values(3, ix, vals);
+    EXPECT_DOUBLE_EQ(v(0), 3.);
+    EXPECT_DOUBLE_EQ(v(1), 5.);
+    EXPECT_DOUBLE_EQ(v(2), 9.);
+    v.destroy();
+}
+
 TEST(VectorTest, set_values)
 {
     Vector v = Vector::create_seq(MPI_COMM_WORLD, 3);


### PR DESCRIPTION
To accomodate cases when values and indices come from PETSc
