### PR TITLE
Updating cmake scripts to work with cmake 3.31+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if (GODZILLA_BUILD_TESTS)
     FetchContent_Declare(
         googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG v1.12.0
+        GIT_TAG v1.15.2
     )
     set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
     mark_as_advanced(FORCE

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -81,7 +81,10 @@ if(GODZILLA_CODE_COVERAGE)
                 ${CODE_COVERAGE_PROFRAWS}
         )
 
-        add_custom_target(htmlcov DEPENDS ${PROJECT_BINARY_DIR}/htmlcov/index.html)
+        add_custom_target(htmlcov
+            DEPENDS ${PROJECT_BINARY_DIR}/htmlcov/index.html
+            COMMENT "Open ${PROJECT_BINARY_DIR}/htmlcov/index.html in your browser to view the coverage report."
+        )
         add_custom_command(
             OUTPUT
                 ${PROJECT_BINARY_DIR}/htmlcov/index.html
@@ -96,14 +99,6 @@ if(GODZILLA_CODE_COVERAGE)
                 ${EXCLUDE_REGEX}
             DEPENDS
                 ${COVERAGE_INFO}
-        )
-
-        add_custom_command(
-            TARGET htmlcov
-            POST_BUILD
-            COMMAND ;
-            COMMENT
-                "Open ${PROJECT_BINARY_DIR}/htmlcov/index.html in your browser to view the coverage report."
         )
 
         function(target_code_coverage TARGET_NAME)
@@ -154,7 +149,10 @@ if(GODZILLA_CODE_COVERAGE)
                 ${EXCLUDE_REGEX}
         )
 
-        add_custom_target(htmlcov DEPENDS ${PROJECT_BINARY_DIR}/htmlcov/index.html)
+        add_custom_target(htmlcov
+            DEPENDS ${PROJECT_BINARY_DIR}/htmlcov/index.html
+            COMMENT "Open ${PROJECT_BINARY_DIR}/htmlcov/index.html in your browser to view the coverage report."
+        )
         add_custom_command(
             OUTPUT
                 ${PROJECT_BINARY_DIR}/htmlcov/index.html
@@ -164,14 +162,6 @@ if(GODZILLA_CODE_COVERAGE)
                 ${COVERAGE_INFO}
             DEPENDS
                 ${COVERAGE_INFO}
-        )
-
-        add_custom_command(
-            TARGET htmlcov
-            POST_BUILD
-            COMMAND ;
-            COMMENT
-                "Open ${PROJECT_BINARY_DIR}/htmlcov/index.html in your browser to view the coverage report."
         )
 
         function(target_code_coverage TARGET_NAME)

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -10,16 +10,8 @@ if(GODZILLA_CODE_COVERAGE)
     set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${COVERAGE_INFO}")
 
     if(CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang" OR CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
-        find_program(
-            LLVM_COV_PATH
-            NAMES
-                llvm-cov
-        )
-        find_program(
-            LLVM_PROFDATA_PATH
-            NAMES
-                llvm-profdata
-        )
+        find_program(LLVM_COV_PATH NAMES llvm-cov)
+        find_program(LLVM_PROFDATA_PATH NAMES llvm-profdata)
         mark_as_advanced(FORCE
             LLVM_COV_PATH
             LLVM_PROFDATA_PATH

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -3,14 +3,17 @@
 find_package(Doxygen QUIET)
 find_program(SPHINX_BUILD sphinx-build)
 
-if(DOXYGEN_FOUND AND NOT ${SPHINX_BUILD} STREQUAL SPHINX_BUILD-NOTFOUND)
+if (DOXYGEN_FOUND AND NOT ${SPHINX_BUILD} STREQUAL SPHINX_BUILD-NOTFOUND)
     find_program(SPHINX_BUILD sphinx-build)
     mark_as_advanced(FORCE SPHINX_BUILD)
 
     configure_file(Doxyfile.in Doxyfile)
     configure_file(conf.py.in conf.py)
 
-    add_custom_target(doc DEPENDS ${PROJECT_BINARY_DIR}/html/index.html)
+    add_custom_target(doc
+        DEPENDS ${PROJECT_BINARY_DIR}/html/index.html
+        COMMENT "Open ${PROJECT_BINARY_DIR}/docs/html/index.html in your browser to view the documentation."
+    )
 
     file(GLOB_RECURSE RST_FILES ${PROJECT_SOURCE_DIR}/docs/*.rst)
     file(GLOB_RECURSE HEADER_FILES ${PROJECT_SOURCE_DIR}/include/*.h)
@@ -35,23 +38,19 @@ if(DOXYGEN_FOUND AND NOT ${SPHINX_BUILD} STREQUAL SPHINX_BUILD-NOTFOUND)
             ${PROJECT_BINARY_DIR}/docs/Doxyfile
             ${HEADER_FILES}
     )
-
-    add_custom_command(
-        TARGET doc
-        POST_BUILD
-        COMMAND echo "Open ${PROJECT_BINARY_DIR}/docs/html/index.html in your browser to view the documentation."
-    )
-
 else()
     add_custom_target(doc)
 
     add_custom_command(
         TARGET doc
+        POST_BUILD
         COMMAND echo "Unable to generate documentation:"
     )
+
     if (NOT DOXYGEN_FOUND)
         add_custom_command(
             TARGET doc
+            POST_BUILD
             COMMAND echo "- 'doxygen' is not installed."
         )
     endif()
@@ -59,6 +58,7 @@ else()
     if (${SPHINX_BUILD} STREQUAL SPHINX_BUILD-NOTFOUND)
         add_custom_command(
             TARGET doc
+            POST_BUILD
             COMMAND echo "- 'sphinx-build' is not installed."
         )
     endif()


### PR DESCRIPTION
- maint: bump gtest version to 1.15.2
- maint: updating code coverage script for cmake 3.31+
- maint: reflow in cmake/CodeCoverage
- maint: update cmake doc generating script to work with 3.31+
