### PR TITLE
Adopting Ptr/Qtr

### DIFF
--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -8,7 +8,9 @@
 #include "godzilla/Parameters.h"
 #include "godzilla/Factory.h"
 #include "godzilla/PrintInterface.h"
+#include "godzilla/Ptr.h"
 #include "godzilla/Qtr.h"
+#include "godzilla/Logger.h"
 #include <chrono>
 
 namespace mpi = mpicpp_lite;
@@ -17,7 +19,6 @@ namespace godzilla {
 
 class Problem;
 class InputFile;
-class Logger;
 
 class App : public PrintInterface {
 public:
@@ -70,7 +71,7 @@ public:
     /// Get logger associated with the application
     ///
     /// @return Logger
-    Logger * get_logger() const;
+    Ptr<Logger> get_logger();
 
     /// Get Application name
     ///
@@ -224,7 +225,7 @@ private:
     Registry & registry;
 
     /// Log with errors and/or warnings
-    Logger * logger;
+    Ptr<Logger> logger;
 
     /// Command line arguments
     std::vector<std::string> args;

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -6,6 +6,7 @@
 #include "godzilla/Types.h"
 #include "godzilla/Qtr.h"
 #include "godzilla/Ptr.h"
+#include "godzilla/Qtr.h"
 #include "godzilla/Label.h"
 #include "godzilla/UnstructuredMesh.h"
 #include "godzilla/Problem.h"

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -5,6 +5,7 @@
 
 #include "godzilla/Types.h"
 #include "godzilla/Qtr.h"
+#include "godzilla/Ptr.h"
 #include "godzilla/Label.h"
 #include "godzilla/UnstructuredMesh.h"
 #include "godzilla/Problem.h"
@@ -464,7 +465,7 @@ private:
     UnstructuredMesh * unstr_mesh;
 
     /// Logger object
-    Logger * logger;
+    Ptr<Logger> logger;
 
     /// Object that manages a discrete system
     PetscDS ds;

--- a/include/godzilla/LoggingInterface.h
+++ b/include/godzilla/LoggingInterface.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "godzilla/Ptr.h"
 #include "godzilla/Logger.h"
 
 namespace godzilla {
@@ -11,7 +12,7 @@ namespace godzilla {
 ///
 class LoggingInterface {
 public:
-    explicit LoggingInterface(Logger * alogger, std::string aprefix = "") :
+    explicit LoggingInterface(Ptr<Logger> alogger, std::string aprefix = "") :
         logger(alogger),
         prefix(std::move(aprefix))
     {
@@ -43,7 +44,7 @@ public:
 
 private:
     /// Logger object
-    Logger * logger;
+    Ptr<Logger> logger;
 
     /// Prefix for each logger line
     std::string prefix;

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -58,7 +58,7 @@ App::App(const mpi::Communicator & comm,
     name(name),
     mpi_comm(comm),
     registry(godzilla::registry),
-    logger(new Logger()),
+    logger(Ptr<Logger>::alloc()),
     cmdln_opts(name),
     verbosity_level(1),
     yml(nullptr),
@@ -78,7 +78,7 @@ App::App(const mpi::Communicator & comm,
     name(name),
     mpi_comm(comm),
     registry(godzilla::registry),
-    logger(new Logger()),
+    logger(Ptr<Logger>::alloc()),
     args(args),
     cmdln_opts(name),
     verbosity_level(1),
@@ -97,7 +97,7 @@ App::App(const mpi::Communicator & comm,
     name(name),
     mpi_comm(comm),
     registry(registry),
-    logger(new Logger()),
+    logger(Ptr<Logger>::alloc()),
     cmdln_opts(name),
     verbosity_level(1),
     yml(nullptr),
@@ -118,7 +118,7 @@ App::App(const mpi::Communicator & comm,
     name(name),
     mpi_comm(comm),
     registry(registry),
-    logger(new Logger()),
+    logger(Ptr<Logger>::alloc()),
     args(args),
     cmdln_opts(name),
     verbosity_level(1),
@@ -132,7 +132,6 @@ App::App(const mpi::Communicator & comm,
 App::~App()
 {
     CALL_STACK_MSG();
-    delete this->logger;
     this->factory.destroy();
 }
 
@@ -151,8 +150,8 @@ App::get_version() const
     return ver;
 }
 
-Logger *
-App::get_logger() const
+Ptr<Logger>
+App::get_logger()
 {
     CALL_STACK_MSG();
     return this->logger;

--- a/test/src/RZSymmetry_test.cpp
+++ b/test/src/RZSymmetry_test.cpp
@@ -35,7 +35,7 @@ TEST(RZSymmetryTest, check_dim)
     rz.create();
 
     testing::internal::CaptureStderr();
-    auto * logger = app.get_logger();
+    auto logger = app.get_logger();
     if (logger->get_num_entries() > 0)
         logger->print();
     auto stdout = testing::internal::GetCapturedStderr();
@@ -72,7 +72,7 @@ TEST(RZSymmetryTest, check_compatible)
     rz.create();
 
     testing::internal::CaptureStderr();
-    auto * logger = app.get_logger();
+    auto logger = app.get_logger();
     if (logger->get_num_entries() > 0)
         logger->print();
     auto stdout = testing::internal::GetCapturedStderr();


### PR DESCRIPTION
- `Logger` is stored as `Ptr`
- BC delegates in `DiscreteProblemInterface` are stored as `Qtr`
