### PR TITLE
Removing polymoprhism from Problem::get_dimension

### DIFF
--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -59,7 +59,7 @@ public:
     virtual Mesh * get_mesh() const;
 
     /// Get problem spatial dimension
-    virtual Int get_dimension() const;
+    Int get_dimension() const;
 
     /// Get simulation time. For steady-state simulations, time is always 0
     ///


### PR DESCRIPTION
This is just a convenience API that forwards the call to underlying mesh.
