### PR TITLE
Improving HDF5File interface

### DIFF
--- a/include/godzilla/HDF5File.h
+++ b/include/godzilla/HDF5File.h
@@ -157,6 +157,10 @@ class HDF5File {
 
         Group open_group(const std::string & name);
 
+        bool has_attribute(const std::string & name) const;
+
+        bool has_dataset(const std::string & name) const;
+
         template <typename T>
         void write_attribute(const std::string & name, const T & value);
 
@@ -408,6 +412,24 @@ private:
 inline HDF5File::Group::~Group()
 {
     H5Gclose(this->id);
+}
+
+inline bool
+HDF5File::Group::has_attribute(const std::string & name) const
+{
+    auto res = H5Aexists(this->id, name.c_str());
+    if (res < 0)
+        throw Exception("Failed to check attribute");
+    return res > 0;
+}
+
+inline bool
+HDF5File::Group::has_dataset(const std::string & name) const
+{
+    auto res = H5Lexists(this->id, name.c_str(), H5P_DEFAULT);
+    if (res < 0)
+        throw Exception("Failed to check dataset");
+    return res > 0;
 }
 
 inline HDF5File::Group

--- a/include/godzilla/HDF5File.h
+++ b/include/godzilla/HDF5File.h
@@ -548,6 +548,13 @@ HDF5File::Dataset::read(std::string & data) const
         data = std::string(c_str);
         H5free_memory(c_str);
     }
+    else {
+        size_t size = H5Tget_size(dtype);
+        data.resize(size);
+        auto res = H5Dread(this->id, dtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, data.data());
+        if (res < 0)
+            throw Exception("Error reading dataset");
+    }
     H5Tclose(dtype);
 }
 

--- a/include/godzilla/HDF5File.h
+++ b/include/godzilla/HDF5File.h
@@ -569,7 +569,7 @@ HDF5File::Dataset::read(Int n, T data[])
 {
     auto res = H5Dread(this->id, hdf5::get_datatype<T>(), H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
     if (res < 0)
-        throw Exception("Error writing dataset");
+        throw Exception("Error reading dataset");
 }
 
 template <typename T>

--- a/include/godzilla/HDF5File.h
+++ b/include/godzilla/HDF5File.h
@@ -182,6 +182,12 @@ class HDF5File {
         template <typename T>
         void read_dataset(const std::string & name, Int n, T data[]);
 
+        Dataset
+        get_dataset(const std::string & name) const
+        {
+            return Dataset::open(this->id, name);
+        }
+
     public:
         static Group
         open(hid_t parent_id, const std::string & name)

--- a/include/godzilla/HDF5File.h
+++ b/include/godzilla/HDF5File.h
@@ -302,6 +302,17 @@ class HDF5File {
             return Dataspace(H5Dget_space(this->id));
         }
 
+        std::vector<size_t>
+        get_dimensions() const
+        {
+            auto dspace = get_space();
+            auto d = dspace.get_simple_extent_dims();
+            std::vector<size_t> dims(d.size());
+            for (std::size_t i = 0; i < d.size(); ++i)
+                dims[i] = d[i];
+            return dims;
+        }
+
         const hid_t id;
 
         template <typename T>

--- a/include/godzilla/HDF5File.h
+++ b/include/godzilla/HDF5File.h
@@ -616,6 +616,19 @@ HDF5File::Dataset::read(std::string & data) const
     H5Tclose(dtype);
 }
 
+template <>
+inline void
+HDF5File::Dataset::read(bool & data) const
+{
+    auto dtype = H5Dget_type(this->id);
+    int value;
+    auto res = H5Dread(this->id, dtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, &value);
+    if (res < 0)
+        throw Exception("Error reading dataset");
+    data = value != 0;
+    H5Tclose(dtype);
+}
+
 template <typename T, typename A>
 inline void
 HDF5File::Dataset::read(std::vector<T, A> & data) const
@@ -713,6 +726,19 @@ HDF5File::Attribute::read(std::string & data) const
         if (res < 0)
             throw Exception("Error reading attribute");
     }
+    H5Tclose(dtype);
+}
+
+template <>
+inline void
+HDF5File::Attribute::read(bool & data) const
+{
+    auto dtype = H5Aget_type(this->id);
+    int value;
+    auto res = H5Aread(this->id, dtype, &value);
+    if (res < 0)
+        throw Exception("Error reading attribute");
+    data = value != 0;
     H5Tclose(dtype);
 }
 

--- a/include/godzilla/HDF5File.h
+++ b/include/godzilla/HDF5File.h
@@ -380,6 +380,10 @@ public:
 
     std::string get_file_path() const;
 
+    bool has_attribute(const std::string & name) const;
+
+    bool has_dataset(const std::string & name) const;
+
     template <typename T>
     void write_dataset(const std::string & name, const T & data);
 
@@ -711,6 +715,24 @@ inline HDF5File::Group
 HDF5File::open_group(const std::string & name) const
 {
     return Group::open(this->id, name);
+}
+
+inline bool
+HDF5File::has_attribute(const std::string & name) const
+{
+    auto res = H5Aexists(this->id, name.c_str());
+    if (res < 0)
+        throw Exception("Failed to check attribute");
+    return res > 0;
+}
+
+inline bool
+HDF5File::has_dataset(const std::string & name) const
+{
+    auto res = H5Lexists(this->id, name.c_str(), H5P_DEFAULT);
+    if (res < 0)
+        throw Exception("Failed to check dataset");
+    return res > 0;
 }
 
 template <typename T>

--- a/include/godzilla/HDF5File.h
+++ b/include/godzilla/HDF5File.h
@@ -641,6 +641,13 @@ HDF5File::Attribute::read(std::string & data) const
         data = std::string(str);
         H5free_memory(str);
     }
+    else {
+        size_t size = H5Tget_size(dtype);
+        data.resize(size);
+        auto res = H5Aread(this->id, dtype, data.data());
+        if (res < 0)
+            throw Exception("Error reading attribute");
+    }
     H5Tclose(dtype);
 }
 


### PR DESCRIPTION
- Fixing a typo
- `HDF5File::Dataspace::get_simple_extent_dims` returns `std:vector`
- Allow reading attributes that are fixed-sized strings
- Allow reading datasets that are fixed-sized strings
- Adding `Group::has_{attribute|dataset}`
- Adding `HDF5File::has_{attribute|dataset}`
- Adding `Dataset::get_dimensions`
- Adding `Group::get_dataset`
- Allow reading vector-valued attributes
- HDF5: reading `bool` values needs special care
