### PR TITLE
Adding non-const version of `operator bool`

### DIFF
--- a/include/godzilla/Delegate.h
+++ b/include/godzilla/Delegate.h
@@ -61,6 +61,7 @@ public:
 
     /// Check whether delegates is callable
     operator bool() const { return static_cast<bool>(this->fn); }
+    operator bool() { return static_cast<bool>(this->fn); }
 
 private:
     std::function<R(ARGS...)> fn;

--- a/include/godzilla/HashMap.h
+++ b/include/godzilla/HashMap.h
@@ -101,6 +101,7 @@ public:
     HashEqual(Int a, Int b) { this->equal = (a == b); }
 
     operator bool() const { return this->equal; }
+    operator bool() { return this->equal; }
 
 private:
     bool equal;

--- a/include/godzilla/Label.h
+++ b/include/godzilla/Label.h
@@ -101,6 +101,7 @@ public:
 
     /// Typecast operator to determine if label is null or not
     operator bool() const;
+    operator bool();
 
 private:
     DMLabel label;

--- a/include/godzilla/Section.h
+++ b/include/godzilla/Section.h
@@ -280,6 +280,7 @@ public:
     operator PetscSection &() { return this->section; }
 
     operator bool() const { return this->section != nullptr; }
+    operator bool() { return this->section != nullptr; }
 
     static Section create(DM dm,
                           const Int n_comp[],

--- a/include/godzilla/StarForest.h
+++ b/include/godzilla/StarForest.h
@@ -48,6 +48,7 @@ public:
 
         /// Test if graph is empty
         operator bool() const;
+        operator bool();
 
     private:
         Int n_roots, n_leaves;

--- a/src/Label.cpp
+++ b/src/Label.cpp
@@ -161,4 +161,10 @@ Label::operator bool() const
     return !is_null();
 }
 
+Label::operator bool()
+{
+    CALL_STACK_MSG();
+    return !is_null();
+}
+
 } // namespace godzilla

--- a/src/StarForest.cpp
+++ b/src/StarForest.cpp
@@ -78,6 +78,11 @@ StarForest::Graph::operator bool() const
     return this->leaves != nullptr;
 }
 
+StarForest::Graph::operator bool()
+{
+    return this->leaves != nullptr;
+}
+
 // ---
 
 StarForest::StarForest() : sf(nullptr) {}

--- a/test/src/IndexSet_test.cpp
+++ b/test/src/IndexSet_test.cpp
@@ -401,3 +401,24 @@ TEST(IndexSetTest, sum)
     is2.destroy();
     is1.destroy();
 }
+
+TEST(IndexSetTest, oper_bool)
+{
+    TestApp app;
+    if (app.get_comm().size() != 1)
+        return;
+
+    IndexSet empty;
+    const auto & cempty = empty;
+    EXPECT_FALSE(empty);
+    EXPECT_FALSE(cempty);
+
+    auto is1 = IndexSet::create_general(app.get_comm(), { 1, 3, 4, 5, 8, 10 });
+    const auto cis1 = &is1;
+    EXPECT_TRUE(is1);
+    EXPECT_TRUE(cis1);
+
+    is1.destroy();
+    EXPECT_FALSE(empty);
+    EXPECT_FALSE(cempty);
+}

--- a/test/src/Label_test.cpp
+++ b/test/src/Label_test.cpp
@@ -152,3 +152,22 @@ TEST(Label, view)
     EXPECT_THAT(output, testing::HasSubstr("[0]: 4 (102)"));
     EXPECT_THAT(output, testing::HasSubstr("[0]: 7 (103)"));
 }
+
+TEST(Label, oper_bool)
+{
+    TestApp app;
+
+    Label lbl;
+    const auto & clbl = lbl;
+
+    EXPECT_FALSE(lbl);
+    EXPECT_FALSE(clbl);
+
+    lbl.create(app.get_comm(), "name");
+    EXPECT_TRUE(lbl);
+    EXPECT_TRUE(clbl);
+
+    lbl.destroy();
+    EXPECT_FALSE(lbl);
+    EXPECT_FALSE(clbl);
+}

--- a/test/src/Section_test.cpp
+++ b/test/src/Section_test.cpp
@@ -1,4 +1,5 @@
 #include "gmock/gmock.h"
+#include "TestApp.h"
 #include "godzilla/Section.h"
 #include "godzilla/Range.h"
 
@@ -312,4 +313,22 @@ TEST(SectionTest, view)
     auto output = testing::internal::GetCapturedStdout();
     EXPECT_THAT(output, testing::HasSubstr("(   0) dim  2 offset   0"));
     EXPECT_THAT(output, testing::HasSubstr("(   1) dim  3 offset   2"));
+}
+
+TEST(SectionTest, oper_bool)
+{
+    TestApp app;
+
+    Section sect;
+    const auto & csect = sect;
+    EXPECT_FALSE(sect);
+    EXPECT_FALSE(csect);
+
+    sect.create(MPI_COMM_WORLD);
+    EXPECT_TRUE(sect);
+    EXPECT_TRUE(csect);
+
+    sect.destroy();
+    EXPECT_FALSE(sect);
+    EXPECT_FALSE(csect);
 }

--- a/test/src/StarForrest_test.cpp
+++ b/test/src/StarForrest_test.cpp
@@ -125,3 +125,21 @@ TEST(StarForestTest, view)
     EXPECT_THAT(out, HasSubstr("[0] 0 <- (0,0)"));
     EXPECT_THAT(out, HasSubstr("MultiSF sort=rank-order"));
 }
+
+TEST(StarForestTest, oper_bool)
+{
+    TestApp app;
+
+    StarForest sf;
+    const auto & csf = sf;
+    EXPECT_FALSE(sf);
+    EXPECT_FALSE(csf);
+
+    sf.create(app.get_comm());
+    EXPECT_TRUE(sf);
+    EXPECT_TRUE(csf);
+
+    sf.destroy();
+    EXPECT_FALSE(sf);
+    EXPECT_FALSE(csf);
+}


### PR DESCRIPTION
- When things like `Label` and `IndexSet` are non-const member variable
  we need the operator bool work for non-const objects. With just the const
  version, client code was compiling and misbehaving. This fixes the problem.
- Also added unit tests.
