### PR TITLE
Fixing orientation of TET4 elements

### DIFF
--- a/include/godzilla/FEBoundary.h
+++ b/include/godzilla/FEBoundary.h
@@ -265,14 +265,16 @@ private:
     {
         CALL_STACK_MSG();
         for (Int i = 0; i < this->facets.get_local_size(); ++i) {
-            auto face_conn = this->mesh->get_connectivity(this->facets(i));
-            auto support = this->mesh->get_support(this->facets(i));
+            auto facet = this->facets(i);
+            auto face_conn = this->mesh->get_connectivity(facet);
+            auto support = this->mesh->get_support(facet);
             Int ie = support[0];
-            Real volume = this->mesh->compute_cell_volume(ie);
-            auto elem_conn = this->mesh->get_connectivity(ie);
-            Int local_idx = get_local_face_index(elem_conn, face_conn);
+            auto cone = this->mesh->get_cone(ie);
+            auto local_face_idx = utils::index_of(cone, facet);
+            auto grad_fn_idx = fe::get_grad_fn_index<ELEM_TYPE, DIM, N_ELEM_NODES>(local_face_idx);
+            auto volume = this->mesh->compute_cell_volume(ie);
             auto edge_length = this->lengths(i);
-            auto grad = DenseVector<Real, DIM>(calc_grad_shape(ie, volume).column(local_idx));
+            DenseVector<Real, DIM> grad(calc_grad_shape(ie, volume).column(grad_fn_idx));
             this->normals(i) = fe::normal<ELEM_TYPE>(volume, edge_length, grad);
         }
     }

--- a/include/godzilla/FEGeometry.h
+++ b/include/godzilla/FEGeometry.h
@@ -219,21 +219,6 @@ calc_nodal_radius<AXISYMMETRIC, 2>(const Array1D<DenseVector<Real, 2>> & coords)
     return rad;
 }
 
-/// Get local vertex index
-///
-/// @param conn Element connectivity array
-/// @param vertex Vertex index
-/// @return
-inline Int
-get_local_vertex_index(const std::vector<Int> & conn, Int vertex)
-{
-    CALL_STACK_MSG();
-    for (std::size_t i = 0; i < conn.size(); ++i)
-        if (conn[i] == vertex)
-            return i;
-    throw Exception("Vertex {} is not part of the connectivity array.", vertex);
-}
-
 /// Get local face index
 ///
 /// @param elem_conn Element connectivity array
@@ -254,6 +239,43 @@ get_local_face_index(const std::vector<Int> & elem_conn, const std::vector<Int> 
     assert(diff.size() == 1);
     auto it = std::find(elem_conn.begin(), elem_conn.end(), diff[0]);
     return std::distance(elem_conn.begin(), it);
+}
+
+template <ElementType ELEM_TYPE, Int DIM, Int N_ELEM_NODES = get_num_element_nodes(ELEM_TYPE)>
+inline Int
+get_grad_fn_index(Int facet_idx)
+{
+    throw NotImplementedException(
+        "get_grad_fn_index is not implemented for {} element in {} dimensions",
+        conv::to_str(ELEM_TYPE),
+        DIM);
+}
+
+template <>
+inline Int
+get_grad_fn_index<EDGE2, 1, 2>(Int facet_idx)
+{
+    static std::array<Int, 2> grad_fn_index = { 1, 0 };
+    assert(facet_idx >= 0 && facet_idx < 2);
+    return grad_fn_index[facet_idx];
+}
+
+template <>
+inline Int
+get_grad_fn_index<TRI3, 2, 3>(Int facet_idx)
+{
+    static std::array<Int, 3> grad_fn_index = { 2, 0, 1 };
+    assert(facet_idx >= 0 && facet_idx < 3);
+    return grad_fn_index[facet_idx];
+}
+
+template <>
+inline Int
+get_grad_fn_index<TET4, 3, 4>(Int facet_idx)
+{
+    static std::array<Int, 4> grad_fn_index = { 3, 2, 1, 0 };
+    assert(facet_idx >= 0 && facet_idx < 4);
+    return grad_fn_index[facet_idx];
 }
 
 } // namespace fe

--- a/include/godzilla/FEShapeFns.h
+++ b/include/godzilla/FEShapeFns.h
@@ -92,20 +92,20 @@ grad_shape<TET4, 3>(const DenseMatrix<Real, 4, 3> & coords, Real volume)
     auto z4 = coords(3, 2);
 
     DenseMatrix<Real, 3, 4> grads;
-    auto ddx1 = -y2 * z3 + y2 * z4 + y3 * z2 - y3 * z4 - y4 * z2 + y4 * z3;
-    auto ddx2 = y1 * z3 - y1 * z4 - y3 * z1 + y3 * z4 + y4 * z1 - y4 * z3;
-    auto ddx3 = -y1 * z2 + y1 * z4 + y2 * z1 - y2 * z4 - y4 * z1 + y4 * z2;
-    auto ddx4 = y1 * z2 - y1 * z3 - y2 * z1 + y2 * z3 + y3 * z1 - y3 * z2;
+    auto ddx1 = y2 * z3 - y2 * z4 - y3 * z2 + y3 * z4 + y4 * z2 - y4 * z3;
+    auto ddx2 = -y1 * z3 + y1 * z4 + y3 * z1 - y3 * z4 - y4 * z1 + y4 * z3;
+    auto ddx3 = -y2 * z1 + y2 * z4 + y1 * z2 - y1 * z4 - y4 * z2 + y4 * z1;
+    auto ddx4 = y2 * z1 - y2 * z3 - y1 * z2 + y1 * z3 + y3 * z2 - y3 * z1;
 
-    auto ddy1 = x2 * z3 - x2 * z4 - x3 * z2 + x3 * z4 + x4 * z2 - x4 * z3;
-    auto ddy2 = -x1 * z3 + x1 * z4 + x3 * z1 - x3 * z4 - x4 * z1 + x4 * z3;
-    auto ddy3 = x1 * z2 - x1 * z4 - x2 * z1 + x2 * z4 + x4 * z1 - x4 * z2;
-    auto ddy4 = -x1 * z2 + x1 * z3 + x2 * z1 - x2 * z3 - x3 * z1 + x3 * z2;
+    auto ddy1 = -x2 * z3 + x2 * z4 + x3 * x2 - x3 * z4 - x4 * x2 + x4 * z3;
+    auto ddy2 = x1 * z3 - x1 * z4 - x3 * z1 + x3 * z4 + x4 * z1 - x4 * z3;
+    auto ddy3 = x2 * z1 - x2 * z4 - x1 * z2 + x1 * z4 + x4 * z2 - x4 * z1;
+    auto ddy4 = -x2 * z1 + x2 * z3 + x1 * z2 - x1 * z3 - x3 * z2 + x3 * z1;
 
-    auto ddz1 = -x2 * y3 + x2 * y4 + x3 * y2 - x3 * y4 - x4 * y2 + x4 * y3;
-    auto ddz2 = x1 * y3 - x1 * y4 - x3 * y1 + x3 * y4 + x4 * y1 - x4 * y3;
-    auto ddz3 = -x1 * y2 + x1 * y4 + x2 * y1 - x2 * y4 - x4 * y1 + x4 * y2;
-    auto ddz4 = x1 * y2 - x1 * y3 - x2 * y1 + x2 * y3 + x3 * y1 - x3 * y2;
+    auto ddz1 = x2 * y3 - x2 * y4 - x3 * y2 + x3 * y4 + x4 * y2 - x4 * y3;
+    auto ddz2 = -x1 * y3 + x1 * y4 + x3 * y1 - x3 * y4 - x4 * y1 + x4 * y3;
+    auto ddz3 = -x2 * y1 + x2 * y4 + x1 * y2 - x1 * y4 - x4 * y2 + x4 * y1;
+    auto ddz4 = x2 * y1 - x2 * y3 - x1 * y2 + x1 * y3 + x3 * y2 - x3 * y1;
 
     grads.set_col(0, { ddx1, ddy1, ddz1 });
     grads.set_col(1, { ddx2, ddy2, ddz2 });

--- a/include/godzilla/FEVolumes.h
+++ b/include/godzilla/FEVolumes.h
@@ -86,8 +86,8 @@ volume<TET4, 3>(const DenseMatrix<Real, 4, 3> & coords)
     auto y4 = coords(3, 1);
     auto z4 = coords(3, 2);
 
-    DenseVector<Real, 3> v0({ x2 - x1, y2 - y1, z2 - z1 });
-    DenseVector<Real, 3> v1({ x3 - x1, y3 - y1, z3 - z1 });
+    DenseVector<Real, 3> v0({ x1 - x2, y1 - y2, z1 - z2 });
+    DenseVector<Real, 3> v1({ x3 - x2, y3 - y2, z3 - z2 });
     DenseVector<Real, 3> v2({ x4 - x1, y4 - y1, z4 - z1 });
 
     return (1. / 6.) * dot(cross_product(v0, v1), v2);

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -515,7 +515,7 @@ DGProblemInterface::set_up_section_constraint_indicies(Section & section)
                     auto n_nodes_per_elem = (Int) econn.size();
                     std::vector<Int> indices;
                     for (std::size_t j = 0; j < fconn.size(); ++j) {
-                        auto local_node_idx = fe::get_local_vertex_index(econn, fconn[j]);
+                        auto local_node_idx = utils::index_of(econn, fconn[j]);
                         for (std::size_t k = 0; k < components.size(); ++k) {
                             auto c = components[k];
                             indices.push_back((c * n_nodes_per_elem) + local_node_idx);

--- a/test/common/TestMesh3D.cpp
+++ b/test/common/TestMesh3D.cpp
@@ -15,7 +15,7 @@ Qtr<Mesh>
 TestMesh3D::create_mesh()
 {
     const Int N_ELEM_NODES = 4;
-    std::vector<Int> cells = { 0, 1, 2, 3 };
+    std::vector<Int> cells = { 1, 0, 2, 3 };
     std::vector<Real> coords = { 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1 };
     auto m = UnstructuredMesh::build_from_cell_list(get_comm(),
                                                     3_D,
@@ -31,8 +31,8 @@ TestMesh3D::create_mesh()
 
     create_side_set(m, face_sets, 1, { 6 }, "front");
     create_side_set(m, face_sets, 2, { 5 }, "bottom");
-    create_side_set(m, face_sets, 3, { 7 }, "left");
-    create_side_set(m, face_sets, 4, { 8 }, "slanted");
+    create_side_set(m, face_sets, 3, { 7 }, "slanted");
+    create_side_set(m, face_sets, 4, { 8 }, "left");
 
     std::map<Int, std::string> face_set_names;
     face_set_names[1] = "front";

--- a/test/src/FEBoundary3D_test.cpp
+++ b/test/src/FEBoundary3D_test.cpp
@@ -1,6 +1,8 @@
 #include "gmock/gmock.h"
+#include <cstdio>
 #include "TestApp.h"
 #include "TestMesh3D.h"
+#include "godzilla/FileMesh.h"
 #include "godzilla/UnstructuredMesh.h"
 #include "godzilla/MeshObject.h"
 #include "godzilla/FEGeometry.h"
@@ -163,7 +165,7 @@ TEST(FEBoundaryTest, test_3d)
 
         EXPECT_DOUBLE_EQ(bnd.facet_area(0), 0.5 * std::sqrt(3));
 
-        EXPECT_EQ(bnd.vals(0), 8);
+        EXPECT_EQ(bnd.vals(0), 7);
 
         bnd.destroy();
     }

--- a/test/src/FEGeometry_test.cpp
+++ b/test/src/FEGeometry_test.cpp
@@ -1,5 +1,6 @@
 #include "gmock/gmock.h"
 #include "godzilla/DenseMatrix.h"
+#include "godzilla/Enums.h"
 #include "godzilla/FEGeometry.h"
 #include "godzilla/FEShapeFns.h"
 #include "godzilla/FEVolumes.h"
@@ -212,20 +213,31 @@ TEST(FEGeometryTest, calc_nodal_radius_rz_tri3)
     EXPECT_DOUBLE_EQ(rad(2), 1.);
 }
 
-TEST(FEGeometryTest, get_local_vertex_index)
-{
-    std::vector<Int> elem = { 2, 7, 4 };
-    EXPECT_EQ(fe::get_local_vertex_index(elem, 2), 0);
-    EXPECT_EQ(fe::get_local_vertex_index(elem, 7), 1);
-    EXPECT_EQ(fe::get_local_vertex_index(elem, 4), 2);
-    EXPECT_THROW_MSG(fe::get_local_vertex_index(elem, 0),
-                     "Vertex 0 is not part of the connectivity array.");
-}
-
 TEST(FEGeometryTest, get_local_face_index)
 {
     std::vector<Int> elem = { 2, 4, 7 };
     EXPECT_EQ(fe::get_local_face_index(elem, { 2, 4 }), 2);
     EXPECT_EQ(fe::get_local_face_index(elem, { 4, 7 }), 0);
     EXPECT_EQ(fe::get_local_face_index(elem, { 7, 2 }), 1);
+}
+
+TEST(FEGeometryTest, get_grad_fn_index_edge2)
+{
+    EXPECT_EQ((fe::get_grad_fn_index<EDGE2, 1, 2>(0)), 1);
+    EXPECT_EQ((fe::get_grad_fn_index<EDGE2, 1, 2>(1)), 0);
+}
+
+TEST(FEGeometryTest, get_grad_fn_index_tri3)
+{
+    EXPECT_EQ((fe::get_grad_fn_index<TRI3, 2, 3>(0)), 2);
+    EXPECT_EQ((fe::get_grad_fn_index<TRI3, 2, 3>(1)), 0);
+    EXPECT_EQ((fe::get_grad_fn_index<TRI3, 2, 3>(2)), 1);
+}
+
+TEST(FEGeometryTest, get_grad_fn_index_tet4)
+{
+    EXPECT_EQ((fe::get_grad_fn_index<TET4, 3, 4>(0)), 3);
+    EXPECT_EQ((fe::get_grad_fn_index<TET4, 3, 4>(1)), 2);
+    EXPECT_EQ((fe::get_grad_fn_index<TET4, 3, 4>(2)), 1);
+    EXPECT_EQ((fe::get_grad_fn_index<TET4, 3, 4>(3)), 0);
 }

--- a/test/src/FEShapeFns_test.cpp
+++ b/test/src/FEShapeFns_test.cpp
@@ -35,18 +35,18 @@ TEST(FEShapeFns, grad_shape_tri3)
 TEST(FEShapeFns, grad_shape_tet4)
 {
     DenseMatrix<Real, 4, 3> coords;
-    coords.set_row(0, { 0, 0, 0 });
-    coords.set_row(1, { 1, 0, 0 });
+    coords.set_row(0, { 1, 0, 0 });
+    coords.set_row(1, { 0, 0, 0 });
     coords.set_row(2, { 0, 1, 0 });
     coords.set_row(3, { 0, 0, 1 });
     Real volume = fe::volume<TET4>(coords);
     auto grads = fe::grad_shape<TET4, 3>(coords, volume);
-    EXPECT_DOUBLE_EQ(grads(0, 0), -1);
-    EXPECT_DOUBLE_EQ(grads(1, 0), -1);
-    EXPECT_DOUBLE_EQ(grads(2, 0), -1);
-    EXPECT_DOUBLE_EQ(grads(0, 1), 1);
-    EXPECT_DOUBLE_EQ(grads(1, 1), 0);
-    EXPECT_DOUBLE_EQ(grads(2, 1), 0);
+    EXPECT_DOUBLE_EQ(grads(0, 0), 1);
+    EXPECT_DOUBLE_EQ(grads(1, 0), 0);
+    EXPECT_DOUBLE_EQ(grads(2, 0), 0);
+    EXPECT_DOUBLE_EQ(grads(0, 1), -1);
+    EXPECT_DOUBLE_EQ(grads(1, 1), -1);
+    EXPECT_DOUBLE_EQ(grads(2, 1), -1);
     EXPECT_DOUBLE_EQ(grads(0, 2), 0);
     EXPECT_DOUBLE_EQ(grads(1, 2), 1);
     EXPECT_DOUBLE_EQ(grads(2, 2), 0);

--- a/test/src/FEVolumes_test.cpp
+++ b/test/src/FEVolumes_test.cpp
@@ -33,8 +33,8 @@ TEST(FEVolumesTest, volume_tri3)
 TEST(FEVolumesTest, volume_tet4)
 {
     DenseMatrix<Real, 4, 3> coords;
-    coords.set_row(0, { 0., 0., 0 });
-    coords.set_row(1, { 1., 0., 0 });
+    coords.set_row(0, { 1., 0., 0 });
+    coords.set_row(1, { 0., 0., 0 });
     coords.set_row(2, { 0., 1., 0. });
     coords.set_row(3, { 0., 0., 1. });
     EXPECT_EQ(fe::volume<TET4>(coords), 1. / 6.);

--- a/test/src/NaturalBoundaryInfo_test.cpp
+++ b/test/src/NaturalBoundaryInfo_test.cpp
@@ -125,11 +125,53 @@ TEST(NaturalBoundaryTest, test_3d)
         TestBoundary3D bnd(m, bnd_facets);
         bnd.create();
         EXPECT_DOUBLE_EQ(bnd.num_facets(), 1);
-        EXPECT_DOUBLE_EQ(bnd.facet(0), 7);
+        EXPECT_DOUBLE_EQ(bnd.facet(0), 8);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(0), -1);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(1), 0);
         EXPECT_DOUBLE_EQ(bnd.normal(0)(2), 0);
         EXPECT_DOUBLE_EQ(bnd.facet_length(0), 0.5);
+        bnd.destroy();
+    }
+
+    {
+        auto label = m->get_label("bottom");
+        auto bnd_facets = points_from_label(label);
+        TestBoundary3D bnd(m, bnd_facets);
+        bnd.create();
+        EXPECT_DOUBLE_EQ(bnd.num_facets(), 1);
+        EXPECT_DOUBLE_EQ(bnd.facet(0), 5);
+        EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 0);
+        EXPECT_DOUBLE_EQ(bnd.normal(0)(1), 0);
+        EXPECT_DOUBLE_EQ(bnd.normal(0)(2), -1);
+        EXPECT_DOUBLE_EQ(bnd.facet_length(0), 0.5);
+        bnd.destroy();
+    }
+
+    {
+        auto label = m->get_label("front");
+        auto bnd_facets = points_from_label(label);
+        TestBoundary3D bnd(m, bnd_facets);
+        bnd.create();
+        EXPECT_DOUBLE_EQ(bnd.num_facets(), 1);
+        EXPECT_DOUBLE_EQ(bnd.facet(0), 6);
+        EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 0);
+        EXPECT_DOUBLE_EQ(bnd.normal(0)(1), -1);
+        EXPECT_DOUBLE_EQ(bnd.normal(0)(2), 0);
+        EXPECT_DOUBLE_EQ(bnd.facet_length(0), 0.5);
+        bnd.destroy();
+    }
+
+    {
+        auto label = m->get_label("slanted");
+        auto bnd_facets = points_from_label(label);
+        TestBoundary3D bnd(m, bnd_facets);
+        bnd.create();
+        EXPECT_DOUBLE_EQ(bnd.num_facets(), 1);
+        EXPECT_DOUBLE_EQ(bnd.facet(0), 7);
+        EXPECT_DOUBLE_EQ(bnd.normal(0)(0), 0.57735026918962584);
+        EXPECT_DOUBLE_EQ(bnd.normal(0)(1), 0.57735026918962584);
+        EXPECT_DOUBLE_EQ(bnd.normal(0)(2), 0.57735026918962584);
+        EXPECT_DOUBLE_EQ(bnd.facet_length(0), 0.5 * std::sqrt(3));
         bnd.destroy();
     }
 }


### PR DESCRIPTION
TET4 orientation must match the orientation ued by PETSc, since that
is what we build upon.
