### PR TITLE
`create_preconditioner` API returns `Preconditiner` object

### DIFF
--- a/examples/ns-incomp/include/NSIncompressibleProblem.h
+++ b/examples/ns-incomp/include/NSIncompressibleProblem.h
@@ -2,6 +2,7 @@
 
 #include "godzilla/ImplicitFENonlinearProblem.h"
 #include "godzilla/PCFieldSplit.h"
+#include "godzilla/Preconditioner.h"
 #include "godzilla/Types.h"
 
 using namespace godzilla;
@@ -19,7 +20,7 @@ protected:
     void set_up_weak_form() override;
     void set_up_matrix_properties() override;
     void set_up_field_null_space(DM dm) override;
-    void create_preconditioner(PC pc) override;
+    Preconditioner create_preconditioner(PC pc) override;
 
     FieldID velocity_id;
     FieldID pressure_id;

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -2,6 +2,7 @@
 #include "godzilla/FunctionInterface.h"
 #include "NSIncompressibleProblem.h"
 #include "godzilla/PCFieldSplit.h"
+#include "godzilla/Preconditioner.h"
 #include "godzilla/ResidualFunc.h"
 #include "godzilla/JacobianFunc.h"
 #include "godzilla/CallStack.h"
@@ -348,7 +349,7 @@ NSIncompressibleProblem::set_up_field_null_space(DM dm)
     // PETSC_CHECK(MatNullSpaceDestroy(&nsp));
 }
 
-void
+Preconditioner
 NSIncompressibleProblem::create_preconditioner(PC pc)
 {
     CALL_STACK_MSG();
@@ -382,4 +383,6 @@ NSIncompressibleProblem::create_preconditioner(PC pc)
     auto & ksp_press = sub_ksp[this->pressure_id.value()];
     ksp_press.set_tolerances(1.0e-10, PETSC_DEFAULT, PETSC_DEFAULT, PETSC_DEFAULT);
     auto precond_press = ksp_press.set_pc_type<PCJacobi>();
+
+    return this->fsplit;
 }

--- a/include/godzilla/LinearProblem.h
+++ b/include/godzilla/LinearProblem.h
@@ -63,7 +63,7 @@ protected:
     virtual void set_up_matrix_properties();
 
     /// Method for creating a preconditioner
-    virtual void create_preconditioner(PC pc);
+    virtual Preconditioner create_preconditioner(PC pc);
 
     /// Monitor callback
     void monitor(Int it, Real rnorm);

--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -125,7 +125,7 @@ private:
     virtual void set_up_solver_parameters();
 
     /// Method for creating a preconditioner
-    virtual void create_preconditioner(PC pc);
+    virtual Preconditioner create_preconditioner(PC pc);
 
     /// Method for setting matrix properties
     virtual void set_up_matrix_properties();

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -83,7 +83,8 @@ LinearProblem::create()
     init();
     allocate_objects();
     set_up_matrix_properties();
-    create_preconditioner(this->ks.get_pc());
+    this->pcond = create_preconditioner(this->ks.get_pc());
+    this->pcond.inc_reference();
     set_up_solver_parameters();
     set_up_monitors();
     set_up_callbacks();
@@ -183,12 +184,11 @@ LinearProblem::set_up_matrix_properties()
     CALL_STACK_MSG();
 }
 
-void
+Preconditioner
 LinearProblem::create_preconditioner(PC pc)
 {
     CALL_STACK_MSG();
-    this->pcond = Preconditioner(pc);
-    this->pcond.inc_reference();
+    return Preconditioner(pc);
 }
 
 void

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -85,7 +85,8 @@ NonlinearProblem::create()
     init();
     allocate_objects();
     set_up_matrix_properties();
-    create_preconditioner(this->ksp.get_pc());
+    this->pcond = create_preconditioner(this->ksp.get_pc());
+    this->pcond.inc_reference();
     set_up_solver_parameters();
     set_up_line_search();
     set_up_monitors();
@@ -288,12 +289,11 @@ NonlinearProblem::set_up_matrix_properties()
     CALL_STACK_MSG();
 }
 
-void
+Preconditioner
 NonlinearProblem::create_preconditioner(PC pc)
 {
     CALL_STACK_MSG();
-    this->pcond = Preconditioner(pc);
-    this->pcond.inc_reference();
+    return Preconditioner(pc);
 }
 
 void

--- a/test/src/FENonlinearProblemJFNK_test.cpp
+++ b/test/src/FENonlinearProblemJFNK_test.cpp
@@ -3,6 +3,7 @@
 #include "TestApp.h"
 #include "godzilla/LineMesh.h"
 #include "godzilla/FENonlinearProblem.h"
+#include "godzilla/Preconditioner.h"
 #include "godzilla/ResidualFunc.h"
 #include "godzilla/JacobianFunc.h"
 #include "godzilla/ConstantInitialCondition.h"
@@ -23,7 +24,7 @@ protected:
     void set_up_fields() override;
     void set_up_weak_form() override;
     void set_up_solve_type() override;
-    void create_preconditioner(PC pc) override;
+    Preconditioner create_preconditioner(PC pc) override;
 
     const FieldID iu;
 
@@ -106,12 +107,12 @@ GTestFENonlinearProblemJFNK::set_up_solve_type()
     set_use_matrix_free(true, false);
 }
 
-void
+Preconditioner
 GTestFENonlinearProblemJFNK::create_preconditioner(PC pc)
 {
     this->p = PCFactor(pc);
     this->p.set_type(PCFactor::ILU);
-    this->p.inc_reference();
+    return this->p;
 }
 
 } // namespace

--- a/test/src/PCShell_test.cpp
+++ b/test/src/PCShell_test.cpp
@@ -3,6 +3,7 @@
 #include "godzilla/LineMesh.h"
 #include "godzilla/LinearProblem.h"
 #include "godzilla/PCShell.h"
+#include "godzilla/Preconditioner.h"
 #include "godzilla/Problem.h"
 #include "godzilla/Vector.h"
 
@@ -47,13 +48,13 @@ public:
         set_compute_rhs(this, &CustomLinearProblem::compute_rhs);
     }
 
-    void
+    Preconditioner
     create_preconditioner(PC pc) override
     {
         this->pcshell = PCShell(pc);
-        this->pcshell.inc_reference();
         this->pcshell.set_apply(this, &CustomLinearProblem::apply_pc);
         this->pcshell.set_apply_transpose(this, &CustomLinearProblem::apply_transpose_pc);
+        return this->pcshell;
     }
 
     void


### PR DESCRIPTION
- this makes sense
- users no longer have to increase the reference of preconditiner object
  by themselves, we do that for them (yay!)

Closes #798
