### PR TITLE
Fixing `Logger::print` of number of warnings/errors

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -37,6 +37,9 @@ void
 Logger::print() const
 {
     CALL_STACK_MSG();
+    if (this->num_errors == 0 && this->num_warnings == 0)
+        return;
+
     for (auto & entry : this->entries) {
         switch (entry.type) {
         case ERROR:


### PR DESCRIPTION
We only print when anything was found. The previous code assumed
`print` was called if there were problems. That's no longer the case
and that created this regression.
