### PR TITLE
Adding conversion module

### DIFF
--- a/include/godzilla/Convert.h
+++ b/include/godzilla/Convert.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <string>
+
+namespace godzilla {
+namespace conv {
+
+/// Convert type to string
+///
+/// @param value Value to convert
+template <typename T>
+std::string to_str(T value);
+
+} // namespace conv
+} // namespace godzilla

--- a/include/godzilla/FEGeometry.h
+++ b/include/godzilla/FEGeometry.h
@@ -5,6 +5,7 @@
 
 #include "godzilla/CallStack.h"
 #include "godzilla/Types.h"
+#include "godzilla/Convert.h"
 #include "godzilla/Exception.h"
 #include "godzilla/UnstructuredMesh.h"
 #include "godzilla/Vector.h"
@@ -88,7 +89,7 @@ normal(Real volume, Real face_volume, const DenseVector<Real, DIM> & grad)
     CALL_STACK_MSG();
     throw NotImplementedException(
         "Computation of a normal for element '{}' in {} dimensions is not implemented",
-        get_element_type_str(ELEM_TYPE),
+        conv::to_str(ELEM_TYPE),
         DIM);
 }
 
@@ -124,7 +125,7 @@ element_length(const DenseMatrix<Real, DIM, N_ELEM_NODES> & grad_phi)
     CALL_STACK_MSG();
     throw NotImplementedException(
         "Computation of a element length for '{}' in {} dimensions is not implemented",
-        get_element_type_str(ELEM_TYPE),
+        conv::to_str(ELEM_TYPE),
         DIM);
 }
 

--- a/include/godzilla/FEIntegration.h
+++ b/include/godzilla/FEIntegration.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "godzilla/Types.h"
+#include "godzilla/Convert.h"
 #include "godzilla/Error.h"
 #include "godzilla/Exception.h"
 
@@ -23,7 +24,7 @@ inline Real
 integration_coeff()
 {
     throw NotImplementedException("Integration coefficient for '{}' is not implemented",
-                                  get_element_type_str(ELEM_TYPE));
+                                  conv::to_str(ELEM_TYPE));
 }
 
 template <>
@@ -74,7 +75,7 @@ inline Real
 integration_coeff()
 {
     throw NotImplementedException("Integration coefficient for '{}' is not implemented",
-                                  get_element_type_str(ELEM_TYPE));
+                                  conv::to_str(ELEM_TYPE));
 }
 
 template <>
@@ -174,7 +175,7 @@ inline Real
 surface_integration_coeff()
 {
     throw NotImplementedException("Surface integration coefficient for '{}' is not implemented",
-                                  get_element_type_str(ELEM_TYPE));
+                                  conv::to_str(ELEM_TYPE));
 }
 
 template <>

--- a/include/godzilla/FEMatrices.h
+++ b/include/godzilla/FEMatrices.h
@@ -5,6 +5,7 @@
 
 #include "godzilla/Exception.h"
 #include "godzilla/Types.h"
+#include "godzilla/Convert.h"
 #include "godzilla/Error.h"
 #include "godzilla/DenseVector.h"
 #include "godzilla/DenseMatrix.h"
@@ -27,8 +28,7 @@ template <ElementType ETYPE, Int N_ELEM_NODES = get_num_element_nodes(ETYPE)>
 inline DenseMatrixSymm<Real, N_ELEM_NODES>
 mass()
 {
-    throw NotImplementedException("Mass matrix is not implemented for {}",
-                                  get_element_type_str(ETYPE));
+    throw NotImplementedException("Mass matrix is not implemented for {}", conv::to_str(ETYPE));
 }
 
 /// Local mass matrix for EDGE2 in 1D
@@ -84,7 +84,7 @@ inline DenseMatrixSymm<Real, N_ELEM_NODES>
 mass_rz(Real rad_e, const DenseVector<Real, N_ELEM_NODES> & rad_n)
 {
     throw NotImplementedException("Mass matrix (RZ) is not implemented for {}",
-                                  get_element_type_str(ETYPE));
+                                  conv::to_str(ETYPE));
 }
 
 /// Local mass matrix (RZ) for EDGE2 in 1D
@@ -121,7 +121,7 @@ inline DenseMatrixSymm<Real, N_ELEM_NODES>
 mass_lumped()
 {
     throw NotImplementedException("Lumped mass matrix is not implemented for {}",
-                                  get_element_type_str(ETYPE));
+                                  conv::to_str(ETYPE));
 }
 
 /// Local lumped mass matrix for EDGE2 in 1D
@@ -170,7 +170,7 @@ inline DenseMatrixSymm<Real, N_ELEM_NODES>
 mass_lumped_rz(const DenseVector<Real, N_ELEM_NODES> & rad_n)
 {
     throw NotImplementedException("Mass matrix (RZ) is not implemented for {}",
-                                  get_element_type_str(ETYPE));
+                                  conv::to_str(ETYPE));
 }
 
 template <>
@@ -208,7 +208,7 @@ inline DenseMatrixSymm<Real, N_ELEM_NODES>
 stiffness()
 {
     throw NotImplementedException("Stiffness matrix is not implemented for {}",
-                                  get_element_type_str(ETYPE));
+                                  conv::to_str(ETYPE));
 }
 
 /// Local mass matrix for EDGE2 in 1D

--- a/include/godzilla/FEShapeFns.h
+++ b/include/godzilla/FEShapeFns.h
@@ -5,6 +5,7 @@
 
 #include "godzilla/CallStack.h"
 #include "godzilla/Types.h"
+#include "godzilla/Convert.h"
 #include "godzilla/Array1D.h"
 #include "godzilla/UnstructuredMesh.h"
 #include "godzilla/DenseVector.h"
@@ -29,7 +30,7 @@ grad_shape(const DenseMatrix<Real, N, D> & coords, Real volume)
 {
     throw NotImplementedException(
         "Calculation of shape function gradients is not implemented for element '{}' yet",
-        get_element_type_str(ELEM_TYPE));
+        conv::to_str(ELEM_TYPE));
 }
 
 /// Compute gradients of shape functions of EDGE2 in 1-D

--- a/include/godzilla/FEVolumes.h
+++ b/include/godzilla/FEVolumes.h
@@ -5,6 +5,7 @@
 
 #include "godzilla/CallStack.h"
 #include "godzilla/Types.h"
+#include "godzilla/Convert.h"
 #include "godzilla/Array1D.h"
 #include "godzilla/DenseVector.h"
 #include "godzilla/DenseMatrix.h"
@@ -21,7 +22,7 @@ volume(const DenseMatrix<Real, N_ELEM_NODES, DIM> & coords)
 {
     CALL_STACK_MSG();
     throw NotImplementedException("Volume calculation for {} in {} dimensions is not implemented",
-                                  get_element_type_str(ELEM_TYPE),
+                                  conv::to_str(ELEM_TYPE),
                                   DIM);
 }
 
@@ -155,7 +156,7 @@ face_area(const DenseMatrix<Real, N_FACE_NODES, DIM> & coords)
     CALL_STACK_MSG();
     throw NotImplementedException(
         "Face area calculation for {} in {} dimensions is not implemented",
-        get_element_type_str(ELEM_TYPE),
+        conv::to_str(ELEM_TYPE),
         DIM);
 }
 

--- a/include/godzilla/KrylovSolver.h
+++ b/include/godzilla/KrylovSolver.h
@@ -261,12 +261,6 @@ public:
                                                       Real rnorm,
                                                       KSPConvergedReason * reason,
                                                       void * ctx);
-
-    /// Get the converged reason string
-    ///
-    /// @param reason The converged reason
-    /// @return The string representation of the converged reason
-    static std::string converged_reason_str(ConvergedReason reason);
 };
 
 } // namespace godzilla

--- a/include/godzilla/Types.h
+++ b/include/godzilla/Types.h
@@ -28,12 +28,6 @@ invoke_function_delegate(Int dim, Real time, const Real x[], Int nc, Scalar u[],
 
 //
 
-/// Return the text representation of an element type
-///
-/// @param type Element type
-/// @return Text representation of an element type
-std::string get_element_type_str(const ElementType & type);
-
 /// Return number of nodes given FE type
 ///
 /// @param type Element type

--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -443,10 +443,4 @@ public:
     static void invert_cell(PolytopeType type, std::vector<Int> & cone);
 };
 
-/// Get string representation of a polytope type
-///
-/// @param cell_type Cell type
-/// @return String describing the polytope type
-const char * get_polytope_type_str(PolytopeType cell_type);
-
 } // namespace godzilla

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -5,6 +5,7 @@
 #include "godzilla/Enums.h"
 #include "godzilla/CallStack.h"
 #include "godzilla/KrylovSolver.h"
+#include "godzilla/SNESolver.h"
 #include "godzilla/Exception.h"
 
 namespace godzilla {
@@ -109,6 +110,50 @@ to_str(KrylovSolver::ConvergedReason reason)
         return "NaN or inf values";
     else if (reason == KrylovSolver::ConvergedReason::DIVERGED_INDEFINITE_MAT)
         return "indefinite matrix";
+    else
+        return "unknown";
+}
+
+template <>
+std::string
+to_str(SNESolver::ConvergedReason reason)
+{
+    CALL_STACK_MSG();
+    if (reason == SNESolver::ConvergedReason::CONVERGED_ITERATING)
+        return "iterating";
+    else if (reason == SNESolver::ConvergedReason::CONVERGED_FNORM_ABS)
+        return "absolute function norm";
+    else if (reason == SNESolver::ConvergedReason::CONVERGED_FNORM_RELATIVE)
+        return "relative function norm";
+    else if (reason == SNESolver::ConvergedReason::CONVERGED_SNORM_RELATIVE)
+        return "relative step norm";
+    else if (reason == SNESolver::ConvergedReason::CONVERGED_ITS)
+        return "maximum iterations";
+    else if (reason == SNESolver::ConvergedReason::BREAKOUT_INNER_ITER)
+        return "inner iteration breakout";
+    // Diverged reasons
+    else if (reason == SNESolver::ConvergedReason::DIVERGED_FUNCTION_DOMAIN)
+        return "function domain";
+    else if (reason == SNESolver::ConvergedReason::DIVERGED_FUNCTION_COUNT)
+        return "function count";
+    else if (reason == SNESolver::ConvergedReason::DIVERGED_LINEAR_SOLVE)
+        return "linear solve";
+    else if (reason == SNESolver::ConvergedReason::DIVERGED_FNORM_NAN)
+        return "function norm in NaN";
+    else if (reason == SNESolver::ConvergedReason::DIVERGED_MAX_IT)
+        return "maximum iterations";
+    else if (reason == SNESolver::ConvergedReason::DIVERGED_LINE_SEARCH)
+        return "line search";
+    else if (reason == SNESolver::ConvergedReason::DIVERGED_INNER)
+        return "inner solve failed";
+    else if (reason == SNESolver::ConvergedReason::DIVERGED_LOCAL_MIN)
+        return "local minimum";
+    else if (reason == SNESolver::ConvergedReason::DIVERGED_DTOL)
+        return "divergence tolerance";
+    else if (reason == SNESolver::ConvergedReason::DIVERGED_JACOBIAN_DOMAIN)
+        return "Jacobian domain";
+    else if (reason == SNESolver::ConvergedReason::DIVERGED_TR_DELTA)
+        return "trust region delta";
     else
         return "unknown";
 }

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -4,6 +4,7 @@
 #include "godzilla/Convert.h"
 #include "godzilla/Enums.h"
 #include "godzilla/CallStack.h"
+#include "godzilla/KrylovSolver.h"
 
 namespace godzilla {
 namespace conv {
@@ -45,6 +46,50 @@ to_str(PolytopeType elem_type)
     default:
         return "UNKNOWN";
     }
+}
+
+template <>
+std::string
+to_str(KrylovSolver::ConvergedReason reason)
+{
+    CALL_STACK_MSG();
+    if (reason == KrylovSolver::ConvergedReason::CONVERGED_ITERATING)
+        return "iterating";
+    else if (reason == KrylovSolver::ConvergedReason::CONVERGED_RTOL_NORMAL)
+        return "relative tolerance";
+    else if (reason == KrylovSolver::ConvergedReason::CONVERGED_ATOL_NORMAL)
+        return "absolute tolerance";
+    else if (reason == KrylovSolver::ConvergedReason::CONVERGED_RTOL)
+        return "relative tolerance";
+    else if (reason == KrylovSolver::ConvergedReason::CONVERGED_ATOL)
+        return "absolute tolerance";
+    else if (reason == KrylovSolver::ConvergedReason::CONVERGED_ITS)
+        return "maximum iterations";
+    else if (reason == KrylovSolver::ConvergedReason::CONVERGED_STEP_LENGTH)
+        return "step length";
+    else if (reason == KrylovSolver::ConvergedReason::CONVERGED_HAPPY_BREAKDOWN)
+        return "happy breakdown";
+    // Diverged reasons
+    else if (reason == KrylovSolver::ConvergedReason::DIVERGED_NULL)
+        return "null";
+    else if (reason == KrylovSolver::ConvergedReason::DIVERGED_ITS)
+        return "maximum iterations";
+    else if (reason == KrylovSolver::ConvergedReason::DIVERGED_DTOL)
+        return "divergent tolerance";
+    else if (reason == KrylovSolver::ConvergedReason::DIVERGED_BREAKDOWN)
+        return "breakdown";
+    else if (reason == KrylovSolver::ConvergedReason::DIVERGED_BREAKDOWN_BICG)
+        return "breakdown (BiCG)";
+    else if (reason == KrylovSolver::ConvergedReason::DIVERGED_NONSYMMETRIC)
+        return "non-symmetric matrix";
+    else if (reason == KrylovSolver::ConvergedReason::DIVERGED_INDEFINITE_PC)
+        return "indefinite preconditioner";
+    else if (reason == KrylovSolver::ConvergedReason::DIVERGED_NANORINF)
+        return "NaN or inf values";
+    else if (reason == KrylovSolver::ConvergedReason::DIVERGED_INDEFINITE_MAT)
+        return "indefinite matrix";
+    else
+        return "unknown";
 }
 
 } // namespace conv

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2025 David Andrs <andrsd@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#include "godzilla/Convert.h"
+#include "godzilla/Enums.h"
+#include "godzilla/CallStack.h"
+
+namespace godzilla {
+namespace conv {
+
+template <>
+std::string
+to_str(PolytopeType elem_type)
+{
+    CALL_STACK_MSG();
+    switch (elem_type) {
+    case PolytopeType::POINT:
+        return "POINT";
+    case PolytopeType::SEGMENT:
+        return "SEGMENT";
+    case PolytopeType::POINT_PRISM_TENSOR:
+        return "POINT_PRISM_TENSOR";
+    case PolytopeType::TRIANGLE:
+        return "TRIANGLE";
+    case PolytopeType::QUADRILATERAL:
+        return "QUADRILATERAL";
+    case PolytopeType::SEG_PRISM_TENSOR:
+        return "SEG_PRISM_TENSOR";
+    case PolytopeType::TETRAHEDRON:
+        return "TETRAHEDRON";
+    case PolytopeType::HEXAHEDRON:
+        return "HEXAHEDRON";
+    case PolytopeType::TRI_PRISM:
+        return "TRI_PRISM";
+    case PolytopeType::TRI_PRISM_TENSOR:
+        return "TRI_PRISM_TENSOR";
+    case PolytopeType::QUAD_PRISM_TENSOR:
+        return "QUAD_PRISM_TENSOR";
+    case PolytopeType::PYRAMID:
+        return "PYRAMID";
+    case PolytopeType::FV_GHOST:
+        return "FV_GHOST";
+    case PolytopeType::INTERIOR_GHOST:
+        return "INTERIOR_GHOST";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+} // namespace conv
+} // namespace godzilla

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -158,5 +158,26 @@ to_str(SNESolver::ConvergedReason reason)
         return "unknown";
 }
 
+template <>
+std::string
+to_str(SNESolver::LineSearch::LineSearchType type)
+{
+    CALL_STACK_MSG();
+    if (type == SNESolver::LineSearch::BASIC)
+        return "basic";
+    else if (type == SNESolver::LineSearch::L2)
+        return "l2";
+    else if (type == SNESolver::LineSearch::CP)
+        return "cp";
+    else if (type == SNESolver::LineSearch::NLEQERR)
+        return "nleqerr";
+    else if (type == SNESolver::LineSearch::SHELL)
+        return "shell";
+    else if (type == SNESolver::LineSearch::BT)
+        return "bt";
+    else
+        return "unknown";
+}
+
 } // namespace conv
 } // namespace godzilla

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -5,6 +5,7 @@
 #include "godzilla/Enums.h"
 #include "godzilla/CallStack.h"
 #include "godzilla/KrylovSolver.h"
+#include "godzilla/Exception.h"
 
 namespace godzilla {
 namespace conv {
@@ -45,6 +46,26 @@ to_str(PolytopeType elem_type)
         return "INTERIOR_GHOST";
     default:
         return "UNKNOWN";
+    }
+}
+
+template <>
+std::string
+to_str(const ElementType type)
+{
+    switch (type) {
+    case EDGE2:
+        return "EDGE2";
+    case TRI3:
+        return "TRI3";
+    case QUAD4:
+        return "QUAD4";
+    case TET4:
+        return "TET4";
+    case HEX8:
+        return "HEX8";
+    default:
+        throw InternalError("Unsupported element type");
     }
 }
 

--- a/src/KrylovSolver.cpp
+++ b/src/KrylovSolver.cpp
@@ -229,47 +229,4 @@ KrylovSolver::view(PetscViewer viewer) const
     PETSC_CHECK(KSPView(this->ksp, viewer));
 }
 
-std::string
-KrylovSolver::converged_reason_str(ConvergedReason reason)
-{
-    CALL_STACK_MSG();
-    if (reason == ConvergedReason::CONVERGED_ITERATING)
-        return "iterating";
-    else if (reason == ConvergedReason::CONVERGED_RTOL_NORMAL)
-        return "relative tolerance";
-    else if (reason == ConvergedReason::CONVERGED_ATOL_NORMAL)
-        return "absolute tolerance";
-    else if (reason == ConvergedReason::CONVERGED_RTOL)
-        return "relative tolerance";
-    else if (reason == ConvergedReason::CONVERGED_ATOL)
-        return "absolute tolerance";
-    else if (reason == ConvergedReason::CONVERGED_ITS)
-        return "maximum iterations";
-    else if (reason == ConvergedReason::CONVERGED_STEP_LENGTH)
-        return "step length";
-    else if (reason == ConvergedReason::CONVERGED_HAPPY_BREAKDOWN)
-        return "happy breakdown";
-    // Diverged reasons
-    else if (reason == ConvergedReason::DIVERGED_NULL)
-        return "null";
-    else if (reason == ConvergedReason::DIVERGED_ITS)
-        return "maximum iterations";
-    else if (reason == ConvergedReason::DIVERGED_DTOL)
-        return "divergent tolerance";
-    else if (reason == ConvergedReason::DIVERGED_BREAKDOWN)
-        return "breakdown";
-    else if (reason == ConvergedReason::DIVERGED_BREAKDOWN_BICG)
-        return "breakdown (BiCG)";
-    else if (reason == ConvergedReason::DIVERGED_NONSYMMETRIC)
-        return "non-symmetric matrix";
-    else if (reason == ConvergedReason::DIVERGED_INDEFINITE_PC)
-        return "indefinite preconditioner";
-    else if (reason == ConvergedReason::DIVERGED_NANORINF)
-        return "NaN or inf values";
-    else if (reason == ConvergedReason::DIVERGED_INDEFINITE_MAT)
-        return "indefinite matrix";
-    else
-        return "unknown";
-}
-
 } // namespace godzilla

--- a/src/Types.cpp
+++ b/src/Types.cpp
@@ -18,23 +18,4 @@ invoke_function_delegate(Int dim, Real time, const Real x[], Int nc, Scalar u[],
 
 } // namespace internal
 
-std::string
-get_element_type_str(const ElementType & type)
-{
-    switch (type) {
-    case EDGE2:
-        return "EDGE2";
-    case TRI3:
-        return "TRI3";
-    case QUAD4:
-        return "QUAD4";
-    case TET4:
-        return "TET4";
-    case HEX8:
-        return "HEX8";
-    default:
-        throw InternalError("Unsupported element type");
-    }
-}
-
 } // namespace godzilla

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -6,48 +6,11 @@
 #include "godzilla/IndexSet.h"
 #include "godzilla/Exception.h"
 #include "godzilla/Partitioner.h"
+#include "godzilla/Convert.h"
 #include "petscdmplex.h"
 #include "petscdmtypes.h"
 
 namespace godzilla {
-
-const char *
-get_polytope_type_str(PolytopeType elem_type)
-{
-    CALL_STACK_MSG();
-    switch (elem_type) {
-    case PolytopeType::POINT:
-        return "POINT";
-    case PolytopeType::SEGMENT:
-        return "SEGMENT";
-    case PolytopeType::POINT_PRISM_TENSOR:
-        return "POINT_PRISM_TENSOR";
-    case PolytopeType::TRIANGLE:
-        return "TRIANGLE";
-    case PolytopeType::QUADRILATERAL:
-        return "QUADRILATERAL";
-    case PolytopeType::SEG_PRISM_TENSOR:
-        return "SEG_PRISM_TENSOR";
-    case PolytopeType::TETRAHEDRON:
-        return "TETRAHEDRON";
-    case PolytopeType::HEXAHEDRON:
-        return "HEXAHEDRON";
-    case PolytopeType::TRI_PRISM:
-        return "TRI_PRISM";
-    case PolytopeType::TRI_PRISM_TENSOR:
-        return "TRI_PRISM_TENSOR";
-    case PolytopeType::QUAD_PRISM_TENSOR:
-        return "QUAD_PRISM_TENSOR";
-    case PolytopeType::PYRAMID:
-        return "PYRAMID";
-    case PolytopeType::FV_GHOST:
-        return "FV_GHOST";
-    case PolytopeType::INTERIOR_GHOST:
-        return "INTERIOR_GHOST";
-    default:
-        return "UNKNOWN";
-    }
-}
 
 UnstructuredMesh::UnstructuredMesh(const mpi::Communicator & comm) :
     Mesh(nullptr),
@@ -664,7 +627,7 @@ UnstructuredMesh::get_num_cell_nodes(PolytopeType elem_type)
     case PolytopeType::HEXAHEDRON:
         return 8;
     default:
-        error("Unsupported type '{}'.", get_polytope_type_str(elem_type));
+        error("Unsupported type '{}'.", conv::to_str(elem_type));
     }
 }
 

--- a/test/src/Convert_test.cpp
+++ b/test/src/Convert_test.cpp
@@ -1,6 +1,7 @@
 #include <gmock/gmock.h>
 #include "godzilla/Convert.h"
 #include "godzilla/Enums.h"
+#include "godzilla/KrylovSolver.h"
 
 using namespace godzilla;
 
@@ -21,4 +22,10 @@ TEST(ConvertTest, polytope_type)
     EXPECT_EQ(conv::to_str(PolytopeType::FV_GHOST), "FV_GHOST");
     EXPECT_EQ(conv::to_str(PolytopeType::INTERIOR_GHOST), "INTERIOR_GHOST");
     EXPECT_EQ(conv::to_str(PolytopeType::UNKNOWN), "UNKNOWN");
+}
+
+TEST(ConvertTest, converged_reason)
+{
+    EXPECT_EQ(conv::to_str(KrylovSolver::CONVERGED_ITS), "maximum iterations");
+    EXPECT_EQ(conv::to_str(KrylovSolver::DIVERGED_NULL), "null");
 }

--- a/test/src/Convert_test.cpp
+++ b/test/src/Convert_test.cpp
@@ -2,6 +2,7 @@
 #include "godzilla/Convert.h"
 #include "godzilla/Enums.h"
 #include "godzilla/KrylovSolver.h"
+#include "godzilla/SNESolver.h"
 
 using namespace godzilla;
 
@@ -33,8 +34,15 @@ TEST(ConvertTest, element_type)
     EXPECT_EQ(conv::to_str(HEX8), "HEX8");
 }
 
-TEST(ConvertTest, converged_reason)
+TEST(ConvertTest, ksp_converged_reason)
 {
     EXPECT_EQ(conv::to_str(KrylovSolver::CONVERGED_ITS), "maximum iterations");
     EXPECT_EQ(conv::to_str(KrylovSolver::DIVERGED_NULL), "null");
+}
+
+TEST(ConvertTest, snes_converged_reason)
+{
+    EXPECT_EQ(conv::to_str(SNESolver::CONVERGED_FNORM_ABS), "absolute function norm");
+    EXPECT_EQ(conv::to_str(SNESolver::CONVERGED_ITS), "maximum iterations");
+    EXPECT_EQ(conv::to_str(SNESolver::DIVERGED_FUNCTION_DOMAIN), "function domain");
 }

--- a/test/src/Convert_test.cpp
+++ b/test/src/Convert_test.cpp
@@ -24,6 +24,15 @@ TEST(ConvertTest, polytope_type)
     EXPECT_EQ(conv::to_str(PolytopeType::UNKNOWN), "UNKNOWN");
 }
 
+TEST(ConvertTest, element_type)
+{
+    EXPECT_EQ(conv::to_str(EDGE2), "EDGE2");
+    EXPECT_EQ(conv::to_str(TRI3), "TRI3");
+    EXPECT_EQ(conv::to_str(QUAD4), "QUAD4");
+    EXPECT_EQ(conv::to_str(TET4), "TET4");
+    EXPECT_EQ(conv::to_str(HEX8), "HEX8");
+}
+
 TEST(ConvertTest, converged_reason)
 {
     EXPECT_EQ(conv::to_str(KrylovSolver::CONVERGED_ITS), "maximum iterations");

--- a/test/src/Convert_test.cpp
+++ b/test/src/Convert_test.cpp
@@ -1,0 +1,24 @@
+#include <gmock/gmock.h>
+#include "godzilla/Convert.h"
+#include "godzilla/Enums.h"
+
+using namespace godzilla;
+
+TEST(ConvertTest, polytope_type)
+{
+    EXPECT_EQ(conv::to_str(PolytopeType::POINT), "POINT");
+    EXPECT_EQ(conv::to_str(PolytopeType::SEGMENT), "SEGMENT");
+    EXPECT_EQ(conv::to_str(PolytopeType::POINT_PRISM_TENSOR), "POINT_PRISM_TENSOR");
+    EXPECT_EQ(conv::to_str(PolytopeType::TRIANGLE), "TRIANGLE");
+    EXPECT_EQ(conv::to_str(PolytopeType::QUADRILATERAL), "QUADRILATERAL");
+    EXPECT_EQ(conv::to_str(PolytopeType::SEG_PRISM_TENSOR), "SEG_PRISM_TENSOR");
+    EXPECT_EQ(conv::to_str(PolytopeType::TETRAHEDRON), "TETRAHEDRON");
+    EXPECT_EQ(conv::to_str(PolytopeType::HEXAHEDRON), "HEXAHEDRON");
+    EXPECT_EQ(conv::to_str(PolytopeType::TRI_PRISM), "TRI_PRISM");
+    EXPECT_EQ(conv::to_str(PolytopeType::TRI_PRISM_TENSOR), "TRI_PRISM_TENSOR");
+    EXPECT_EQ(conv::to_str(PolytopeType::QUAD_PRISM_TENSOR), "QUAD_PRISM_TENSOR");
+    EXPECT_EQ(conv::to_str(PolytopeType::PYRAMID), "PYRAMID");
+    EXPECT_EQ(conv::to_str(PolytopeType::FV_GHOST), "FV_GHOST");
+    EXPECT_EQ(conv::to_str(PolytopeType::INTERIOR_GHOST), "INTERIOR_GHOST");
+    EXPECT_EQ(conv::to_str(PolytopeType::UNKNOWN), "UNKNOWN");
+}

--- a/test/src/Convert_test.cpp
+++ b/test/src/Convert_test.cpp
@@ -46,3 +46,13 @@ TEST(ConvertTest, snes_converged_reason)
     EXPECT_EQ(conv::to_str(SNESolver::CONVERGED_ITS), "maximum iterations");
     EXPECT_EQ(conv::to_str(SNESolver::DIVERGED_FUNCTION_DOMAIN), "function domain");
 }
+
+TEST(ConvertTest, snes_line_search)
+{
+    EXPECT_EQ(conv::to_str(SNESolver::LineSearch::BASIC), "basic");
+    EXPECT_EQ(conv::to_str(SNESolver::LineSearch::L2), "l2");
+    EXPECT_EQ(conv::to_str(SNESolver::LineSearch::CP), "cp");
+    EXPECT_EQ(conv::to_str(SNESolver::LineSearch::NLEQERR), "nleqerr");
+    EXPECT_EQ(conv::to_str(SNESolver::LineSearch::SHELL), "shell");
+    EXPECT_EQ(conv::to_str(SNESolver::LineSearch::BT), "bt");
+}

--- a/test/src/KrylovSolver_test.cpp
+++ b/test/src/KrylovSolver_test.cpp
@@ -341,13 +341,6 @@ TEST(KrylovSolver, get_operators)
     ks.destroy();
 }
 
-TEST(KrylovSolver, converged_reason_str)
-{
-    EXPECT_EQ(KrylovSolver::converged_reason_str(KrylovSolver::CONVERGED_ITS),
-              "maximum iterations");
-    EXPECT_EQ(KrylovSolver::converged_reason_str(KrylovSolver::DIVERGED_NULL), "null");
-}
-
 TEST(KrylovSolver, view)
 {
     TestApp app;

--- a/test/src/Types_test.cpp
+++ b/test/src/Types_test.cpp
@@ -3,15 +3,6 @@
 
 using namespace godzilla;
 
-TEST(TypesTest, get_element_type_str)
-{
-    EXPECT_EQ(get_element_type_str(EDGE2), "EDGE2");
-    EXPECT_EQ(get_element_type_str(TRI3), "TRI3");
-    EXPECT_EQ(get_element_type_str(QUAD4), "QUAD4");
-    EXPECT_EQ(get_element_type_str(TET4), "TET4");
-    EXPECT_EQ(get_element_type_str(HEX8), "HEX8");
-}
-
 TEST(TypesTest, get_num_element_nodes)
 {
     EXPECT_EQ(get_num_element_nodes(EDGE2), 2);

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -276,25 +276,6 @@ TEST(UnstructuredMeshTest, ranges)
     EXPECT_EQ(all_cell_range.last(), 12);
 }
 
-TEST(UnstructuredMeshTest, polytope_type_str)
-{
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::POINT), "POINT");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::SEGMENT), "SEGMENT");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::POINT_PRISM_TENSOR), "POINT_PRISM_TENSOR");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::TRIANGLE), "TRIANGLE");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::QUADRILATERAL), "QUADRILATERAL");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::SEG_PRISM_TENSOR), "SEG_PRISM_TENSOR");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::TETRAHEDRON), "TETRAHEDRON");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::HEXAHEDRON), "HEXAHEDRON");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::TRI_PRISM), "TRI_PRISM");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::TRI_PRISM_TENSOR), "TRI_PRISM_TENSOR");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::QUAD_PRISM_TENSOR), "QUAD_PRISM_TENSOR");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::PYRAMID), "PYRAMID");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::FV_GHOST), "FV_GHOST");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::INTERIOR_GHOST), "INTERIOR_GHOST");
-    EXPECT_STREQ(get_polytope_type_str(PolytopeType::UNKNOWN), "UNKNOWN");
-}
-
 TEST(UnstructuredMesh, get_cone_recursive_vertices)
 {
     TestApp app;


### PR DESCRIPTION
- Moving polytope conversion to string into new conv module
- Moving string conversion of Krylov solver converged reason into conversion module
- `get_element_type_str` is replaced by `conv::to_str` from the conversion module
- Adding string conversion routine for SNESolver::ConvergedReason
- Adding string conversion routine for SNES linear search
