### PR TITLE
Removing deprecated API

### DIFF
--- a/include/godzilla/Array1D.h
+++ b/include/godzilla/Array1D.h
@@ -99,15 +99,6 @@ public:
     /// Get number of entries in the array
     ///
     /// @return Number of entries in the array
-    [[deprecated("Use size() instead")]] Int
-    get_size() const
-    {
-        return this->n;
-    }
-
-    /// Get number of entries in the array
-    ///
-    /// @return Number of entries in the array
     Int
     size() const
     {
@@ -132,32 +123,6 @@ public:
         this->n = 0;
     }
 
-    /// Get values from specified indices
-    ///
-    /// @tparam N Size of the index array
-    /// @param idx Indices to get the values from
-    /// @return Vector with the value from locations specified by `idx`
-    template <Int N>
-    [[deprecated("")]] DenseVector<T, N>
-    get_values(DenseVector<Int, N> idx) const
-    {
-        DenseVector<T, N> res;
-        for (Int i = 0; i < N; ++i)
-            res(i) = get(idx(i));
-        return res;
-    }
-
-    template <Int N>
-    [[deprecated("")]] DenseVector<T, N>
-    get_values(const std::vector<Int> & idx) const
-    {
-        assert(N == idx.size());
-        DenseVector<T, N> res;
-        for (Int i = 0; i < N; ++i)
-            res(i) = (*this)(idx[i]);
-        return res;
-    }
-
     /// Assign a value into all vector entries, i.e. `vec[i] = val`
     ///
     /// @param val Value to assign
@@ -167,32 +132,6 @@ public:
         assert(this->data != nullptr);
         for (Int i = 0; i < this->n; ++i)
             this->data[i] = val;
-    }
-
-    /// Set multiple values at specified indices
-    ///
-    /// @tparam N Size of the array
-    /// @param idx Indices where the values are to be set
-    /// @param a Values to be set
-    template <Int N>
-    [[deprecated("")]] void
-    set_values(const DenseVector<Int, N> & idx, const DenseVector<T, N> & a)
-    {
-        for (Int i = 0; i < N; ++i)
-            (*this)(idx(i)) = a(i);
-    }
-
-    /// Add values to specified locations
-    ///
-    /// @tparam N Size of the index and value array
-    /// @param idx Indices to modify
-    /// @param a Vector with values to add at locations specified by `idx`
-    template <Int N>
-    [[deprecated("")]] void
-    add(const DenseVector<Int, N> & idx, const DenseVector<T, N> & a)
-    {
-        for (Int i = 0; i < N; ++i)
-            (*this)(idx(i)) += a(i);
     }
 
     // operators

--- a/include/godzilla/DenseMatrix.h
+++ b/include/godzilla/DenseMatrix.h
@@ -319,15 +319,6 @@ public:
     /// Compute transpose
     ///
     /// @return Transposed matrix
-    [[deprecated("Use transpose() instead")]] DenseMatrix<T, COLS, ROWS>
-    trans() const
-    {
-        return transpose();
-    }
-
-    /// Compute transpose
-    ///
-    /// @return Transposed matrix
     DenseMatrix<T, COLS, ROWS>
     transpose() const
     {
@@ -500,26 +491,6 @@ public:
             for (Int j = 0; j < COLS; ++j)
                 set(i, j) = m(i, j);
         return *this;
-    }
-
-    /// Get access to the underlying data
-    ///
-    /// WARNING: Avoid using this API as much as you can
-    /// @return Pointer to the underlying matrix entries
-    [[deprecated("Use data() instead")]] T *
-    get_data()
-    {
-        return &this->values[0];
-    }
-
-    /// Get access to the underlying data
-    ///
-    /// WARNING: Avoid using this API as much as you can
-    /// @return Pointer to the underlying matrix entries
-    [[deprecated("Use data() instead")]] const T *
-    get_data() const
-    {
-        return &this->values[0];
     }
 
     /// Get access to the underlying data

--- a/include/godzilla/DenseMatrixSymm.h
+++ b/include/godzilla/DenseMatrixSymm.h
@@ -308,18 +308,6 @@ public:
         return mult(x);
     }
 
-    [[deprecated("Use data() instead")]] T *
-    get_data()
-    {
-        return &this->values[0];
-    }
-
-    [[deprecated("Use data() instead")]] const T *
-    get_data() const
-    {
-        return &this->values[0];
-    }
-
     T *
     data()
     {

--- a/include/godzilla/Vector.h
+++ b/include/godzilla/Vector.h
@@ -48,16 +48,10 @@ public:
     void get_values(const std::vector<Int> & idx, std::vector<Scalar> & y) const;
 
     void abs();
-    [[deprecated("")]] Scalar dot(const Vector & y) const;
+
     void scale(Scalar alpha);
 
-    [[deprecated("")]] void duplicate(Vector & b) const;
     Vector duplicate() const;
-
-    /// Copy this vector into `y`
-    ///
-    /// @param y Vector to copy our values into
-    [[deprecated("Message")]] void copy(Vector & y) const;
 
     /// Copies between a reduced vector and the appropriate elements of a full-space vector.
     ///
@@ -94,50 +88,6 @@ public:
     /// @param tol The zero tolerance
     void filter(Real tol);
 #endif
-
-    /// Computes `this[i] = alpha x[i] + this[i]`
-    ///
-    /// @param alpha Scalar
-    /// @param x Vector to scale by `alpha`
-    [[deprecated("")]] void axpy(Scalar alpha, const Vector & x);
-
-    /// Computes `this[i] = alpha x[i] + beta y[i]`
-    ///
-    /// @param alpha Scalar
-    /// @param beta Scalar
-    /// @param x Vector sclaed by `alpha`
-    [[deprecated("")]] void axpby(Scalar alpha, Scalar beta, const Vector & x);
-
-    /// Computes `this[i] = x[i] + beta * this[i]`
-    ///
-    /// @param beta Scalar
-    /// @param x Unscaled vector
-    [[deprecated("")]] void aypx(Scalar beta, const Vector & x);
-
-    /// Computes `this[i] = alpha * x[i] + y[i]
-    ///
-    /// @param alpha Scalar
-    /// @param x First vector multiplied by `alpha`
-    /// @param y Second vector
-    [[deprecated("")]] void waxpy(Scalar alpha, const Vector & x, const Vector & y);
-
-    /// Computes `this = this + \sum_i alpha[i] x[i]`
-    ///
-    /// Length of `alpha` and `x` must be the same
-    ///
-    /// @param alpha Array of scalars
-    /// @param x Array of vectors
-    [[deprecated("")]] void maxpy(const std::vector<Scalar> & alpha, const std::vector<Vector> & x);
-
-    /// Computes `this = alpha * x + beta * y + gamma * this`
-    ///
-    /// @param alpha First scalar
-    /// @param beta Second scalar
-    /// @param gamma Third scalar
-    /// @param x First vector
-    /// @param y Second vector
-    [[deprecated("")]] void
-    axpbypcz(Scalar alpha, Scalar beta, Scalar gamma, const Vector & x, const Vec & y);
 
     void reciprocal();
 
@@ -295,15 +245,6 @@ public:
     /// @param comm The MPI communicator to use
     /// @param vecs The subvectors to be nested
     static NestVector create_nest(MPI_Comm comm, const std::vector<Vector> & vecs);
-
-    [[deprecated("")]] static void
-    pointwise_min(const Vector & w, const Vector & x, const Vector & y);
-    [[deprecated("")]] static void
-    pointwise_max(const Vector & w, const Vector & x, const Vector & y);
-    [[deprecated("")]] static void
-    pointwise_mult(const Vector & w, const Vector & x, const Vector & y);
-    [[deprecated("")]] static void
-    pointwise_divide(const Vector & w, const Vector & x, const Vector & y);
 };
 
 template <Int N>

--- a/src/Vector.cpp
+++ b/src/Vector.cpp
@@ -107,27 +107,11 @@ Vector::abs()
     PETSC_CHECK(VecAbs(this->obj));
 }
 
-Scalar
-Vector::dot(const Vector & y) const
-{
-    CALL_STACK_MSG();
-    Scalar val;
-    PETSC_CHECK(VecDot(this->obj, y.obj, &val));
-    return val;
-}
-
 void
 Vector::scale(Scalar alpha)
 {
     CALL_STACK_MSG();
     PETSC_CHECK(VecScale(this->obj, alpha));
-}
-
-void
-Vector::duplicate(Vector & b) const
-{
-    CALL_STACK_MSG();
-    VecDuplicate(this->obj, &b.obj);
 }
 
 Vector
@@ -136,13 +120,6 @@ Vector::duplicate() const
     Vector dup;
     PETSC_CHECK(VecDuplicate(this->obj, dup));
     return dup;
-}
-
-void
-Vector::copy(Vector & y) const
-{
-    CALL_STACK_MSG();
-    PETSC_CHECK(VecCopy(this->obj, y.obj));
 }
 
 void
@@ -192,54 +169,6 @@ Vector::filter(Real tol)
     PETSC_CHECK(VecFilter(this->obj, tol));
 }
 #endif
-
-void
-Vector::axpy(Scalar alpha, const Vector & x)
-{
-    CALL_STACK_MSG();
-    PETSC_CHECK(VecAXPY(this->obj, alpha, x));
-}
-
-void
-Vector::axpby(Scalar alpha, Scalar beta, const Vector & x)
-{
-    CALL_STACK_MSG();
-    PETSC_CHECK(VecAXPBY(this->obj, alpha, beta, x));
-}
-
-void
-Vector::aypx(Scalar beta, const Vector & x)
-{
-    CALL_STACK_MSG();
-    PETSC_CHECK(VecAYPX(this->obj, beta, x));
-}
-
-void
-Vector::waxpy(Scalar alpha, const Vector & x, const Vector & y)
-{
-    CALL_STACK_MSG();
-    PETSC_CHECK(VecWAXPY(this->obj, alpha, x, y));
-}
-
-void
-Vector::maxpy(const std::vector<Scalar> & alpha, const std::vector<Vector> & x)
-{
-    CALL_STACK_MSG();
-    if (alpha.size() == x.size()) {
-        auto n = alpha.size();
-        std::vector<Vec> xx(n);
-        for (std::size_t i = 0; i < n; ++i)
-            xx[i] = (Vec) x[i];
-        PETSC_CHECK(VecMAXPY(this->obj, n, alpha.data(), xx.data()));
-    }
-}
-
-void
-Vector::axpbypcz(Scalar alpha, Scalar beta, Scalar gamma, const Vector & x, const Vec & y)
-{
-    CALL_STACK_MSG();
-    PETSC_CHECK(VecAXPBYPCZ(this->obj, alpha, beta, gamma, x, y));
-}
 
 void
 Vector::reciprocal()
@@ -474,34 +403,6 @@ Vector::create_nest(MPI_Comm comm, const std::vector<Vector> & vecs)
     NestVector y;
     PETSC_CHECK(VecCreateNest(comm, vecs.size(), nullptr, vvs.data(), y));
     return y;
-}
-
-void
-Vector::pointwise_min(const Vector & w, const Vector & x, const Vector & y)
-{
-    CALL_STACK_MSG();
-    PETSC_CHECK(VecPointwiseMin(w, x, y));
-}
-
-void
-Vector::pointwise_max(const Vector & w, const Vector & x, const Vector & y)
-{
-    CALL_STACK_MSG();
-    PETSC_CHECK(VecPointwiseMax(w, x, y));
-}
-
-void
-Vector::pointwise_mult(const Vector & w, const Vector & x, const Vector & y)
-{
-    CALL_STACK_MSG();
-    PETSC_CHECK(VecPointwiseMult(w, x, y));
-}
-
-void
-Vector::pointwise_divide(const Vector & w, const Vector & x, const Vector & y)
-{
-    CALL_STACK_MSG();
-    PETSC_CHECK(VecPointwiseDivide(w, x, y));
 }
 
 void


### PR DESCRIPTION
- Removing deprecated methods from Array1D
- Removing deprecated methods from `DenseMatrix`
- Removing deprecated methods from DenseMatrixSymm
- Removing deprecated methods from `Vector`
