### PR TITLE
Monitors are no longer virtual methods

### DIFF
--- a/include/godzilla/LinearProblem.h
+++ b/include/godzilla/LinearProblem.h
@@ -66,7 +66,7 @@ protected:
     virtual void create_preconditioner(PC pc);
 
     /// Monitor callback
-    virtual void monitor(Int it, Real rnorm);
+    void monitor(Int it, Real rnorm);
 
     /// Set KSP matrix evaluation function
     ///

--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -85,10 +85,10 @@ protected:
     virtual void set_up_solve_type();
 
     /// SNES monitor
-    virtual void snes_monitor(Int it, Real norm);
+    void snes_monitor(Int it, Real norm);
 
     /// KSP monitor
-    virtual void ksp_monitor(Int it, Real rnorm);
+    void ksp_monitor(Int it, Real rnorm);
 
     /// Set residual evaluation function
     ///

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -257,7 +257,7 @@ protected:
 
 private:
     /// Monitor
-    virtual void monitor(Int stepi, Real time, const Vector & x);
+    void monitor(Int stepi, Real time, const Vector & x);
 
     /// Set up time integration scheme
     virtual void set_up_time_scheme() = 0;


### PR DESCRIPTION
We provide default monitors. If applications need to change them, they do
so via `set_monitor` and providing their own delegate.  This is why we
can change the virtual methods to non-virtual.
