### PR TITLE
Refactoring Vector API

### DIFF
--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -55,7 +55,7 @@ public:
     /// Copy this vector into `y`
     ///
     /// @param y Vector to copy our values into
-    void copy(Vector & y) const;
+    [[deprecated("Message")]] void copy(Vector & y) const;
 
     /// Copies between a reduced vector and the appropriate elements of a full-space vector.
     ///
@@ -278,6 +278,12 @@ Vector::set_values_local(const DenseVector<Int, N> & ix,
     CALL_STACK_MSG();
     PETSC_CHECK(VecSetValuesLocal(this->vec, N, ix.data(), y.data(), mode));
 }
+
+/// Copy vector `x` into `y`
+///
+/// @param x Source vector
+/// @param y Target vector
+void copy(const Vector & x, Vector & y);
 
 /// Compute vector dot product
 ///

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -48,7 +48,8 @@ public:
     void abs();
     Scalar dot(const Vector & y) const;
     void scale(Scalar alpha);
-    void duplicate(Vector & b) const;
+
+    [[deprecated("")]] void duplicate(Vector & b) const;
     Vector duplicate() const;
 
     /// Copy this vector into `y`
@@ -151,10 +152,7 @@ public:
     /// @param ix Indices where to add/insert
     /// @param y Values
     /// @param mode Insertion mode
-    void set_values(Int n,
-                    const Int * ix,
-                    const Scalar * y,
-                    InsertMode mode = INSERT_VALUES);
+    void set_values(Int n, const Int * ix, const Scalar * y, InsertMode mode = INSERT_VALUES);
 
     /// Inserts or adds values into certain locations of a vector
     ///

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -46,7 +46,7 @@ public:
     void get_values(const std::vector<Int> & idx, std::vector<Scalar> & y) const;
 
     void abs();
-    Scalar dot(const Vector & y) const;
+    [[deprecated("")]] Scalar dot(const Vector & y) const;
     void scale(Scalar alpha);
 
     [[deprecated("")]] void duplicate(Vector & b) const;
@@ -278,5 +278,12 @@ Vector::set_values_local(const DenseVector<Int, N> & ix,
     CALL_STACK_MSG();
     PETSC_CHECK(VecSetValuesLocal(this->vec, N, ix.data(), y.data(), mode));
 }
+
+/// Compute vector dot product
+///
+/// @param x First vector
+/// @param y Second vector
+/// @return Dot product
+Scalar dot(const Vector & x, const Vector & y);
 
 } // namespace godzilla

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -110,7 +110,7 @@ public:
     ///
     /// @param beta Scalar
     /// @param x Unscaled vector
-    void aypx(Scalar beta, const Vector & x);
+    [[deprecated("")]] void aypx(Scalar beta, const Vector & x);
 
     /// Computes `this[i] = alpha * x[i] + y[i]
     ///
@@ -305,5 +305,12 @@ void axpy(Vector & y, Scalar alpha, const Vector & x);
 /// @param x Vector scaled by `alpha`
 /// @param y Vector accumulated into
 void axpby(Vector & y, Scalar alpha, Scalar beta, const Vector & x);
+
+/// Computes `y[i] = x[i] + beta * y[i]`
+///
+/// @param beta Scalar
+/// @param x Unscaled vector
+/// @param y Resulting vector
+void aypx(Vector & y, Scalar beta, const Vector & x);
 
 } // namespace godzilla

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -134,7 +134,8 @@ public:
     /// @param gamma Third scalar
     /// @param x First vector
     /// @param y Second vector
-    void axpbypcz(Scalar alpha, Scalar beta, Scalar gamma, const Vector & x, const Vec & y);
+    [[deprecated("")]] void
+    axpbypcz(Scalar alpha, Scalar beta, Scalar gamma, const Vector & x, const Vec & y);
 
     void reciprocal();
 
@@ -328,5 +329,16 @@ void waxpy(Vector & w, Scalar alpha, const Vector & x, const Vector & y);
 /// @param alpha Array of scalars
 /// @param x Array of vectors
 void maxpy(Vector & y, const std::vector<Scalar> & alpha, const std::vector<Vector> & x);
+
+/// Computes `this = alpha * x + beta * y + gamma * this`
+///
+/// @param alpha First scalar
+/// @param beta Second scalar
+/// @param gamma Third scalar
+/// @param x First vector
+/// @param y Second vector
+/// @param z Resulting vector
+void
+axpbypcz(Vector & z, Scalar alpha, Scalar beta, Scalar gamma, const Vector & x, const Vector & y);
 
 } // namespace godzilla

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -251,10 +251,14 @@ public:
     /// @param N global vector length (or PETSC_DETERMINE to have calculated if n is given)
     static Vector create_mpi(MPI_Comm comm, Int n, Int N);
 
-    static void pointwise_min(const Vector & w, const Vector & x, const Vector & y);
-    static void pointwise_max(const Vector & w, const Vector & x, const Vector & y);
-    static void pointwise_mult(const Vector & w, const Vector & x, const Vector & y);
-    static void pointwise_divide(const Vector & w, const Vector & x, const Vector & y);
+    [[deprecated("")]] static void
+    pointwise_min(const Vector & w, const Vector & x, const Vector & y);
+    [[deprecated("")]] static void
+    pointwise_max(const Vector & w, const Vector & x, const Vector & y);
+    [[deprecated("")]] static void
+    pointwise_mult(const Vector & w, const Vector & x, const Vector & y);
+    [[deprecated("")]] static void
+    pointwise_divide(const Vector & w, const Vector & x, const Vector & y);
 
 private:
     Vec vec;
@@ -340,5 +344,10 @@ void maxpy(Vector & y, const std::vector<Scalar> & alpha, const std::vector<Vect
 /// @param z Resulting vector
 void
 axpbypcz(Vector & z, Scalar alpha, Scalar beta, Scalar gamma, const Vector & x, const Vector & y);
+
+void pointwise_min(const Vector & w, const Vector & x, const Vector & y);
+void pointwise_max(const Vector & w, const Vector & x, const Vector & y);
+void pointwise_mult(const Vector & w, const Vector & x, const Vector & y);
+void pointwise_divide(const Vector & w, const Vector & x, const Vector & y);
 
 } // namespace godzilla

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -96,8 +96,8 @@ public:
     /// Computes `this[i] = alpha x[i] + this[i]`
     ///
     /// @param alpha Scalar
-    /// @param x Vetor to scale by `alpha`
-    void axpy(Scalar alpha, const Vector & x);
+    /// @param x Vector to scale by `alpha`
+    [[deprecated("")]] void axpy(Scalar alpha, const Vector & x);
 
     /// Computes `this[i] = alpha x[i] + beta y[i]`
     ///
@@ -291,5 +291,11 @@ void copy(const Vector & x, Vector & y);
 /// @param y Second vector
 /// @return Dot product
 Scalar dot(const Vector & x, const Vector & y);
+
+/// Computes `y[i] = alpha x[i] + y[i]`
+///
+/// @param alpha Scalar
+/// @param x Vector to scale by `alpha`
+void axpy(Vector & y, Scalar alpha, const Vector & x);
 
 } // namespace godzilla

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -117,7 +117,7 @@ public:
     /// @param alpha Scalar
     /// @param x First vector multiplied by `alpha`
     /// @param y Second vector
-    void waxpy(Scalar alpha, const Vector & x, const Vector & y);
+    [[deprecated("")]] void waxpy(Scalar alpha, const Vector & x, const Vector & y);
 
     /// Computes `this = this + \sum_i alpha[i] x[i]`
     ///
@@ -312,5 +312,13 @@ void axpby(Vector & y, Scalar alpha, Scalar beta, const Vector & x);
 /// @param x Unscaled vector
 /// @param y Resulting vector
 void aypx(Vector & y, Scalar beta, const Vector & x);
+
+/// Computes `z[i] = alpha * x[i] + y[i]
+///
+/// @param alpha Scalar
+/// @param x First vector multiplied by `alpha`
+/// @param y Second vector
+/// @param w Resulting vector
+void waxpy(Vector & w, Scalar alpha, const Vector & x, const Vector & y);
 
 } // namespace godzilla

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -104,7 +104,7 @@ public:
     /// @param alpha Scalar
     /// @param beta Scalar
     /// @param x Vector sclaed by `alpha`
-    void axpby(Scalar alpha, Scalar beta, const Vector & x);
+    [[deprecated("")]] void axpby(Scalar alpha, Scalar beta, const Vector & x);
 
     /// Computes `this[i] = x[i] + beta * this[i]`
     ///
@@ -297,5 +297,13 @@ Scalar dot(const Vector & x, const Vector & y);
 /// @param alpha Scalar
 /// @param x Vector to scale by `alpha`
 void axpy(Vector & y, Scalar alpha, const Vector & x);
+
+/// Computes `y[i] = alpha x[i] + beta y[i]`
+///
+/// @param alpha Scalar
+/// @param beta Scalar
+/// @param x Vector scaled by `alpha`
+/// @param y Vector accumulated into
+void axpby(Vector & y, Scalar alpha, Scalar beta, const Vector & x);
 
 } // namespace godzilla

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -125,7 +125,7 @@ public:
     ///
     /// @param alpha Array of scalars
     /// @param x Array of vectors
-    void maxpy(const std::vector<Scalar> & alpha, const std::vector<Vector> & x);
+    [[deprecated("")]] void maxpy(const std::vector<Scalar> & alpha, const std::vector<Vector> & x);
 
     /// Computes `this = alpha * x + beta * y + gamma * this`
     ///
@@ -320,5 +320,13 @@ void aypx(Vector & y, Scalar beta, const Vector & x);
 /// @param y Second vector
 /// @param w Resulting vector
 void waxpy(Vector & w, Scalar alpha, const Vector & x, const Vector & y);
+
+/// Computes `y = y + \sum_i alpha[i] x[i]`
+///
+/// Length of `alpha` and `x` must be the same
+///
+/// @param alpha Array of scalars
+/// @param x Array of vectors
+void maxpy(Vector & y, const std::vector<Scalar> & alpha, const std::vector<Vector> & x);
 
 } // namespace godzilla

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -532,4 +532,11 @@ axpy(Vector & y, Scalar alpha, const Vector & x)
     PETSC_CHECK(VecAXPY(y, alpha, x));
 }
 
+void
+axpby(Vector & y, Scalar alpha, Scalar beta, const Vector & x)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecAXPBY(y, alpha, beta, x));
+}
+
 } // namespace godzilla

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -509,4 +509,13 @@ Vector::copy(const IndexSet & is, ScatterMode mode, Vector & reduced)
     PETSC_CHECK(VecISCopy(this->vec, is, mode, reduced));
 }
 
+Scalar
+dot(const Vector & x, const Vector & y)
+{
+    CALL_STACK_MSG();
+    Scalar val;
+    PETSC_CHECK(VecDot(x, y, &val));
+    return val;
+}
+
 } // namespace godzilla

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -573,4 +573,32 @@ axpbypcz(Vector & z, Scalar alpha, Scalar beta, Scalar gamma, const Vector & x, 
     PETSC_CHECK(VecAXPBYPCZ(z, alpha, beta, gamma, x, y));
 }
 
+void
+pointwise_min(const Vector & w, const Vector & x, const Vector & y)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecPointwiseMin(w, x, y));
+}
+
+void
+pointwise_max(const Vector & w, const Vector & x, const Vector & y)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecPointwiseMax(w, x, y));
+}
+
+void
+pointwise_mult(const Vector & w, const Vector & x, const Vector & y)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecPointwiseMult(w, x, y));
+}
+
+void
+pointwise_divide(const Vector & w, const Vector & x, const Vector & y)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecPointwiseDivide(w, x, y));
+}
+
 } // namespace godzilla

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -566,4 +566,11 @@ maxpy(Vector & y, const std::vector<Scalar> & alpha, const std::vector<Vector> &
     PETSC_CHECK(VecMAXPY(y, n, alpha.data(), xx.data()));
 }
 
+void
+axpbypcz(Vector & z, Scalar alpha, Scalar beta, Scalar gamma, const Vector & x, const Vector & y)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecAXPBYPCZ(z, alpha, beta, gamma, x, y));
+}
+
 } // namespace godzilla

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -518,4 +518,11 @@ dot(const Vector & x, const Vector & y)
     return val;
 }
 
+void
+copy(const Vector & x, Vector & y)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecCopy(x, y));
+}
+
 } // namespace godzilla

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -553,4 +553,17 @@ waxpy(Vector & w, Scalar alpha, const Vector & x, const Vector & y)
     PETSC_CHECK(VecWAXPY(w, alpha, x, y));
 }
 
+void
+maxpy(Vector & y, const std::vector<Scalar> & alpha, const std::vector<Vector> & x)
+{
+    CALL_STACK_MSG();
+    assert(alpha.size() == x.size());
+
+    auto n = alpha.size();
+    std::vector<Vec> xx(n);
+    for (std::size_t i = 0; i < n; ++i)
+        xx[i] = (Vec) x[i];
+    PETSC_CHECK(VecMAXPY(y, n, alpha.data(), xx.data()));
+}
+
 } // namespace godzilla

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -539,4 +539,11 @@ axpby(Vector & y, Scalar alpha, Scalar beta, const Vector & x)
     PETSC_CHECK(VecAXPBY(y, alpha, beta, x));
 }
 
+void
+aypx(Vector & y, Scalar beta, const Vector & x)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecAYPX(y, beta, x));
+}
+
 } // namespace godzilla

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -546,4 +546,11 @@ aypx(Vector & y, Scalar beta, const Vector & x)
     PETSC_CHECK(VecAYPX(y, beta, x));
 }
 
+void
+waxpy(Vector & w, Scalar alpha, const Vector & x, const Vector & y)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecWAXPY(w, alpha, x, y));
+}
+
 } // namespace godzilla

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -525,4 +525,11 @@ copy(const Vector & x, Vector & y)
     PETSC_CHECK(VecCopy(x, y));
 }
 
+void
+axpy(Vector & y, Scalar alpha, const Vector & x)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(VecAXPY(y, alpha, x));
+}
+
 } // namespace godzilla

--- a/test/src/Matrix_test.cpp
+++ b/test/src/Matrix_test.cpp
@@ -224,8 +224,7 @@ TEST(MatrixTest, mult)
     Vector x = Vector::create_seq(MPI_COMM_WORLD, 2);
     x.set_values(std::vector<Int>({ 0, 1 }), { 3, 5 });
 
-    Vector y;
-    x.duplicate(y);
+    auto y = x.duplicate();
 
     m.mult(x, y);
 

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -497,7 +497,7 @@ TEST(VectorTest, pointwise_min)
     y.set_value(0, 3.);
     y.set_value(1, 4.);
 
-    Vector::pointwise_min(w, x, y);
+    pointwise_min(w, x, y);
     EXPECT_DOUBLE_EQ(w(0), 2.);
     EXPECT_DOUBLE_EQ(w(1), 4.);
 
@@ -518,7 +518,7 @@ TEST(VectorTest, pointwise_max)
     y.set_value(0, 3.);
     y.set_value(1, 4.);
 
-    Vector::pointwise_max(w, x, y);
+    pointwise_max(w, x, y);
     EXPECT_DOUBLE_EQ(w(0), 3.);
     EXPECT_DOUBLE_EQ(w(1), 5.);
 
@@ -539,7 +539,7 @@ TEST(VectorTest, pointwise_mult)
     y.set_value(0, 3.);
     y.set_value(1, 4.);
 
-    Vector::pointwise_mult(w, x, y);
+    pointwise_mult(w, x, y);
     EXPECT_DOUBLE_EQ(w(0), 6.);
     EXPECT_DOUBLE_EQ(w(1), 20.);
 
@@ -560,7 +560,7 @@ TEST(VectorTest, pointwise_divide)
     y.set_value(0, 2.);
     y.set_value(1, 3.);
 
-    Vector::pointwise_divide(w, x, y);
+    pointwise_divide(w, x, y);
     EXPECT_DOUBLE_EQ(w(0), 4.);
     EXPECT_DOUBLE_EQ(w(1), 6.);
 

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -475,7 +475,7 @@ TEST(VectorTest, axpbypcz)
     Real alpha = 2.;
     Real beta = 3.;
     Real gamma = 4;
-    w.axpbypcz(alpha, beta, gamma, x, y);
+    axpbypcz(w, alpha, beta, gamma, x, y);
 
     EXPECT_DOUBLE_EQ(w(0), 17.);
     EXPECT_DOUBLE_EQ(w(1), 26.);

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -429,7 +429,7 @@ TEST(VectorTest, waxpy)
     y.set_value(1, 4.);
 
     Vector w = Vector::create_seq(MPI_COMM_WORLD, 2);
-    w.waxpy(3., x, y);
+    waxpy(w, 3., x, y);
     EXPECT_DOUBLE_EQ(w(0), 9.);
     EXPECT_DOUBLE_EQ(w(1), 19.);
 

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -253,8 +253,8 @@ TEST(VectorTest, dot)
     u.set_value(1, 5.);
     u.set_value(2, 2.);
 
-    Scalar dot = v.dot(u);
-    EXPECT_DOUBLE_EQ(dot, 32.);
+    auto dp = dot(v, u);
+    EXPECT_DOUBLE_EQ(dp, 32.);
 
     v.destroy();
     u.destroy();

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -452,7 +452,7 @@ TEST(VectorTest, maxpy)
     w.zero();
     std::vector<Scalar> alpha = { 2, -1 };
     std::vector<Vector> x = { v1, v2 };
-    w.maxpy(alpha, x);
+    maxpy(w, alpha, x);
 
     EXPECT_DOUBLE_EQ(w(0), 1.);
     EXPECT_DOUBLE_EQ(w(1), 6.);

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -204,21 +204,6 @@ TEST(VectorTest, assign)
     v.destroy();
 }
 
-TEST(VectorTest, duplicate)
-{
-    Vector v = Vector::create_seq(MPI_COMM_WORLD, 3);
-    v.set_value(0, 1.);
-    v.set_value(1, 3.);
-    v.set_value(2, 7.);
-    Vector dup;
-    v.duplicate(dup);
-    v.copy(dup);
-    EXPECT_DOUBLE_EQ(dup(0), 1.);
-    EXPECT_DOUBLE_EQ(dup(1), 3.);
-    EXPECT_DOUBLE_EQ(dup(2), 7.);
-    v.destroy();
-}
-
 TEST(VectorTest, duplicate_ret)
 {
     Vector v = Vector::create_seq(MPI_COMM_WORLD, 3);
@@ -503,10 +488,8 @@ TEST(VectorTest, axpbypcz)
 TEST(VectorTest, pointwise_min)
 {
     Vector x = Vector::create_seq(MPI_COMM_WORLD, 2);
-    Vector y;
-    x.duplicate(y);
-    Vector w;
-    x.duplicate(w);
+    Vector y = x.duplicate();
+    Vector w = x.duplicate();
 
     x.set_value(0, 2.);
     x.set_value(1, 5.);
@@ -526,10 +509,8 @@ TEST(VectorTest, pointwise_min)
 TEST(VectorTest, pointwise_max)
 {
     Vector x = Vector::create_seq(MPI_COMM_WORLD, 2);
-    Vector y;
-    x.duplicate(y);
-    Vector w;
-    x.duplicate(w);
+    Vector y = x.duplicate();
+    Vector w = x.duplicate();
 
     x.set_value(0, 2.);
     x.set_value(1, 5.);
@@ -549,10 +530,8 @@ TEST(VectorTest, pointwise_max)
 TEST(VectorTest, pointwise_mult)
 {
     Vector x = Vector::create_seq(MPI_COMM_WORLD, 2);
-    Vector y;
-    x.duplicate(y);
-    Vector w;
-    x.duplicate(w);
+    Vector y = x.duplicate();
+    Vector w = x.duplicate();
 
     x.set_value(0, 2.);
     x.set_value(1, 5.);
@@ -572,10 +551,8 @@ TEST(VectorTest, pointwise_mult)
 TEST(VectorTest, pointwise_divide)
 {
     Vector x = Vector::create_seq(MPI_COMM_WORLD, 2);
-    Vector y;
-    x.duplicate(y);
-    Vector w;
-    x.duplicate(w);
+    Vector y = x.duplicate();
+    Vector w = x.duplicate();
 
     x.set_value(0, 8.);
     x.set_value(1, 18.);

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -211,7 +211,7 @@ TEST(VectorTest, duplicate_ret)
     v.set_value(1, 3.);
     v.set_value(2, 7.);
     Vector dup = v.duplicate();
-    v.copy(dup);
+    copy(v, dup);
     EXPECT_DOUBLE_EQ(dup(0), 1.);
     EXPECT_DOUBLE_EQ(dup(1), 3.);
     EXPECT_DOUBLE_EQ(dup(2), 7.);

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -410,7 +410,7 @@ TEST(VectorTest, aypx)
     x.set_value(0, 2.);
     x.set_value(1, 5.);
 
-    y.aypx(3., x);
+    aypx(y, 3., x);
     EXPECT_DOUBLE_EQ(y(0), 11.);
     EXPECT_DOUBLE_EQ(y(1), 17.);
 

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -376,7 +376,7 @@ TEST(VectorTest, axpy)
     x.set_value(0, 2.);
     x.set_value(1, 5.);
 
-    y.axpy(3., x);
+    axpy(y, 3., x);
     EXPECT_DOUBLE_EQ(y(0), 9.);
     EXPECT_DOUBLE_EQ(y(1), 19.);
     x.destroy();

--- a/test/src/Vector_test.cpp
+++ b/test/src/Vector_test.cpp
@@ -393,7 +393,7 @@ TEST(VectorTest, axpby)
     x.set_value(0, 2.);
     x.set_value(1, 5.);
 
-    y.axpby(3., 4., x);
+    axpby(y, 3., 4., x);
     EXPECT_DOUBLE_EQ(y(0), 18.);
     EXPECT_DOUBLE_EQ(y(1), 31.);
     x.destroy();


### PR DESCRIPTION
- Vector::duplicate(Vector) is deprecated
- Deprecating Vector::dot
- Deprecating Vector::copy
- Deprecating Vector::axpy
- Deprecating Vector::axpby
- Deprecating Vector::aypx
- Deprecating Vector::waxpy
- Deprecating Vector::maxpy
- Deprecating Vector::axpbypcz
- Deprecating Vector::pointwise_xyz
