### PR TITLE
Fixing cmake config file

### DIFF
--- a/cmake/godzilla-config.cmake.in
+++ b/cmake/godzilla-config.cmake.in
@@ -1,4 +1,5 @@
 set(GODZILLA_VERSION @PROJECT_VERSION@)
+set(GODZILLA_WITH_TECIOCPP @GODZILLA_WITH_TECIOCPP@)
 
 @PACKAGE_INIT@
 
@@ -9,6 +10,9 @@ include(CMakeFindDependencyMacro)
 find_dependency(fmt)
 find_dependency(mpicpp-lite)
 find_dependency(h5pp)
+if (${GODZILLA_WITH_TECIOCPP})
+    find_dependency(teciocpp)
+endif()
 
 find_library(GODZILLA_LIBRARY NAMES godzilla HINTS ${PACKAGE_PREFIX_DIR}/lib NO_DEFAULT_PATH)
 find_path(GODZILLA_INCLUDE_DIR Godzilla.h HINTS ${PACKAGE_PREFIX_DIR}/include/godzilla)


### PR DESCRIPTION
Find teciocpp if godzilla was built with it. This fixes linking errors
in apps.
