### PR TITLE
Refactoring Registry usage with App class

### DIFF
--- a/examples/advect-eqn/src/main.cpp
+++ b/examples/advect-eqn/src/main.cpp
@@ -5,6 +5,8 @@
 #include "InflowBC.h"
 #include "OutflowBC.h"
 
+godzilla::Registry registry;
+
 void
 registerObjects(godzilla::Registry & r)
 {
@@ -20,9 +22,9 @@ main(int argc, char * argv[])
     try {
         godzilla::mpi::Communicator comm(MPI_COMM_WORLD);
         godzilla::Init init(argc, argv);
-        registerObjects(godzilla::App::get_registry());
+        registerObjects(registry);
 
-        godzilla::App app(comm, "advect-eqn", argc, argv);
+        godzilla::App app(comm, registry, "advect-eqn", argc, argv);
         app.run();
 
         return 0;

--- a/examples/burgers-eqn/src/main.cpp
+++ b/examples/burgers-eqn/src/main.cpp
@@ -2,6 +2,8 @@
 #include "godzilla/Init.h"
 #include "BurgersEquation.h"
 
+godzilla::Registry registry;
+
 void
 registerObjects(godzilla::Registry & r)
 {
@@ -15,9 +17,9 @@ main(int argc, char * argv[])
     try {
         godzilla::mpi::Communicator comm;
         godzilla::Init init(argc, argv);
-        registerObjects(godzilla::App::get_registry());
+        registerObjects(registry);
 
-        godzilla::App app(comm, "burgers-eqn", argc, argv);
+        godzilla::App app(comm, registry, "burgers-eqn", argc, argv);
         app.run();
 
         return 0;

--- a/examples/heat-eqn/src/main.cpp
+++ b/examples/heat-eqn/src/main.cpp
@@ -4,6 +4,8 @@
 #include "HeatEquationExplicit.h"
 #include "HeatEquationProblem.h"
 
+godzilla::Registry registry;
+
 void
 registerObjects(godzilla::Registry & r)
 {
@@ -19,9 +21,9 @@ main(int argc, char * argv[])
     try {
         godzilla::mpi::Communicator comm(MPI_COMM_WORLD);
         godzilla::Init init(argc, argv);
-        registerObjects(godzilla::App::get_registry());
+        registerObjects(registry);
 
-        godzilla::App app(comm, "heat-eqn", argc, argv);
+        godzilla::App app(comm, registry, "heat-eqn", argc, argv);
         app.run();
 
         return 0;

--- a/examples/ns-incomp/src/main.cpp
+++ b/examples/ns-incomp/src/main.cpp
@@ -2,6 +2,8 @@
 #include "godzilla/Init.h"
 #include "NSIncompressibleProblem.h"
 
+godzilla::Registry registry;
+
 void
 registerObjects(godzilla::Registry & r)
 {
@@ -15,9 +17,9 @@ main(int argc, char * argv[])
     try {
         godzilla::mpi::Communicator comm(MPI_COMM_WORLD);
         godzilla::Init init(argc, argv);
-        registerObjects(godzilla::App::get_registry());
+        registerObjects(registry);
 
-        godzilla::App app(comm, "ns-incomp", argc, argv);
+        godzilla::App app(comm, registry, "ns-incomp", argc, argv);
         app.run();
 
         return 0;

--- a/examples/poisson/src/main.cpp
+++ b/examples/poisson/src/main.cpp
@@ -2,6 +2,8 @@
 #include "godzilla/Init.h"
 #include "PoissonEquation.h"
 
+godzilla::Registry registry;
+
 void
 registerObjects(godzilla::Registry & r)
 {
@@ -15,9 +17,9 @@ main(int argc, char * argv[])
     try {
         godzilla::mpi::Communicator comm(MPI_COMM_WORLD);
         godzilla::Init init(argc, argv);
-        registerObjects(godzilla::App::get_registry());
+        registerObjects(registry);
 
-        godzilla::App app(comm, "poisson", argc, argv);
+        godzilla::App app(comm, registry, "poisson", argc, argv);
         app.run();
 
         return 0;

--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -47,7 +47,7 @@ public:
     /// @param argc Number of command line arguments
     /// @param argv Command line arguments
     App(const mpi::Communicator & comm,
-        const Registry & registry,
+        Registry & registry,
         const std::string & name,
         int argc,
         const char * const * argv);
@@ -59,7 +59,7 @@ public:
     /// @param name Name of the application
     /// @param args Command line arguments (without the executable name as first argument)
     App(const mpi::Communicator & comm,
-        const Registry & registry,
+        Registry & registry,
         const std::string & name,
         const std::vector<std::string> & args);
 
@@ -79,6 +79,11 @@ public:
     ///
     /// @return The application version as a string
     virtual const std::string & get_version() const;
+
+    /// Get the instance of registry
+    ///
+    /// @return Instance of the Registry class
+    Registry & get_registry();
 
     /// Get the factory for building objects
     ///
@@ -204,6 +209,9 @@ private:
     /// MPI communicator
     mpi::Communicator mpi_comm;
 
+    /// Registry
+    Registry & registry;
+
     /// Log with errors and/or warnings
     Logger * logger;
 
@@ -229,15 +237,7 @@ private:
     Factory factory;
 
 public:
-    /// Get the instance of registry
-    ///
-    /// @return Instance of the Registry class
-    static Registry & get_registry();
-
     static void registerObjects(Registry & registry);
-
-private:
-    static Registry registry;
 };
 
 template <typename T>

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -16,7 +16,7 @@
 
 namespace godzilla {
 
-Registry App::registry;
+Registry registry;
 
 App::App(const mpi::Communicator & comm,
          const std::string & name,
@@ -25,43 +25,7 @@ App::App(const mpi::Communicator & comm,
     PrintInterface(comm, this->verbosity_level, name),
     name(name),
     mpi_comm(comm),
-    logger(new Logger()),
-    cmdln_opts(name),
-    verbosity_level(1),
-    yml(nullptr),
-    problem(nullptr),
-    factory(App::get_registry())
-{
-    CALL_STACK_MSG();
-    this->args.resize(argc);
-    for (int i = 0; i < argc; ++i)
-        this->args.emplace_back(argv[i]);
-}
-
-App::App(const mpi::Communicator & comm,
-         const std::string & name,
-         const std::vector<std::string> & args) :
-    PrintInterface(comm, this->verbosity_level, name),
-    name(name),
-    mpi_comm(comm),
-    logger(new Logger()),
-    args(args),
-    cmdln_opts(name),
-    verbosity_level(1),
-    yml(nullptr),
-    problem(nullptr),
-    factory(App::get_registry())
-{
-}
-
-App::App(const mpi::Communicator & comm,
-         const Registry & registry,
-         const std::string & name,
-         int argc,
-         const char * const * argv) :
-    PrintInterface(comm, this->verbosity_level, name),
-    name(name),
-    mpi_comm(comm),
+    registry(godzilla::registry),
     logger(new Logger()),
     cmdln_opts(name),
     verbosity_level(1),
@@ -76,12 +40,52 @@ App::App(const mpi::Communicator & comm,
 }
 
 App::App(const mpi::Communicator & comm,
-         const Registry & registry,
          const std::string & name,
          const std::vector<std::string> & args) :
     PrintInterface(comm, this->verbosity_level, name),
     name(name),
     mpi_comm(comm),
+    registry(godzilla::registry),
+    logger(new Logger()),
+    args(args),
+    cmdln_opts(name),
+    verbosity_level(1),
+    yml(nullptr),
+    problem(nullptr),
+    factory(registry)
+{
+}
+
+App::App(const mpi::Communicator & comm,
+         Registry & registry,
+         const std::string & name,
+         int argc,
+         const char * const * argv) :
+    PrintInterface(comm, this->verbosity_level, name),
+    name(name),
+    mpi_comm(comm),
+    registry(registry),
+    logger(new Logger()),
+    cmdln_opts(name),
+    verbosity_level(1),
+    yml(nullptr),
+    problem(nullptr),
+    factory(registry)
+{
+    CALL_STACK_MSG();
+    this->args.resize(argc);
+    for (int i = 0; i < argc; ++i)
+        this->args.emplace_back(argv[i]);
+}
+
+App::App(const mpi::Communicator & comm,
+         Registry & registry,
+         const std::string & name,
+         const std::vector<std::string> & args) :
+    PrintInterface(comm, this->verbosity_level, name),
+    name(name),
+    mpi_comm(comm),
+    registry(registry),
     logger(new Logger()),
     args(args),
     cmdln_opts(name),
@@ -339,7 +343,7 @@ App::run_problem()
 Registry &
 App::get_registry()
 {
-    return registry;
+    return this->registry;
 }
 
 } // namespace godzilla

--- a/test/src/FENonlinearProblem_test.h
+++ b/test/src/FENonlinearProblem_test.h
@@ -15,7 +15,7 @@ public:
     SetUp() override
     {
         GodzillaAppTest::SetUp();
-        App::get_registry().add<GTestFENonlinearProblem>("GTestFENonlinearProblem");
+        this->app->get_registry().add<GTestFENonlinearProblem>("GTestFENonlinearProblem");
 
         {
             Parameters * params = this->app->get_parameters("LineMesh");
@@ -46,7 +46,8 @@ public:
     SetUp() override
     {
         GodzillaAppTest::SetUp();
-        App::get_registry().add<GTest2FieldsFENonlinearProblem>("GTest2FieldsFENonlinearProblem");
+        this->app->get_registry().add<GTest2FieldsFENonlinearProblem>(
+            "GTest2FieldsFENonlinearProblem");
 
         {
             Parameters * params = this->app->get_parameters("LineMesh");

--- a/test/src/TestApp.cpp
+++ b/test/src/TestApp.cpp
@@ -1,0 +1,9 @@
+#include "TestApp.h"
+#include "godzilla/Registry.h"
+
+Registry registry;
+
+TestApp::TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), ::registry, "godzilla", {})
+{
+    App::registerObjects(::registry);
+}

--- a/test/src/TestApp.h
+++ b/test/src/TestApp.h
@@ -6,8 +6,5 @@ using namespace godzilla;
 
 class TestApp : public App {
 public:
-    TestApp() : App(mpi::Communicator(MPI_COMM_WORLD), "godzilla", {})
-    {
-        App::registerObjects(get_registry());
-    }
+    TestApp();
 };


### PR DESCRIPTION
If an application will be using new classes, etc., then Registry will
reside there and passed into godzilla::App. For testing, and other corner
cases, we can pull the Registry out of the App class and use it directly.
