### PR TITLE
Refactoring Array1D

### DIFF
--- a/include/godzilla/Array1D.h
+++ b/include/godzilla/Array1D.h
@@ -169,18 +169,6 @@ public:
             this->data[i] = val;
     }
 
-    /// Set multiple values into the vector
-    ///
-    /// @param vals Values to set into this vector
-    void
-    set_values(const std::vector<T> & vals)
-    {
-        assert(this->data != nullptr);
-        assert(this->n == vals.size());
-        for (Int i = 0; i < this->n; ++i)
-            this->data[i] = vals[i];
-    }
-
     /// Set multiple values at specified indices
     ///
     /// @tparam N Size of the array
@@ -389,6 +377,19 @@ add_values(Array1D<T> & data, const DenseVector<Int, N> & idx, const DenseVector
 {
     for (Int i = 0; i < N; ++i)
         data[idx(i)] += vals(i);
+}
+
+/// Assign values from `std::vector` into the `Array1D`
+///
+/// @param data Array1D to assign values into
+/// @param vals Values to set into this vector
+template <typename T>
+void
+assign(Array1D<T> & data, const std::vector<T> & vals)
+{
+    assert(data.size() == vals.size());
+    for (Int i = 0; i < data.size(); ++i)
+        data[i] = vals[i];
 }
 
 } // namespace godzilla

--- a/include/godzilla/Array1D.h
+++ b/include/godzilla/Array1D.h
@@ -12,6 +12,8 @@ namespace godzilla {
 
 template <typename T, Int N>
 class DenseVector;
+template <typename T, Int N, Int M>
+class DenseMatrix;
 
 template <typename T>
 class Array1D {
@@ -153,7 +155,7 @@ public:
     /// @param idx Indices to get the values from
     /// @return Vector with the value from locations specified by `idx`
     template <Int N>
-    DenseVector<T, N>
+    [[deprecated("")]] DenseVector<T, N>
     get_values(DenseVector<Int, N> idx) const
     {
         DenseVector<T, N> res;
@@ -163,7 +165,7 @@ public:
     }
 
     template <Int N>
-    DenseVector<T, N>
+    [[deprecated("")]] DenseVector<T, N>
     get_values(const std::vector<Int> & idx) const
     {
         assert(N == idx.size());
@@ -202,7 +204,7 @@ public:
     /// @param idx Indices where the values are to be set
     /// @param a Values to be set
     template <Int N>
-    void
+    [[deprecated("")]] void
     set_values(const DenseVector<Int, N> & idx, const DenseVector<T, N> & a)
     {
         for (Int i = 0; i < N; ++i)
@@ -215,7 +217,7 @@ public:
     /// @param idx Indices to modify
     /// @param a Vector with values to add at locations specified by `idx`
     template <Int N>
-    void
+    [[deprecated("")]] void
     add(const DenseVector<Int, N> & idx, const DenseVector<T, N> & a)
     {
         for (Int i = 0; i < N; ++i)
@@ -232,6 +234,18 @@ public:
 
     T &
     operator()(Int i)
+    {
+        return set(i);
+    }
+
+    const T &
+    operator[](Int i) const
+    {
+        return get(i);
+    }
+
+    T &
+    operator[](Int i)
     {
         return set(i);
     }
@@ -295,6 +309,89 @@ operator<<(std::ostream & os, const Array1D<T> & obj)
     }
     os << ")";
     return os;
+}
+
+/// Get values from an array at specified locations
+///
+/// @tparam T C++ type
+/// @tparam N number of values
+/// @param data Array to get data from
+/// @param idx Vector of indices to obtain data from
+/// @return Vector of values from the array
+template <typename T, Int N>
+DenseVector<T, N>
+get_values(const Array1D<T> & data, const DenseVector<Int, N> & idx)
+{
+    DenseVector<T, N> vals;
+    for (Int i = 0; i < N; i++)
+        vals(i) = data[idx(i)];
+    return vals;
+}
+
+/// Get vector-valued entries from an array at specified locations
+///
+/// @tparam T C++ type
+/// @tparam N number of values
+/// @tparam M number of components in the vector
+/// @param data Array to get data from
+/// @param idx Vector of indices to obtain data from
+/// @return Matrix of values from the array (rows are the vector-valued data)
+template <typename T, Int N, Int M>
+DenseMatrix<Real, N, M>
+get_values(const Array1D<DenseVector<T, M>> & data, const DenseVector<Int, N> & idx)
+{
+    DenseMatrix<Real, N, M> vals;
+    for (Int i = 0; i < N; ++i) {
+        for (Int j = 0; j < M; ++j)
+            vals(i, j) = data[idx(i)](j);
+    }
+    return vals;
+}
+
+/// Get values from an array at specified locations
+///
+/// @tparam T C++ type
+/// @tparam N number of values
+/// @param data Array to get data from
+/// @param idx Vector of indices to obtain data from
+/// @return Vector of values from the array
+template <typename T, Int N>
+DenseVector<T, N>
+get_values(const Array1D<T> & data, const std::vector<Int> & idx)
+{
+    assert(N == idx.size());
+    DenseVector<T, N> vals;
+    for (Int i = 0; i < N; ++i)
+        vals(i) = data[idx[i]];
+    return vals;
+}
+
+/// Set multiple values at specified indices
+///
+/// @tparam N Size of the array
+/// @param idx Indices where the values are to be set
+/// @param a Values to be set
+template <typename T, Int N>
+void
+set_values(Array1D<T> & data, const DenseVector<Int, N> & idx, const DenseVector<T, N> & a)
+{
+    for (Int i = 0; i < N; ++i)
+        data[idx(i)] = a(i);
+}
+
+/// Add values into the array at specified indices
+///
+/// @tparam T C++ type
+/// @tparam N number of values
+/// @param data akceli vector to add values to
+/// @param idx Vector of indices into `data`
+/// @param vals Vector of values to add to `data`
+template <typename T, Int N>
+void
+add_values(Array1D<T> & data, const DenseVector<Int, N> & idx, const DenseVector<T, N> & vals)
+{
+    for (Int i = 0; i < N; ++i)
+        data[idx(i)] += vals(i);
 }
 
 } // namespace godzilla

--- a/include/godzilla/Array1D.h
+++ b/include/godzilla/Array1D.h
@@ -99,8 +99,17 @@ public:
     /// Get number of entries in the array
     ///
     /// @return Number of entries in the array
-    Int
+    [[deprecated("Use size() instead")]] Int
     get_size() const
+    {
+        return this->n;
+    }
+
+    /// Get number of entries in the array
+    ///
+    /// @return Number of entries in the array
+    Int
+    size() const
     {
         return this->n;
     }
@@ -290,9 +299,9 @@ std::ostream &
 operator<<(std::ostream & os, const Array1D<T> & obj)
 {
     os << "(";
-    for (Int i = 0; i < obj.get_size(); ++i) {
+    for (Int i = 0; i < obj.size(); ++i) {
         os << obj(i);
-        if (i < obj.get_size() - 1)
+        if (i < obj.size() - 1)
             os << ", ";
     }
     os << ")";

--- a/include/godzilla/Array1D.h
+++ b/include/godzilla/Array1D.h
@@ -105,32 +105,6 @@ public:
         return this->n;
     }
 
-    /// Get the entry at a specified location for reading
-    ///
-    /// @param i Index fo the entry
-    /// @return Entry at the `ith` location
-    const T &
-    get(Int i) const
-    {
-        assert(this->data != nullptr);
-        assert((i >= this->range.first()) && (i < this->range.last()));
-        auto idx = i - this->range.first();
-        return this->data[idx];
-    }
-
-    /// Get the entry at a specified location for writing
-    ///
-    /// @param i Index fo the entry
-    /// @return Entry at the `ith` location
-    T &
-    set(Int i)
-    {
-        assert(this->data != nullptr);
-        assert((i >= this->range.first()) && (i < this->range.last()));
-        auto idx = i - this->range.first();
-        return this->data[idx];
-    }
-
     /// Set all entries in the array to zero
     void
     zero()
@@ -171,7 +145,7 @@ public:
         assert(N == idx.size());
         DenseVector<T, N> res;
         for (Int i = 0; i < N; ++i)
-            res(i) = get(idx[i]);
+            res(i) = (*this)(idx[i]);
         return res;
     }
 
@@ -179,7 +153,7 @@ public:
     ///
     /// @param val Value to assign
     void
-    set_values(const T & val)
+    set(const T & val)
     {
         assert(this->data != nullptr);
         for (Int i = 0; i < this->n; ++i)
@@ -208,7 +182,7 @@ public:
     set_values(const DenseVector<Int, N> & idx, const DenseVector<T, N> & a)
     {
         for (Int i = 0; i < N; ++i)
-            set(idx(i)) = a(i);
+            (*this)(idx(i)) = a(i);
     }
 
     /// Add values to specified locations
@@ -221,7 +195,7 @@ public:
     add(const DenseVector<Int, N> & idx, const DenseVector<T, N> & a)
     {
         for (Int i = 0; i < N; ++i)
-            set(idx(i)) += a(i);
+            (*this)(idx(i)) += a(i);
     }
 
     // operators
@@ -229,25 +203,39 @@ public:
     const T &
     operator()(Int i) const
     {
-        return get(i);
+        return (*this)[i];
     }
 
     T &
     operator()(Int i)
     {
-        return set(i);
+        return (*this)[i];
     }
 
+    /// Get the entry at a specified location for reading
+    ///
+    /// @param i Index fo the entry
+    /// @return Entry at the `ith` location
     const T &
     operator[](Int i) const
     {
-        return get(i);
+        assert(this->data != nullptr);
+        assert((i >= this->range.first()) && (i < this->range.last()));
+        auto idx = i - this->range.first();
+        return this->data[idx];
     }
 
+    /// Get the entry at a specified location for writing
+    ///
+    /// @param i Index fo the entry
+    /// @return Entry at the `ith` location
     T &
     operator[](Int i)
     {
-        return set(i);
+        assert(this->data != nullptr);
+        assert((i >= this->range.first()) && (i < this->range.last()));
+        auto idx = i - this->range.first();
+        return this->data[idx];
     }
 
     //

--- a/include/godzilla/Array1D.h
+++ b/include/godzilla/Array1D.h
@@ -24,12 +24,12 @@ public:
         using pointer = T *;
         using reference = T &;
 
-        explicit Iterator(const Array1D & arr, Int idx) : arr(arr), idx(idx) {}
+        explicit Iterator(const Array1D * arr, Int idx) : arr(arr), idx(idx) {}
 
         const value_type &
         operator*() const
         {
-            return *(this->arr.data + this->idx);
+            return *(this->arr->data + this->idx);
         }
 
         /// Prefix increment
@@ -52,18 +52,18 @@ public:
         friend bool
         operator==(const Iterator & a, const Iterator & b)
         {
-            return (&a.arr == &b.arr) && (a.idx == b.idx);
+            return (a.arr == b.arr) && (a.idx == b.idx);
         };
 
         friend bool
         operator!=(const Iterator & a, const Iterator & b)
         {
-            return (&a.arr != &b.arr) || (a.idx != b.idx);
+            return (a.arr != b.arr) || (a.idx != b.idx);
         };
 
     private:
         /// IndexSet to iterate over
-        const Array1D & arr;
+        const Array1D * arr;
         /// Index pointing to the `is`
         Int idx;
     };
@@ -265,13 +265,13 @@ public:
     Iterator
     begin()
     {
-        return Iterator(*this, 0);
+        return Iterator(this, 0);
     }
 
     Iterator
     end()
     {
-        return Iterator(*this, this->n);
+        return Iterator(this, this->n);
     }
 
 private:

--- a/include/godzilla/FEGeometry.h
+++ b/include/godzilla/FEGeometry.h
@@ -155,8 +155,8 @@ Array1D<Real>
 calc_element_length(const Array1D<DenseMatrix<Real, DIM, N_ELEM_NODES>> & grad_phi)
 {
     CALL_STACK_MSG();
-    Array1D<Real> elem_lengths(grad_phi.get_size());
-    for (Int ie = 0; ie < grad_phi.get_size(); ++ie)
+    Array1D<Real> elem_lengths(grad_phi.size());
+    for (Int ie = 0; ie < grad_phi.size(); ++ie)
         elem_lengths(ie) = element_length<ELEM_TYPE, DIM>(grad_phi(ie));
     return elem_lengths;
 }
@@ -175,7 +175,7 @@ inline Array1D<Real>
 calc_nodal_radius<CARTESIAN, 1>(Array1D<DenseVector<Real, 1>> & coords)
 {
     CALL_STACK_MSG();
-    auto n = coords.get_size();
+    auto n = coords.size();
     Array1D<Real> rad(n);
     for (Int in = 0; in < n; ++in)
         rad(in) = 1.;
@@ -187,7 +187,7 @@ inline Array1D<Real>
 calc_nodal_radius<CARTESIAN, 2>(Array1D<DenseVector<Real, 2>> & coords)
 {
     CALL_STACK_MSG();
-    auto n = coords.get_size();
+    auto n = coords.size();
     Array1D<Real> rad(n);
     for (Int in = 0; in < n; ++in)
         rad(in) = 1.;
@@ -199,7 +199,7 @@ inline Array1D<Real>
 calc_nodal_radius<CARTESIAN, 3>(Array1D<DenseVector<Real, 3>> & coords)
 {
     CALL_STACK_MSG();
-    auto n = coords.get_size();
+    auto n = coords.size();
     Array1D<Real> rad(n);
     for (Int in = 0; in < n; ++in)
         rad(in) = 1.;
@@ -212,7 +212,7 @@ calc_nodal_radius<AXISYMMETRIC, 2>(Array1D<DenseVector<Real, 2>> & coords)
 {
     // symmetric around x-axis
     CALL_STACK_MSG();
-    auto n = coords.get_size();
+    auto n = coords.size();
     Array1D<Real> rad(n);
     for (Int in = 0; in < n; ++in)
         rad(in) = coords(in)(1);

--- a/include/godzilla/FEShapeFns.h
+++ b/include/godzilla/FEShapeFns.h
@@ -122,8 +122,8 @@ calc_grad_shape(const Array1D<DenseVector<Real, DIM>> & coords,
                 const Array1D<Real> & volumes)
 {
     CALL_STACK_MSG();
-    Array1D<DenseMatrix<Real, DIM, N_ELEM_NODES>> grad_shfns(connect.get_size());
-    for (Int ie = 0; ie < connect.get_size(); ++ie) {
+    Array1D<DenseMatrix<Real, DIM, N_ELEM_NODES>> grad_shfns(connect.size());
+    for (Int ie = 0; ie < connect.size(); ++ie) {
         auto idx = connect[ie];
         auto elem_coord = get_values(coords, idx);
         auto volume = volumes(ie);

--- a/include/godzilla/FEShapeFns.h
+++ b/include/godzilla/FEShapeFns.h
@@ -124,7 +124,7 @@ calc_grad_shape(const Array1D<DenseVector<Real, DIM>> & coords,
     CALL_STACK_MSG();
     Array1D<DenseMatrix<Real, DIM, N_ELEM_NODES>> grad_shfns(connect.get_size());
     for (Int ie = 0; ie < connect.get_size(); ++ie) {
-        auto idx = connect.get(ie);
+        auto idx = connect[ie];
         auto elem_coord = get_values(coords, idx);
         auto volume = volumes(ie);
         grad_shfns(ie) = grad_shape<ELEM_TYPE, DIM>(elem_coord, volume);

--- a/include/godzilla/FEShapeFns.h
+++ b/include/godzilla/FEShapeFns.h
@@ -125,7 +125,7 @@ calc_grad_shape(const Array1D<DenseVector<Real, DIM>> & coords,
     Array1D<DenseMatrix<Real, DIM, N_ELEM_NODES>> grad_shfns(connect.get_size());
     for (Int ie = 0; ie < connect.get_size(); ++ie) {
         auto idx = connect.get(ie);
-        auto elem_coord = mat_row(coords.get_values(idx));
+        auto elem_coord = get_values(coords, idx);
         auto volume = volumes(ie);
         grad_shfns(ie) = grad_shape<ELEM_TYPE, DIM>(elem_coord, volume);
     }

--- a/include/godzilla/FEVolumes.h
+++ b/include/godzilla/FEVolumes.h
@@ -111,7 +111,7 @@ calc_volumes(const Array1D<DenseVector<Real, DIM>> & coords,
 
     for (godzilla::Int ie = 0; ie < connect.get_size(); ++ie) {
         auto idx = connect(ie);
-        auto elem_coord = mat_row(coords.get_values(idx));
+        auto elem_coord = get_values(coords, idx);
         fe_volume(ie) = volume<ELEM_TYPE, DIM>(elem_coord);
     }
 }

--- a/include/godzilla/FEVolumes.h
+++ b/include/godzilla/FEVolumes.h
@@ -107,9 +107,9 @@ calc_volumes(const Array1D<DenseVector<Real, DIM>> & coords,
              Array1D<Real> & fe_volume)
 {
     CALL_STACK_MSG();
-    assert(connect.get_size() == fe_volume.get_size());
+    assert(connect.size() == fe_volume.size());
 
-    for (godzilla::Int ie = 0; ie < connect.get_size(); ++ie) {
+    for (godzilla::Int ie = 0; ie < connect.size(); ++ie) {
         auto idx = connect(ie);
         auto elem_coord = get_values(coords, idx);
         fe_volume(ie) = volume<ELEM_TYPE, DIM>(elem_coord);
@@ -122,7 +122,7 @@ calc_volumes(const Array1D<DenseVector<Real, DIM>> & coords,
              const Array1D<DenseVector<Int, N_ELEM_NODES>> & connect)
 {
     CALL_STACK_MSG();
-    Array1D<Real> fe_volume(connect.get_size());
+    Array1D<Real> fe_volume(connect.size());
     calc_volumes<ELEM_TYPE, DIM, N_ELEM_NODES>(coords, connect, fe_volume);
     return fe_volume;
 }

--- a/src/ShellMatrix.cpp
+++ b/src/ShellMatrix.cpp
@@ -9,19 +9,6 @@
 
 namespace godzilla {
 
-namespace {
-
-Mat
-create_shell(MPI_Comm comm, Int m, Int n, Int M, Int N, void * ctx)
-{
-    CALL_STACK_MSG();
-    Mat mat;
-    PETSC_CHECK(MatCreateShell(comm, m, n, M, N, ctx, &mat));
-    return mat;
-}
-
-} // namespace
-
 ErrorCode
 ShellMatrix::invoke_matmult_op_delegate(Mat matrix, Vec vector, Vec action)
 {
@@ -60,13 +47,5 @@ ShellMatrix::set_operation(MatOperation op, void (*g)(void))
     CALL_STACK_MSG();
     PETSC_CHECK(MatShellSetOperation(*this, op, g));
 }
-
-// ShellMatrix
-// ShellMatrix::create(MPI_Comm comm, Int m, Int n, Int M, Int N)
-// {
-//     Mat mat;
-//     PETSC_CHECK(MatCreateShell(comm, m, n, M, N, nullptr, &mat));
-//     return ShellMatrix(mat);
-// }
 
 } // namespace godzilla

--- a/test/src/Array1D_test.cpp
+++ b/test/src/Array1D_test.cpp
@@ -50,7 +50,7 @@ TEST(Array1DTest, zero)
 TEST(Array1DTest, set_values)
 {
     Array1D<Real> arr(10);
-    arr.set_values(1234);
+    arr.set(1234);
     for (Int i = 0; i < 10; ++i)
         EXPECT_EQ(arr(i), 1234.);
     arr.destroy();

--- a/test/src/Array1D_test.cpp
+++ b/test/src/Array1D_test.cpp
@@ -72,7 +72,7 @@ TEST(Array1DTest, set_values_idxs)
 TEST(Array1DTest, get_data)
 {
     Array1D<Real> y(5);
-    y.set_values({ 2., 3., 1., -2., 0. });
+    assign(y, { 2., 3., 1., -2., 0. });
     Real * raw = y.get_data();
     EXPECT_EQ(raw[0], 2.);
     EXPECT_EQ(raw[1], 3.);
@@ -87,7 +87,7 @@ TEST(Array1DTest, op_to_stream)
     testing::internal::CaptureStdout();
 
     Array1D<Real> x(5);
-    x.set_values({ 1., -1., 3., 0., 2. });
+    assign(x, { 1., -1., 3., 0., 2. });
     std::cout << x;
 
     EXPECT_THAT(testing::internal::GetCapturedStdout(), testing::HasSubstr("(1, -1, 3, 0, 2)"));
@@ -98,7 +98,7 @@ TEST(Array1DTest, op_to_stream)
 TEST(Array1DTest, get_values)
 {
     Array1D<Real> x(8);
-    x.set_values({ 2, 3, 1, -2, 0, 6, 10, 8 });
+    assign(x, { 2, 3, 1, -2, 0, 6, 10, 8 });
 
     DenseVector<Int, 3> idx({ 1, 6, 3 });
     auto vals = get_values(x, idx);
@@ -113,7 +113,7 @@ TEST(Array1DTest, get_values)
 TEST(Array1DTest, get_values_std_vec)
 {
     Array1D<Real> x(8);
-    x.set_values({ 2, 3, 1, -2, 0, 6, 10, 8 });
+    assign(x, { 2, 3, 1, -2, 0, 6, 10, 8 });
 
     auto vals = get_values<Real, 3>(x, { 1, 6, 3 });
 
@@ -127,7 +127,7 @@ TEST(Array1DTest, get_values_std_vec)
 TEST(Array1DTest, add)
 {
     Array1D<Real> x(8);
-    x.set_values({ 2, 3, 1, -2, 0, 6, 10, 8 });
+    assign(x, { 2, 3, 1, -2, 0, 6, 10, 8 });
 
     DenseVector<Int, 3> idx({ 1, 6, 3 });
     DenseVector<Real, 3> dx({ -1, 2, 1 });
@@ -148,7 +148,7 @@ TEST(Array1DTest, add)
 TEST(Array1DTest, range_ops)
 {
     Array1D<Real> arr(8);
-    arr.set_values({ 2, 3, 1, -2, 0, 6, 10, 8 });
+    assign(arr, { 2, 3, 1, -2, 0, 6, 10, 8 });
 
     std::vector<Real> vals;
     for (auto & v : arr)

--- a/test/src/Array1D_test.cpp
+++ b/test/src/Array1D_test.cpp
@@ -62,7 +62,7 @@ TEST(Array1DTest, set_values_idxs)
     arr.zero();
     DenseVector<Int, 3> idxs({ 1, 4, 2 });
     DenseVector<Real, 3> vals({ 8, 7, 6 });
-    arr.set_values(idxs, vals);
+    set_values(arr, idxs, vals);
     EXPECT_EQ(arr(1), 8);
     EXPECT_EQ(arr(4), 7);
     EXPECT_EQ(arr(2), 6);
@@ -101,7 +101,7 @@ TEST(Array1DTest, get_values)
     x.set_values({ 2, 3, 1, -2, 0, 6, 10, 8 });
 
     DenseVector<Int, 3> idx({ 1, 6, 3 });
-    auto vals = x.get_values(idx);
+    auto vals = get_values(x, idx);
 
     EXPECT_EQ(vals(0), 3.);
     EXPECT_EQ(vals(1), 10.);
@@ -115,7 +115,7 @@ TEST(Array1DTest, get_values_std_vec)
     Array1D<Real> x(8);
     x.set_values({ 2, 3, 1, -2, 0, 6, 10, 8 });
 
-    auto vals = x.get_values<3>({ 1, 6, 3 });
+    auto vals = get_values<Real, 3>(x, { 1, 6, 3 });
 
     EXPECT_EQ(vals(0), 3.);
     EXPECT_EQ(vals(1), 10.);
@@ -131,7 +131,7 @@ TEST(Array1DTest, add)
 
     DenseVector<Int, 3> idx({ 1, 6, 3 });
     DenseVector<Real, 3> dx({ -1, 2, 1 });
-    x.add(idx, dx);
+    add_values(x, idx, dx);
 
     EXPECT_EQ(x(0), 2.);
     EXPECT_EQ(x(1), 2.);

--- a/test/src/Array1D_test.cpp
+++ b/test/src/Array1D_test.cpp
@@ -10,7 +10,7 @@ TEST(Array1DTest, create)
 {
     Array1D<Real> arr;
     arr.create(10);
-    EXPECT_EQ(arr.get_size(), 10);
+    EXPECT_EQ(arr.size(), 10);
     arr.destroy();
 }
 
@@ -18,7 +18,7 @@ TEST(Array1DTest, create_rng)
 {
     Array1D<Real> arr;
     arr.create(godzilla::Range(5, 15));
-    EXPECT_EQ(arr.get_size(), 10);
+    EXPECT_EQ(arr.size(), 10);
     arr.destroy();
 }
 

--- a/test/src/FEGeometry_test.cpp
+++ b/test/src/FEGeometry_test.cpp
@@ -22,7 +22,7 @@ TEST(FEGeometryTest, coordinates)
                                                                     true);
 
     auto coords = fe::coordinates<1>(mesh);
-    ASSERT_EQ(coords.get_size(), 4);
+    ASSERT_EQ(coords.size(), 4);
     EXPECT_DOUBLE_EQ(coords(3)(0), 0.);
     EXPECT_DOUBLE_EQ(coords(4)(0), 0.1);
     EXPECT_DOUBLE_EQ(coords(5)(0), 0.2);
@@ -40,7 +40,7 @@ TEST(FEGeometryTest, connectivity)
                                                                     { 0., 0.1, 0.2, 0.3 },
                                                                     true);
     auto connect = fe::connectivity<1, 2>(mesh);
-    ASSERT_EQ(connect.get_size(), 3);
+    ASSERT_EQ(connect.size(), 3);
     EXPECT_EQ(connect(0)(0), 3);
     EXPECT_EQ(connect(0)(1), 4);
     EXPECT_EQ(connect(1)(0), 4);


### PR DESCRIPTION
- Refactoring `Array1D`
- `Array1D::set` sets all entries of the vector to a single value
- Deprecating `Array1D::get_size` in favor of `Array1D::size`
- Fixing compiler warning
- `Array1D::Iterator` uses internally a pointer
- Adding `assign` for setting values from `std::vector` into `Array1D`
