### PR TITLE
Adding `Matrix::set_local_values` for C-style array

### DIFF
--- a/include/godzilla/Matrix.h
+++ b/include/godzilla/Matrix.h
@@ -49,6 +49,13 @@ public:
     void set_value(Int row, Int col, Scalar val, InsertMode mode = INSERT_VALUES);
     void set_value_local(Int row, Int col, Scalar val, InsertMode mode = INSERT_VALUES);
 
+    void set_values(Int n,
+                    const Int * row_idxs,
+                    Int m,
+                    const Int * col_idxs,
+                    const Scalar * vals,
+                    InsertMode mode = INSERT_VALUES);
+
     void set_values(const std::vector<Int> & row_idxs,
                     const std::vector<Int> & col_idxs,
                     const std::vector<Scalar> & vals,
@@ -64,6 +71,22 @@ public:
                     const DynDenseVector<Int> & col_idxs,
                     const DynDenseMatrix<Scalar> & vals,
                     InsertMode mode = INSERT_VALUES);
+
+    /// Inserts or adds values into certain locations of a matrix, using a local numbering of the
+    /// rows and columns.
+    ///
+    /// @param n Number of rows
+    /// @param row_idxs The row local indices
+    /// @param m Number of columns
+    /// @param col_idxs The column local indices
+    /// @param vals The values to insert (row-major format)
+    /// @param mode The insertion mode
+    void set_values_local(Int n,
+                          const Int * row_idxs,
+                          Int m,
+                          const Int * col_idxs,
+                          const Scalar * vals,
+                          InsertMode mode = INSERT_VALUES);
 
     /// Inserts or adds values into certain locations of a matrix, using a local numbering of the
     /// rows and columns.

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -135,6 +135,18 @@ Matrix::set_value_local(Int row, Int col, Scalar val, InsertMode mode)
 }
 
 void
+Matrix::set_values(Int n,
+                   const Int * row_idxs,
+                   Int m,
+                   const Int * col_idxs,
+                   const Scalar * vals,
+                   InsertMode mode)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(MatSetValues(this->mat, n, row_idxs, m, col_idxs, vals, mode));
+}
+
+void
 Matrix::set_values(const std::vector<Int> & row_idxs,
                    const std::vector<Int> & col_idxs,
                    const std::vector<Scalar> & vals,
@@ -164,6 +176,18 @@ Matrix::set_values(const DynDenseVector<Int> & row_idxs,
                              col_idxs.data(),
                              vals.data(),
                              mode));
+}
+
+void
+Matrix::set_values_local(Int n,
+                         const Int * row_idxs,
+                         Int m,
+                         const Int * col_idxs,
+                         const Scalar * vals,
+                         InsertMode mode)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(MatSetValuesLocal(this->mat, n, row_idxs, m, col_idxs, vals, mode));
 }
 
 void

--- a/test/src/Matrix_test.cpp
+++ b/test/src/Matrix_test.cpp
@@ -82,6 +82,21 @@ TEST(MatrixTest, set_value_local)
     m.destroy();
 }
 
+TEST(MatrixTest, set_values_c)
+{
+    Matrix m = Matrix::create_seq_aij(MPI_COMM_WORLD, 2, 2, 2);
+    Int rows[] = { 0, 1 };
+    Int cols[] = { 0, 1 };
+    Scalar vals[] = { 1, 2, 3, 4 };
+    m.set_values(2, rows, 2, cols, vals);
+    m.assemble();
+    EXPECT_DOUBLE_EQ(m(0, 0), 1.);
+    EXPECT_DOUBLE_EQ(m(0, 1), 2.);
+    EXPECT_DOUBLE_EQ(m(1, 0), 3.);
+    EXPECT_DOUBLE_EQ(m(1, 1), 4.);
+    m.destroy();
+}
+
 TEST(MatrixTest, set_values)
 {
     Matrix m = Matrix::create_seq_aij(MPI_COMM_WORLD, 2, 2, 2);
@@ -130,6 +145,21 @@ TEST(MatrixTest, set_values_dyn_dense)
     EXPECT_DOUBLE_EQ(m(0, 2), 2.);
     EXPECT_DOUBLE_EQ(m(1, 0), 3.);
     EXPECT_DOUBLE_EQ(m(1, 2), 4.);
+    m.destroy();
+}
+
+TEST(MatrixTest, set_values_local_c)
+{
+    Matrix m = Matrix::create_seq_aij(MPI_COMM_WORLD, 2, 2, 2);
+    Int rows[] = { 0, 1 };
+    Int cols[] = { 0, 1 };
+    Scalar vals[] = { 1, 2, 3, 4 };
+    m.set_values_local(2, rows, 2, cols, vals);
+    m.assemble();
+    EXPECT_DOUBLE_EQ(m(0, 0), 1.);
+    EXPECT_DOUBLE_EQ(m(0, 1), 2.);
+    EXPECT_DOUBLE_EQ(m(1, 0), 3.);
+    EXPECT_DOUBLE_EQ(m(1, 1), 4.);
     m.destroy();
 }
 


### PR DESCRIPTION
To accomodate case then values and indices come as C-style arrays (like
directly from PETSc)
