### PR TITLE
Removing `lprintf`

### DIFF
--- a/include/godzilla/PrintInterface.h
+++ b/include/godzilla/PrintInterface.h
@@ -53,13 +53,6 @@ public:
                    const unsigned int & verbosity_level,
                    std::string prefix);
 
-    template <typename... T>
-    [[deprecated("Use lprint() instead")]] void
-    lprintf(unsigned int level, fmt::format_string<T...> format, T... args) const
-    {
-        lprint(level, format, std::forward<T>(args)...);
-    }
-
     /// Print a message on a terminal
     ///
     /// @param level Verbosity level. If application verbose level is higher than this number, the

--- a/test/src/PrintInterface_test.cpp
+++ b/test/src/PrintInterface_test.cpp
@@ -18,7 +18,7 @@ TEST(PrintInterfaceTest, error)
     EXPECT_DEATH(app.test(), "\\[ERROR\\] Error");
 }
 
-TEST(PrintInterfaceTest, lprintf)
+TEST(PrintInterfaceTest, lprint)
 {
     testing::internal::CaptureStdout();
 


### PR DESCRIPTION
It has been derecated for some time. It is time to say buh-bye.
