### PR TITLE
Removing `Problem::get_mesh`

### DIFF
--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -26,6 +26,7 @@ class BoundaryCondition;
 class AuxiliaryField;
 class EssentialBC;
 class NaturalBC;
+class MeshObject;
 
 /// Interface for discrete problems
 ///
@@ -62,7 +63,7 @@ public:
     virtual ~DiscreteProblemInterface();
 
     /// Get unstructured mesh associated with this problem
-    UnstructuredMesh * get_unstr_mesh() const;
+    UnstructuredMesh * get_mesh() const;
 
     /// Get problem
     ///
@@ -447,6 +448,9 @@ private:
 
     /// Problem this interface is part of
     Problem * problem;
+
+    /// Mesh object
+    MeshObject * mesh_obj;
 
     /// Unstructured mesh
     UnstructuredMesh * unstr_mesh;

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -55,9 +55,6 @@ public:
     const Vector & get_solution_vector() const;
     Vector & get_solution_vector();
 
-    /// Get mesh this problem is using
-    virtual Mesh * get_mesh() const;
-
     /// Get problem spatial dimension
     Int get_dimension() const;
 

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -60,7 +60,7 @@ void
 AuxiliaryField::create()
 {
     CALL_STACK_MSG();
-    this->mesh = this->dpi->get_unstr_mesh();
+    this->mesh = this->dpi->get_mesh();
     if (!this->region.empty()) {
         if (this->mesh->has_label(this->region)) {
             this->label = this->mesh->get_label(this->region);

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -42,7 +42,7 @@ DGProblemInterface::init()
         create_fe(it.second);
     DiscreteProblemInterface::init();
 
-    auto dm = get_unstr_mesh()->get_dm();
+    auto dm = get_mesh()->get_dm();
     DM cdm = dm;
     while (cdm) {
         set_up_auxiliary_dm(cdm);
@@ -362,7 +362,7 @@ DGProblemInterface::set_aux_field(Int id,
 Int
 DGProblemInterface::get_num_nodes_per_elem(Int c) const
 {
-    auto unstr_mesh = get_unstr_mesh();
+    auto unstr_mesh = get_mesh();
     auto ct = unstr_mesh->get_cell_type(c);
     auto n_nodes = UnstructuredMesh::get_num_cell_nodes(ct);
     return n_nodes;
@@ -397,7 +397,7 @@ DGProblemInterface::create()
     CALL_STACK_MSG();
     set_up_fields();
     DiscreteProblemInterface::create();
-    get_unstr_mesh()->localize_coordinates();
+    get_mesh()->localize_coordinates();
 }
 
 void
@@ -405,7 +405,7 @@ DGProblemInterface::set_up_ds()
 {
     CALL_STACK_MSG();
     create_section();
-    PETSC_CHECK(DMSetAdjacency(get_unstr_mesh()->get_dm(), 0, PETSC_TRUE, PETSC_FALSE));
+    PETSC_CHECK(DMSetAdjacency(get_mesh()->get_dm(), 0, PETSC_TRUE, PETSC_FALSE));
 }
 
 void
@@ -413,7 +413,7 @@ DGProblemInterface::create_section()
 {
     CALL_STACK_MSG();
     auto comm = get_problem()->get_comm();
-    auto unstr_mesh = get_unstr_mesh();
+    auto unstr_mesh = get_mesh();
     auto dm = unstr_mesh->get_dm();
     PETSC_CHECK(DMSetNumFields(dm, 1));
     Section section;
@@ -446,7 +446,7 @@ void
 DGProblemInterface::set_up_section_constraint_dofs(Section & section)
 {
     CALL_STACK_MSG();
-    auto unstr_mesh = get_unstr_mesh();
+    auto unstr_mesh = get_mesh();
 
     auto depth_label = unstr_mesh->get_depth_label();
     auto dim = unstr_mesh->get_dimension();
@@ -481,7 +481,7 @@ void
 DGProblemInterface::set_up_section_constraint_indicies(Section & section)
 {
     CALL_STACK_MSG();
-    auto unstr_mesh = get_unstr_mesh();
+    auto unstr_mesh = get_mesh();
 
     auto depth_label = unstr_mesh->get_depth_label();
     Int dim = unstr_mesh->get_dimension();
@@ -538,7 +538,7 @@ DGProblemInterface::create_aux_fields()
         section_aux.set_num_field_components(fi.id, fi.nc);
     }
 
-    auto unstr_mesh = get_unstr_mesh();
+    auto unstr_mesh = get_mesh();
     auto cell_range = unstr_mesh->get_cell_range();
     section_aux.set_chart(cell_range.first(), cell_range.last());
     for (Int c = cell_range.first(); c < cell_range.last(); c++) {
@@ -573,9 +573,9 @@ void
 DGProblemInterface::create_fe(FieldInfo & fi)
 {
     CALL_STACK_MSG();
-    auto comm = get_unstr_mesh()->get_comm();
+    auto comm = get_mesh()->get_comm();
     Int dim = get_problem()->get_dimension();
-    PetscBool is_simplex = get_unstr_mesh()->is_simplex() ? PETSC_TRUE : PETSC_FALSE;
+    PetscBool is_simplex = get_mesh()->is_simplex() ? PETSC_TRUE : PETSC_FALSE;
     PETSC_CHECK(PetscFECreateLagrange(comm, dim, fi.nc, is_simplex, fi.k, this->qorder, &fi.fe));
 }
 

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -12,6 +12,7 @@
 #include "godzilla/Postprocessor.h"
 #include "godzilla/IndexSet.h"
 #include "godzilla/Exception.h"
+#include "godzilla/MeshObject.h"
 #include "exodusIIcpp/exodusIIcpp.h"
 #include "fmt/format.h"
 #include "fmt/chrono.h"
@@ -143,8 +144,8 @@ ExodusIIOutput::create()
     CALL_STACK_MSG();
     FileOutput::create();
 
-    this->mesh = get_problem() ? dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh())
-                               : get_param<UnstructuredMesh *>("_mesh");
+    this->mesh = this->dpi ? this->dpi->get_mesh()
+                           : get_param<MeshObject *>("_mesh_obj")->get_mesh<UnstructuredMesh>();
     if (this->mesh == nullptr)
         log_error("ExodusII output can be only used with unstructured meshes.");
 

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -193,7 +193,7 @@ ExplicitFELinearProblem::compute_rhs_function_fem(Real time, const Vector & loc_
 {
     // this is based on DMPlexTSComputeRHSFunctionFEM()
     CALL_STACK_MSG();
-    IndexSet all_cells = get_unstr_mesh()->get_all_cells();
+    auto all_cells = get_mesh()->get_all_cells();
 
     for (auto region : get_weak_form()->get_residual_regions()) {
         IndexSet cells;

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -123,7 +123,7 @@ FENonlinearProblem::compute_residual_local(const Vector & x, Vector & f)
 {
     CALL_STACK_MSG();
     // this is based on DMSNESComputeResidual()
-    IndexSet all_cells = get_unstr_mesh()->get_all_cells();
+    auto all_cells = get_mesh()->get_all_cells();
 
     for (auto & region : get_weak_form()->get_residual_regions()) {
         IndexSet cells;
@@ -374,8 +374,8 @@ FENonlinearProblem::compute_bnd_residual_internal(DM dm, Vec loc_x, Vec loc_x_t,
 
     PetscDS prob;
     PETSC_CHECK(DMGetDS(dm, &prob));
-    auto depth_label = get_unstr_mesh()->get_depth_label();
-    Int dim = get_unstr_mesh()->get_dimension();
+    auto depth_label = get_mesh()->get_depth_label();
+    Int dim = get_dimension();
     auto facets = depth_label.get_stratum(dim - 1);
     Int n_bnd;
     PETSC_CHECK(PetscDSGetNumBoundary(prob, &n_bnd));
@@ -580,7 +580,7 @@ FENonlinearProblem::compute_jacobian_local(const Vector & x, Matrix & J, Matrix 
 {
     CALL_STACK_MSG();
     // based on DMPlexSNESComputeJacobianFEM and DMSNESComputeJacobianAction
-    IndexSet all_cells = get_unstr_mesh()->get_all_cells();
+    auto all_cells = get_mesh()->get_all_cells();
 
     auto wf = get_weak_form();
     auto has_jac = wf->has_jacobian();
@@ -879,8 +879,8 @@ FENonlinearProblem::compute_bnd_jacobian_internal(DM dm,
     CALL_STACK_MSG();
     PetscDS prob;
     PETSC_CHECK(DMGetDS(dm, &prob));
-    auto depth_label = get_unstr_mesh()->get_depth_label();
-    Int dim = get_unstr_mesh()->get_dimension();
+    auto depth_label = get_mesh()->get_depth_label();
+    Int dim = get_dimension();
     auto facets = depth_label.get_stratum(dim - 1);
     Int n_bnd;
     PETSC_CHECK(PetscDSGetNumBoundary(prob, &n_bnd));

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -89,7 +89,7 @@ FEProblemInterface::create()
     this->asmbl = new AssemblyData(dim);
     set_up_fields();
     DiscreteProblemInterface::create();
-    get_unstr_mesh()->localize_coordinates();
+    get_mesh()->localize_coordinates();
 }
 
 void
@@ -105,7 +105,7 @@ FEProblemInterface::init()
 
     DiscreteProblemInterface::init();
 
-    auto dm = get_unstr_mesh()->get_dm();
+    auto dm = get_mesh()->get_dm();
     DM cdm = dm;
     while (cdm) {
         set_up_auxiliary_dm(cdm);
@@ -447,9 +447,9 @@ void
 FEProblemInterface::create_fe(FieldInfo & fi)
 {
     CALL_STACK_MSG();
-    auto comm = get_unstr_mesh()->get_comm();
+    auto comm = get_mesh()->get_comm();
     Int dim = get_problem()->get_dimension();
-    PetscBool is_simplex = get_unstr_mesh()->is_simplex() ? PETSC_TRUE : PETSC_FALSE;
+    PetscBool is_simplex = get_mesh()->is_simplex() ? PETSC_TRUE : PETSC_FALSE;
     PETSC_CHECK(PetscFECreateLagrange(comm, dim, fi.nc, is_simplex, fi.k, this->qorder, &fi.fe));
 }
 
@@ -457,7 +457,7 @@ void
 FEProblemInterface::set_up_ds()
 {
     CALL_STACK_MSG();
-    auto dm = get_unstr_mesh()->get_dm();
+    auto dm = get_mesh()->get_dm();
     for (auto & it : this->fields) {
         FieldInfo & fi = it.second;
         PETSC_CHECK(DMSetField(dm, fi.id, fi.block, (PetscObject) fi.fe));
@@ -717,7 +717,7 @@ FEProblemInterface::add_residual_block(Int field_id,
         add_weak_form_residual_block(WeakForm::F1, field_id, f1);
     }
     else {
-        auto label = get_unstr_mesh()->get_label(region);
+        auto label = get_mesh()->get_label(region);
         auto ids = label.get_values();
         for (auto & val : ids) {
             add_weak_form_residual_block(WeakForm::F0, field_id, f0, label, val, 0);
@@ -735,7 +735,7 @@ FEProblemInterface::add_boundary_residual_block(Int field_id,
     CALL_STACK_MSG();
     assert(!boundary.empty());
 
-    auto label = get_unstr_mesh()->get_label(boundary);
+    auto label = get_mesh()->get_label(boundary);
     auto ids = label.get_values();
     for (auto & val : ids) {
         add_weak_form_residual_block(WeakForm::BND_F0, field_id, f0, label, val, 0);
@@ -760,7 +760,7 @@ FEProblemInterface::add_jacobian_block(Int fid,
         add_weak_form_jacobian_block(WeakForm::G3, fid, gid, g3);
     }
     else {
-        auto label = get_unstr_mesh()->get_label(region);
+        auto label = get_mesh()->get_label(region);
         auto ids = label.get_values();
         for (auto & val : ids) {
             add_weak_form_jacobian_block(WeakForm::G0, fid, gid, g0, label, val, 0);
@@ -788,7 +788,7 @@ FEProblemInterface::add_jacobian_preconditioner_block(Int fid,
         add_weak_form_jacobian_block(WeakForm::GP3, fid, gid, g3);
     }
     else {
-        auto label = get_unstr_mesh()->get_label(region);
+        auto label = get_mesh()->get_label(region);
         auto ids = label.get_values();
         for (auto & val : ids) {
             add_weak_form_jacobian_block(WeakForm::GP0, fid, gid, g0, label, val, 0);
@@ -811,7 +811,7 @@ FEProblemInterface::add_boundary_jacobian_block(Int fid,
     CALL_STACK_MSG();
     assert(!region.empty());
 
-    auto label = get_unstr_mesh()->get_label(region);
+    auto label = get_mesh()->get_label(region);
     auto ids = label.get_values();
     for (auto & val : ids) {
         add_weak_form_jacobian_block(WeakForm::BND_G0, fid, gid, g0, label, val, 0);

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -156,7 +156,7 @@ ImplicitFENonlinearProblem::compute_ifunction_fem(Real time,
 {
     // this is based on DMSNESComputeResidual() and DMPlexTSComputeIFunctionFEM()
     CALL_STACK_MSG();
-    IndexSet all_cells = get_unstr_mesh()->get_all_cells();
+    auto all_cells = get_mesh()->get_all_cells();
 
     for (auto & region : get_weak_form()->get_residual_regions()) {
         IndexSet cells;
@@ -185,7 +185,7 @@ ImplicitFENonlinearProblem::compute_ijacobian_fem(Real time,
     // this is based on DMPlexSNESComputeJacobianFEM(), DMSNESComputeJacobianAction() and
     // DMPlexTSComputeIJacobianFEM()
     CALL_STACK_MSG();
-    IndexSet all_cells = get_unstr_mesh()->get_all_cells();
+    auto all_cells = get_mesh()->get_all_cells();
 
     Jp.zero();
 

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -181,6 +181,7 @@ InputFile::build_outputs()
         Block blk = get_block(output_block, it.first.as<std::string>());
         Parameters * params = build_params(blk);
         params->set<Problem *>("_problem") = this->problem;
+        params->set<MeshObject *>("_mesh_obj") = this->mesh_obj;
         auto output = this->app->build_object<Output>(blk.name(), params);
         assert(this->problem != nullptr);
         this->problem->add_output(output);

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -58,7 +58,10 @@ DM
 Problem::get_dm() const
 {
     CALL_STACK_MSG();
-    return get_mesh()->get_dm();
+    assert(this->mesh != nullptr);
+    auto m = this->mesh->get_mesh<Mesh>();
+    assert(m != nullptr);
+    return m->get_dm();
 }
 
 const Vector &
@@ -117,18 +120,13 @@ Problem::allocate_objects()
     set_solution_vector(create_global_vector());
 }
 
-Mesh *
-Problem::get_mesh() const
-{
-    CALL_STACK_MSG();
-    return this->mesh->get_mesh<Mesh>();
-}
-
 Int
 Problem::get_dimension() const
 {
     CALL_STACK_MSG();
-    return get_mesh()->get_dimension();
+    Int dim;
+    PETSC_CHECK(DMGetDimension(get_dm(), &dim));
+    return dim;
 }
 
 Real

--- a/src/TecplotOutput.cpp
+++ b/src/TecplotOutput.cpp
@@ -82,7 +82,7 @@ TecplotOutput::TecplotOutput(const Parameters & params) :
     FileOutput(params),
     format(BINARY),
     dpi(dynamic_cast<DiscreteProblemInterface *>(get_problem())),
-    mesh(get_problem() ? dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh()) : nullptr),
+    mesh(dpi ? dpi->get_mesh() : nullptr),
     variable_names(get_param<std::vector<std::string>>("variables")),
     file(nullptr),
     header_written(false),

--- a/src/VTKOutput.cpp
+++ b/src/VTKOutput.cpp
@@ -6,6 +6,8 @@
 #include "godzilla/VTKOutput.h"
 #include "godzilla/UnstructuredMesh.h"
 #include "godzilla/Problem.h"
+#include "godzilla/DiscreteProblemInterface.h"
+#include "godzilla/MeshObject.h"
 
 namespace godzilla {
 
@@ -13,6 +15,7 @@ Parameters
 VTKOutput::parameters()
 {
     Parameters params = FileOutput::parameters();
+    params.add_private_param<MeshObject *>("_mesh_obj", nullptr);
     return params;
 }
 
@@ -38,7 +41,9 @@ void
 VTKOutput::create()
 {
     CALL_STACK_MSG();
-    const auto * mesh = dynamic_cast<UnstructuredMesh *>(get_problem()->get_mesh());
+    auto dpi = dynamic_cast<DiscreteProblemInterface *>(get_problem());
+    auto mesh =
+        dpi ? dpi->get_mesh() : get_param<MeshObject *>("_mesh_obj")->get_mesh<UnstructuredMesh>();
     if (mesh == nullptr)
         log_error("VTK output works only with unstructured meshes.");
 

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -143,6 +143,7 @@ TEST(ExodusIIOutputTest, fe_check)
     Parameters params = ExodusIIOutput::parameters();
     params.set<App *>("_app") = &app;
     params.set<Problem *>("_problem") = &prob;
+    params.set<MeshObject *>("_mesh_obj") = &mesh;
     ExodusIIOutput out(params);
     prob.add_output(&out);
 

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -57,6 +57,7 @@ TEST(VTKOutputTest, wrong_mesh_type)
     Parameters pars = VTKOutput::parameters();
     pars.set<App *>("_app") = &app;
     pars.set<Problem *>("_problem") = &prob;
+    pars.set<MeshObject *>("_mesh_obj") = &mesh;
     VTKOutput out(pars);
     prob.add_output(&out);
 
@@ -87,6 +88,7 @@ TEST(VTKOutputTest, test)
     Parameters pars = VTKOutput::parameters();
     pars.set<App *>("_app") = &app;
     pars.set<Problem *>("_problem") = &prob;
+    pars.set<MeshObject *>("_mesh_obj") = &mesh;
     VTKOutput out(pars);
 
     prob.add_output(&out);


### PR DESCRIPTION
- this API was removed in favor of `DiscreteProblemInterface::get_mesh` which
  is used more often in the child classes and gives back the UnstructiredMesh,
  which is what the application code uses.
- VTKOutput and TecplotOutput were updated so they match what is going on in
  the ExodusIIOutput.
