### PR TITLE
`Terminal` refactoring

### DIFF
--- a/include/godzilla/Error.h
+++ b/include/godzilla/Error.h
@@ -18,10 +18,10 @@ template <typename... T>
 void
 error_print(fmt::format_string<T...> format, T... args)
 {
-    fmt::print(stderr, "{}", Terminal::Color::red);
+    fmt::print(stderr, "{}", Terminal::red);
     fmt::print(stderr, "[ERROR] ");
     fmt::print(stderr, format, std::forward<T>(args)...);
-    fmt::print(stderr, "{}", Terminal::Color::normal);
+    fmt::print(stderr, "{}", Terminal::normal);
     fmt::print(stderr, "\n");
 }
 

--- a/include/godzilla/PrintInterface.h
+++ b/include/godzilla/PrintInterface.h
@@ -101,7 +101,7 @@ public:
         if (level <= this->verbosity_level && this->proc_id == 0) {
             fmt::print(stdout, "{}", clr);
             print_msg(stdout, format, std::forward<T>(args)...);
-            fmt::print(stdout, "{}", Terminal::Color::normal);
+            fmt::print(stdout, "{}", Terminal::normal);
             fmt::print(stdout, "\n");
         }
     }

--- a/include/godzilla/Terminal.h
+++ b/include/godzilla/Terminal.h
@@ -12,32 +12,10 @@ namespace godzilla {
 ///
 class Terminal {
 public:
-    /// Terminal color as a class
+    /// Terminal code as a class
     ///
     /// Classes can be namespaced to avoid name collisions with other packages (like googletest)
     /// We can detect that this is being put into a stream and potentially strip it
-    ///
-    /// @param aclr Control characters representing the color
-    struct Color {
-        explicit Color(const char * aclr);
-        operator const std::string &() const; // NOLINT(google-explicit-constructor)
-        operator const char *() const; // NOLINT(google-explicit-constructor)
-
-    private:
-        std::string str;
-
-    public:
-        static Color black;
-        static Color red;
-        static Color green;
-        static Color yellow;
-        static Color blue;
-        static Color magenta;
-        static Color cyan;
-        static Color white;
-        static Color normal;
-    };
-
     struct Code {
         explicit Code(const char * code);
         operator const std::string &() const; // NOLINT(google-explicit-constructor)
@@ -45,14 +23,18 @@ public:
 
     private:
         std::string str;
-
-    public:
-        static Code erase_screen;
-        static Code erase_line;
-        static Code erase_ln_to_cursor;
-        static Code erase_ln_from_cursor;
     };
 
+    /// Terminal color is a special code
+    struct Color : public Code {
+        explicit Color(const char * code);
+    };
+
+private:
+    /// Number of colors supported by the terminal
+    static unsigned int num_colors;
+
+public:
     /// Query if terminal has colors
     ///
     /// @return true if terminal supports colors
@@ -61,9 +43,22 @@ public:
     /// Set the terminal to use colors
     static void set_colors(bool state);
 
-private:
-    /// Number of colors supported by the terminal
-    static unsigned int num_colors;
+    // Colors
+    static Color black;
+    static Color red;
+    static Color green;
+    static Color yellow;
+    static Color blue;
+    static Color magenta;
+    static Color cyan;
+    static Color white;
+    static Color normal;
+
+    // Erase functions
+    static Code erase_screen;
+    static Code erase_line;
+    static Code erase_ln_to_cursor;
+    static Code erase_ln_from_cursor;
 };
 
 } // namespace godzilla

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -40,17 +40,17 @@ Logger::print() const
     for (auto & entry : this->entries) {
         switch (entry.type) {
         case ERROR:
-            fmt::print(stderr, "{}", Terminal::Color::red);
+            fmt::print(stderr, "{}", Terminal::red);
             break;
         case WARNING:
-            fmt::print(stderr, "{}", Terminal::Color::yellow);
+            fmt::print(stderr, "{}", Terminal::yellow);
             break;
         }
         fmt::print(stderr, entry.text);
-        fmt::print(stderr, "{}\n", Terminal::Color::normal);
+        fmt::print(stderr, "{}\n", Terminal::normal);
     }
 
-    fmt::print(stderr, "{}", Terminal::Color::magenta);
+    fmt::print(stderr, "{}", Terminal::magenta);
     if (this->num_errors > 0)
         fmt::print(stderr, "{} error(s)", this->num_errors);
 
@@ -60,7 +60,7 @@ Logger::print() const
 
         fmt::print(stderr, "{} warning(s)", this->num_warnings);
     }
-    fmt::print(stderr, " found.{}\n", Terminal::Color::normal);
+    fmt::print(stderr, " found.{}\n", Terminal::normal);
 }
 
 } // namespace godzilla

--- a/src/Terminal.cpp
+++ b/src/Terminal.cpp
@@ -5,34 +5,20 @@
 
 namespace godzilla {
 
-Terminal::Color Terminal::Color::black("\33[30m");
-Terminal::Color Terminal::Color::red("\33[31m");
-Terminal::Color Terminal::Color::green("\33[32m");
-Terminal::Color Terminal::Color::yellow("\33[33m");
-Terminal::Color Terminal::Color::blue("\33[34m");
-Terminal::Color Terminal::Color::magenta("\33[35m");
-Terminal::Color Terminal::Color::cyan("\33[36m");
-Terminal::Color Terminal::Color::white("\33[37m");
-Terminal::Color Terminal::Color::normal("\33[39m");
+Terminal::Color Terminal::black("\033[30m");
+Terminal::Color Terminal::red("\033[31m");
+Terminal::Color Terminal::green("\033[32m");
+Terminal::Color Terminal::yellow("\033[33m");
+Terminal::Color Terminal::blue("\033[34m");
+Terminal::Color Terminal::magenta("\033[35m");
+Terminal::Color Terminal::cyan("\033[36m");
+Terminal::Color Terminal::white("\033[37m");
+Terminal::Color Terminal::normal("\033[39m");
 
-Terminal::Code Terminal::Code::erase_screen("\033[2J");
-Terminal::Code Terminal::Code::erase_line("\033[2K");
-Terminal::Code Terminal::Code::erase_ln_to_cursor("\033[1K");
-Terminal::Code Terminal::Code::erase_ln_from_cursor("\033[0K");
-
-Terminal::Color::Color(const char * aclr) : str(aclr) {}
-
-Terminal::Color::operator const std::string &() const
-{
-    return this->str;
-}
-
-Terminal::Color::operator const char *() const
-{
-    return this->str.c_str();
-}
-
-// Terminal::Code
+Terminal::Code Terminal::erase_screen("\033[2J");
+Terminal::Code Terminal::erase_line("\033[2K");
+Terminal::Code Terminal::erase_ln_to_cursor("\033[1K");
+Terminal::Code Terminal::erase_ln_from_cursor("\033[0K");
 
 Terminal::Code::Code(const char * code) : str(code) {}
 
@@ -45,6 +31,10 @@ Terminal::Code::operator const char *() const
 {
     return this->str.c_str();
 }
+
+Terminal::Color::Color(const char * code) : Code(code) {}
+
+// Terminal
 
 bool
 Terminal::has_colors()

--- a/test/src/Terminal_test.cpp
+++ b/test/src/Terminal_test.cpp
@@ -12,51 +12,67 @@ TEST(TerminalTest, colors)
     EXPECT_FALSE(Terminal::has_colors());
 }
 
-TEST(TerminalTest, ostream_operator_w_colors)
+TEST(TerminalTest, ostream_operator_w_colors_color)
 {
     Terminal::set_colors(true);
     std::ostringstream oss;
-    oss << Terminal::Color::red;
-    EXPECT_STREQ(oss.str().c_str(), Terminal::Color::red);
+    oss << Terminal::red;
+    EXPECT_STREQ(oss.str().c_str(), Terminal::red);
 }
 
-TEST(TerminalTest, ostream_operator_wo_colors)
+TEST(TerminalTest, ostream_operator_wo_colors_color)
 {
     Terminal::set_colors(false);
     std::ostringstream oss;
-    oss << Terminal::Color::red;
+    oss << Terminal::red;
     EXPECT_STREQ(oss.str().c_str(), "");
+}
+
+TEST(TerminalTest, ostream_operator_w_colors_code)
+{
+    Terminal::set_colors(true);
+    std::ostringstream oss;
+    oss << Terminal::erase_line;
+    EXPECT_STREQ(oss.str().c_str(), Terminal::erase_line);
+}
+
+TEST(TerminalTest, ostream_operator_wo_colors_code)
+{
+    Terminal::set_colors(false);
+    std::ostringstream oss;
+    oss << Terminal::erase_line;
+    EXPECT_STREQ(oss.str().c_str(), Terminal::erase_line);
 }
 
 TEST(TerminalTest, string_operator)
 {
-    const std::string & r = Terminal::Color::red;
+    const std::string & r = Terminal::red;
     EXPECT_EQ(r, "\33[31m");
 }
 
 TEST(TerminalTest, fmt_formatter)
 {
-    std::string s = fmt::format("{}", Terminal::Color::red);
-    EXPECT_STREQ(s.c_str(), Terminal::Color::red);
+    std::string s = fmt::format("{}", Terminal::red);
+    EXPECT_STREQ(s.c_str(), Terminal::red);
 }
 
 TEST(TerminalTest, color_codes)
 {
-    EXPECT_STREQ(Terminal::Color::black, "\33[30m");
-    EXPECT_STREQ(Terminal::Color::red, "\33[31m");
-    EXPECT_STREQ(Terminal::Color::green, "\33[32m");
-    EXPECT_STREQ(Terminal::Color::yellow, "\33[33m");
-    EXPECT_STREQ(Terminal::Color::blue, "\33[34m");
-    EXPECT_STREQ(Terminal::Color::magenta, "\33[35m");
-    EXPECT_STREQ(Terminal::Color::cyan, "\33[36m");
-    EXPECT_STREQ(Terminal::Color::white, "\33[37m");
-    EXPECT_STREQ(Terminal::Color::normal, "\33[39m");
+    EXPECT_STREQ(Terminal::black, "\33[30m");
+    EXPECT_STREQ(Terminal::red, "\33[31m");
+    EXPECT_STREQ(Terminal::green, "\33[32m");
+    EXPECT_STREQ(Terminal::yellow, "\33[33m");
+    EXPECT_STREQ(Terminal::blue, "\33[34m");
+    EXPECT_STREQ(Terminal::magenta, "\33[35m");
+    EXPECT_STREQ(Terminal::cyan, "\33[36m");
+    EXPECT_STREQ(Terminal::white, "\33[37m");
+    EXPECT_STREQ(Terminal::normal, "\33[39m");
 }
 
 TEST(TerminalTest, codes)
 {
-    EXPECT_STREQ(Terminal::Code::erase_screen, "\033[2J");
-    EXPECT_STREQ(Terminal::Code::erase_line, "\033[2K");
-    EXPECT_STREQ(Terminal::Code::erase_ln_to_cursor, "\033[1K");
-    EXPECT_STREQ(Terminal::Code::erase_ln_from_cursor, "\033[0K");
+    EXPECT_STREQ(Terminal::erase_screen, "\033[2J");
+    EXPECT_STREQ(Terminal::erase_line, "\033[2K");
+    EXPECT_STREQ(Terminal::erase_ln_to_cursor, "\033[1K");
+    EXPECT_STREQ(Terminal::erase_ln_from_cursor, "\033[0K");
 }


### PR DESCRIPTION
- `Color` is now specialization of `Code`
- colors and codes are now just in `Terminal` => less typing and we did not really needed that anyway
