### PR TITLE
Applications can write performance log into a YAML file

### DIFF
--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -8,6 +8,7 @@
 #include "godzilla/Parameters.h"
 #include "godzilla/Factory.h"
 #include "godzilla/PrintInterface.h"
+#include <chrono>
 
 namespace mpi = mpicpp_lite;
 
@@ -202,6 +203,12 @@ protected:
     /// Export parameters into a YAML format
     void export_parameters_yaml() const;
 
+    /// Write performance log
+    ///
+    /// @param file_name File name to write into
+    /// @param run_time Total application run time
+    void write_perf_log(const std::string file_name, std::chrono::duration<double> run_time) const;
+
 private:
     /// Create an input file instance
     virtual InputFile * create_input_file();
@@ -229,6 +236,9 @@ private:
 
     /// Restart file name
     std::string restart_file_name;
+
+    /// Performance log file name
+    std::string perf_log_file_name;
 
     /// YML file with application objects
     InputFile * yml;

--- a/include/godzilla/PerfLog.h
+++ b/include/godzilla/PerfLog.h
@@ -5,6 +5,7 @@
 
 #include "petsclog.h"
 #include <map>
+#include <vector>
 
 #define GODZILLA_PERF_LOG_REGISTER_EVENT(name) perf_log::register_event(name);
 #define GODZILLA_PERF_LOG_EVENT(name) perf_log::ScopedEvent __event__(name);
@@ -89,6 +90,9 @@ class EventInfo {
 public:
     EventInfo(EventID event_id, StageID stage_id);
 
+    /// The flag to print info in summary
+    bool visible() const;
+
     /// Get the number of FLOPS
     ///
     /// @return Number of FLOPS
@@ -103,6 +107,15 @@ public:
     ///
     /// @return Number of times this event was called
     int num_calls() const;
+
+    /// The number of messages in this event
+    LogDouble num_messages() const;
+
+    /// The total message lengths in this event
+    LogDouble messages_length() const;
+
+    /// The number of reductions in this event
+    LogDouble num_reductions() const;
 
 private:
     /// Event information collected by PETSc
@@ -141,7 +154,7 @@ public:
     /// Destroy an event
     ///
     /// This will finish logging the event
-    virtual ~Event();
+    virtual ~Event() = default;
 
     /// Log the beginning of the event
     void begin();
@@ -153,6 +166,12 @@ public:
     ///
     /// @return ID of this event
     EventID get_id() const;
+
+    /// Get event name
+    std::string name() const;
+
+    /// Get event info
+    EventInfo info() const;
 
 private:
     /// Get event ID from event name
@@ -174,5 +193,8 @@ public:
     explicit ScopedEvent(const std::string & name);
     virtual ~ScopedEvent();
 };
+
+/// Return list of events registered by the application
+const std::vector<EventID> & registered_event_ids();
 
 } // namespace godzilla::perf_log

--- a/include/godzilla/Utils.h
+++ b/include/godzilla/Utils.h
@@ -144,6 +144,21 @@ index_of(const std::vector<T> & array, T value)
 /// @return Demangled name
 std::string demangle(const std::string & mangled_name);
 
+/// Safely compute ratio of 2 numbers (avoiding division by zero)
+///
+/// @param num Numerator
+/// @param den Denominator
+/// @return Computed ratio
+template <typename T>
+T
+ratio(T num, T den)
+{
+    if (den != 0.)
+        return num / den;
+    else
+        return 0.;
+}
+
 } // namespace utils
 
 /// Enumerate for iterable containters


### PR DESCRIPTION
- Adding a `perf-log` command line switch to specify the file name
- At the end of execution a YAML file is produced
- Performance log only contains events registered via godzilla API