### PR TITLE
Applications can inject their own `MeshObject` via an input file

### DIFF
--- a/include/godzilla/InputFile.h
+++ b/include/godzilla/InputFile.h
@@ -138,6 +138,8 @@ protected:
     Block & get_root();
 
 private:
+    virtual MeshObject * create_mesh_object();
+
     /// Application object
     App * app;
     /// Name of this input file

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -145,14 +145,21 @@ InputFile::add_object(Object * obj)
     }
 }
 
+MeshObject *
+InputFile::create_mesh_object()
+{
+    CALL_STACK_MSG();
+    auto node = get_block(this->root, "mesh");
+    Parameters * params = build_params(node);
+    return this->app->build_object<MeshObject>("mesh", params);
+}
+
 void
 InputFile::build_mesh()
 {
     CALL_STACK_MSG();
     lprintln(9, "- mesh");
-    auto node = get_block(this->root, "mesh");
-    Parameters * params = build_params(node);
-    this->mesh_obj = this->app->build_object<MeshObject>("mesh", params);
+    this->mesh_obj = create_mesh_object();
     add_object(this->mesh_obj);
 }
 


### PR DESCRIPTION
If needed, applications can override `InputFile::create_mesh_object` and
supply thier own mesh object if needed.  This opens the design more.
