### PR TITLE
Do not register custom MPI datatype for DenseVector<T, 1>

### DIFF
--- a/include/godzilla/DenseVector.h
+++ b/include/godzilla/DenseVector.h
@@ -971,11 +971,28 @@ operator<<(std::ostream & os, const DynDenseVector<T> & obj)
 
 namespace mpicpp_lite {
 
+template <>
+inline MPI_Datatype
+mpi_datatype<godzilla::DenseVector<godzilla::Real, 1>>()
+{
+    return mpi_datatype<godzilla::Real>();
+}
+
+template <>
+inline MPI_Datatype
+mpi_datatype<godzilla::DenseVector<godzilla::Int, 1>>()
+{
+    return mpi_datatype<godzilla::Int>();
+}
+
 template <typename T, godzilla::Int D>
 struct DatatypeTraits<godzilla::DenseVector<T, D>> {
     static MPI_Datatype
     get()
     {
+        // D=1 hoses up MPI internally, so we need to prevent the code from compiling.
+        // for D=1, use `mpi_datatype` instead.
+        static_assert(D > 1);
         return type_contiguous(D, mpi_datatype<T>());
     }
 };


### PR DESCRIPTION
We need to use `mpi_datatype` for DenseVector<T, 1> rather then `type_contiguous(1, mpi_datatype<T>())`, which seems to fubar MPI internally and it starts to see things like `double` as the custom defined type and that's when things break interestingly.

We prevent the code from compiling when somebody tries to use `DenseVector<T, 1>`. We use `mpi_datatype` for `DenseVector<Int, 1>` and `DenseVector<Real, 1>` which covers our current needs.