### PR TITLE
Adding API to support parallel communication

### DIFF
--- a/include/godzilla/DenseVector.h
+++ b/include/godzilla/DenseVector.h
@@ -7,6 +7,7 @@
 #include "godzilla/Types.h"
 #include "godzilla/DenseMatrix.h"
 #include "godzilla/Utils.h"
+#include "mpicpp-lite/mpicpp-lite.h"
 #include <cassert>
 #include <initializer_list>
 #include <type_traits>
@@ -963,3 +964,63 @@ operator<<(std::ostream & os, const DynDenseVector<T> & obj)
 }
 
 } // namespace godzilla
+
+namespace mpicpp_lite {
+
+template <typename T, godzilla::Int D>
+struct DatatypeTraits<godzilla::DenseVector<T, D>> {
+    static MPI_Datatype
+    get()
+    {
+        return type_contiguous(D, mpi_datatype<T>());
+    }
+};
+
+namespace op {
+
+template <typename T, godzilla::Int D>
+struct sum<godzilla::DenseVector<T, D>> :
+    public UserOp<sum<godzilla::DenseVector<T, D>>, godzilla::DenseVector<T, D>> {
+public:
+    godzilla::DenseVector<T, D>
+    operator()(const godzilla::DenseVector<T, D> & x, const godzilla::DenseVector<T, D> & y) const
+    {
+        return x + y;
+    }
+};
+
+template <typename T, godzilla::Int D>
+struct prod<godzilla::DenseVector<T, D>> :
+    public UserOp<prod<godzilla::DenseVector<T, D>>, godzilla::DenseVector<T, D>> {
+public:
+    godzilla::DenseVector<T, D>
+    operator()(const godzilla::DenseVector<T, D> & x, const godzilla::DenseVector<T, D> & y) const
+    {
+        throw godzilla::Exception("Unable to use DenseVector with mpi::op::prod");
+    }
+};
+
+template <typename T, godzilla::Int D>
+struct max<godzilla::DenseVector<T, D>> :
+    public UserOp<max<godzilla::DenseVector<T, D>>, godzilla::DenseVector<T, D>> {
+public:
+    godzilla::DenseVector<T, D>
+    operator()(const godzilla::DenseVector<T, D> & x, const godzilla::DenseVector<T, D> & y) const
+    {
+        throw godzilla::Exception("Unable to use DenseVector with mpi::op::max");
+    }
+};
+
+template <typename T, godzilla::Int D>
+struct min<godzilla::DenseVector<T, D>> :
+    public UserOp<min<godzilla::DenseVector<T, D>>, godzilla::DenseVector<T, D>> {
+public:
+    godzilla::DenseVector<T, D>
+    operator()(const godzilla::DenseVector<T, D> & x, const godzilla::DenseVector<T, D> & y) const
+    {
+        throw godzilla::Exception("Unable to use DenseVector with mpi::op::min");
+    }
+};
+
+} // namespace op
+} // namespace mpicpp_lite

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -472,4 +472,10 @@ global_to_local(DM dm, const Array1D<T> & g, InsertMode mode, Array1D<T> & l)
     sf.broadcast_end(g, l, mpi::op::replace<T>());
 }
 
+/// Creates a DM object with the same topology as the original.
+///
+/// @param dm Data manager
+/// @return Cloned data manager
+DM clone(DM dm);
+
 } // namespace godzilla

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "godzilla/CallStack.h"
 #include "godzilla/Types.h"
 #include "godzilla/Object.h"
 #include "godzilla/PrintInterface.h"
@@ -22,6 +23,8 @@ class Output;
 class FileOutput;
 class Section;
 class StarForest;
+template <typename T>
+class Array1D;
 
 /// Problem
 ///
@@ -385,5 +388,31 @@ Section get_global_section(DM dm);
 ///
 /// @param dm Data manager
 StarForest get_section_star_forest(DM dm);
+
+/// Equivalent of `create_local_vector` but for `Array1D`
+///
+/// @param dm Data manager
+template <typename T>
+Array1D<T>
+create_local_array1d(DM dm)
+{
+    CALL_STACK_MSG();
+    auto section = get_local_section(dm);
+    auto size = section.get_storage_size();
+    return Array1D<T>(size);
+}
+
+/// Equivalent of `create_global_vector` but for `Array1D`
+///
+/// @param dm Data manager
+template <typename T>
+Array1D<T>
+create_global_array1d(DM dm)
+{
+    CALL_STACK_MSG();
+    auto section = get_global_section(dm);
+    auto size = section.get_constrained_storage_size();
+    return Array1D<T>(size);
+}
 
 } // namespace godzilla

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -390,7 +390,7 @@ DiscreteProblemInterface::set_up_auxiliary_dm(DM dm)
     if (get_num_aux_fields() == 0)
         return;
 
-    PETSC_CHECK(DMClone(dm, &this->dm_aux));
+    this->dm_aux = clone(dm);
 
     create_aux_fields();
 

--- a/src/Init.cpp
+++ b/src/Init.cpp
@@ -4,7 +4,11 @@
 #include "godzilla/Init.h"
 #include "godzilla/CallStack.h"
 #include "godzilla/PerfLog.h"
+#include "mpicpp-lite/mpicpp-lite.h"
 #include "petscsys.h"
+#include <mpicpp-lite/impl/Environment.h>
+
+namespace mpi = mpicpp_lite;
 
 namespace godzilla {
 
@@ -36,6 +40,7 @@ Init::Init(int argc, char * argv[])
 
 Init::~Init()
 {
+    mpi::Environment::destroy();
     PetscFinalize();
 }
 

--- a/src/MeshPartitioningOutput.cpp
+++ b/src/MeshPartitioningOutput.cpp
@@ -39,8 +39,7 @@ MeshPartitioningOutput::output_step()
     PETSC_CHECK(PetscViewerHDF5Open(get_comm(), get_file_name().c_str(), FILE_MODE_WRITE, &viewer));
 
     assert(get_problem()->get_dm() != nullptr);
-    DM dmp;
-    PETSC_CHECK(DMClone(get_problem()->get_dm(), &dmp));
+    DM dmp = clone(get_problem()->get_dm());
 
     Int dim;
     PETSC_CHECK(DMGetDimension(dmp, &dim));

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -10,7 +10,6 @@
 #include "godzilla/Output.h"
 #include "godzilla/FileOutput.h"
 #include "godzilla/Section.h"
-#include "godzilla/StarForest.h"
 
 namespace godzilla {
 

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -3,6 +3,7 @@
 
 #include "godzilla/Problem.h"
 #include "godzilla/CallStack.h"
+#include "godzilla/Error.h"
 #include "godzilla/MeshObject.h"
 #include "godzilla/Mesh.h"
 #include "godzilla/Function.h"
@@ -583,6 +584,15 @@ get_section_star_forest(DM dm)
     PetscSF sf;
     PETSC_CHECK(DMGetSectionSF(dm, &sf));
     return { sf };
+}
+
+DM
+clone(DM dm)
+{
+    CALL_STACK_MSG();
+    DM cln;
+    PETSC_CHECK(DMClone(dm, &cln));
+    return cln;
 }
 
 } // namespace godzilla

--- a/test/src/Problem_test.cpp
+++ b/test/src/Problem_test.cpp
@@ -367,8 +367,7 @@ TEST(ProblemTest, loc_glob_arithmetic_type)
     m->set_partitioner(part);
     m->distribute(problem.get_partition_overlap());
 
-    DM dm;
-    PETSC_CHECK(DMClone(problem.get_dm(), &dm));
+    DM dm = clone(problem.get_dm());
     PetscBool simplex = PETSC_TRUE;
     PetscFE fe;
     constexpr int DIM = 1;
@@ -423,8 +422,7 @@ TEST(ProblemTest, loc_glob_arithmetic_type_min_max)
     m->set_partitioner(part);
     m->distribute(problem.get_partition_overlap());
 
-    DM dm;
-    PETSC_CHECK(DMClone(problem.get_dm(), &dm));
+    DM dm = clone(problem.get_dm());
     PetscBool simplex = PETSC_TRUE;
     PetscFE fe;
     constexpr int DIM = 1;
@@ -479,8 +477,7 @@ TEST(ProblemTest, loc_glob_vec_type)
     m->set_partitioner(part);
     m->distribute(problem.get_partition_overlap());
 
-    DM dm;
-    PETSC_CHECK(DMClone(problem.get_dm(), &dm));
+    DM dm = clone(problem.get_dm());
     PetscBool simplex = PETSC_TRUE;
     PetscFE fe;
     constexpr int DIM = 1;


### PR DESCRIPTION
- `DenseVector` can be send over MPI via mpicpp_lite
- Adding `create_{local|global}_array1d`
- Adding `local_to_global` and `global_to_local` that works with `Array1D`
- Adding `clone` for DM
