### PR TITLE
`pre_solve` and `post_solve` are virtual

### DIFF
--- a/include/godzilla/LinearProblem.h
+++ b/include/godzilla/LinearProblem.h
@@ -24,13 +24,13 @@ public:
     void read_restart_file(const RestartFile & file) override;
 
     /// Call before `solve()`
-    void pre_solve();
+    virtual void pre_solve();
 
     /// Solve the linear problem
     void solve();
 
     /// Call after `solve()`
-    void post_solve();
+    virtual void post_solve();
 
     /// true if solve converged, otherwise false
     bool converged();

--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -45,13 +45,13 @@ public:
     void set_use_matrix_free(bool mf_operator, bool mf);
 
     /// Called before the solve
-    void pre_solve();
+    virtual void pre_solve();
 
     /// Solve the problem
     void solve();
 
     /// Called after the solve
-    void post_solve();
+    virtual void post_solve();
 
 protected:
     /// Get underlying non-linear solver

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -166,8 +166,6 @@ LinearProblem::run()
     pre_solve();
     solve();
     post_solve();
-    if (converged())
-        on_final();
 }
 
 void
@@ -193,6 +191,8 @@ void
 LinearProblem::post_solve()
 {
     CALL_STACK_MSG();
+    if (converged())
+        on_final();
 }
 
 void

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -288,8 +288,6 @@ NonlinearProblem::run()
     pre_solve();
     solve();
     post_solve();
-    if (converged())
-        on_final();
 }
 
 void
@@ -317,6 +315,8 @@ void
 NonlinearProblem::post_solve()
 {
     CALL_STACK_MSG();
+    if (converged())
+        on_final();
 }
 
 void


### PR DESCRIPTION
I finally convinced myself that `pre_solve` and `post_solve` should be virtual.
This allows user applications to simply insert their own code and retain the coding
in `run` which is called from the main app. This is the case for just standalone apps.
Coupled apps will be able to still call `pre_solve` and `post_solve` when needed, since
these are still public.

Note that we also have `pre_step` and `post_step` which are also virtual.
