### PR TITLE
Moving `compute_boundary_local`

### DIFF
--- a/include/godzilla/ExplicitProblemInterface.h
+++ b/include/godzilla/ExplicitProblemInterface.h
@@ -39,6 +39,12 @@ protected:
     /// @param F Local output vector
     virtual void compute_rhs_local(Real time, const Vector & x, Vector & F);
 
+    /// Insert the essential boundary values into the local vector
+    ///
+    /// @param time The time
+    /// @param x Local solution
+    virtual void compute_boundary_local(Real time, Vector & x);
+
 private:
     void set_up_time_scheme() override;
 

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -265,12 +265,6 @@ protected:
     /// Clears all the monitors that have been set on a time-stepping object.
     void monitor_cancel();
 
-    /// Insert the essential boundary values into the local vector
-    ///
-    /// @param time The time
-    /// @param x Local solution
-    virtual void compute_boundary_local(Real time, Vector & x);
-
 private:
     /// Monitor
     void monitor(Int stepi, Real time, const Vector & x);

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -130,7 +130,7 @@ ExplicitFELinearProblem::compute_solution_vector_local()
     CALL_STACK_MSG();
     auto & loc_sln = get_solution_vector_local();
     global_to_local(get_solution_vector(), INSERT_VALUES, loc_sln);
-    TransientProblemInterface::compute_boundary_local(get_time(), loc_sln);
+    ExplicitProblemInterface::compute_boundary_local(get_time(), loc_sln);
 }
 
 void

--- a/src/ExplicitProblemInterface.cpp
+++ b/src/ExplicitProblemInterface.cpp
@@ -143,4 +143,12 @@ ExplicitProblemInterface::compute_rhs_local(Real time, const Vector & x, Vector 
 {
 }
 
+void
+ExplicitProblemInterface::compute_boundary_local(Real time, Vector & x)
+{
+    CALL_STACK_MSG();
+    auto dm = this->nl_problem->get_dm();
+    PETSC_CHECK(DMPlexTSComputeBoundary(dm, time, x, nullptr, this));
+}
+
 } // namespace godzilla

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -152,7 +152,7 @@ ImplicitFENonlinearProblem::compute_solution_vector_local()
     CALL_STACK_MSG();
     auto loc_sln = get_solution_vector_local();
     global_to_local(get_solution_vector(), INSERT_VALUES, loc_sln);
-    TransientProblemInterface::compute_boundary_local(get_time(), loc_sln);
+    PETSC_CHECK(DMPlexTSComputeBoundary(get_dm(), get_time(), loc_sln, nullptr, this));
 }
 
 void

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -423,12 +423,4 @@ TransientProblemInterface::monitor_cancel()
     this->monitor_method.reset();
 }
 
-void
-TransientProblemInterface::compute_boundary_local(Real time, Vector & x)
-{
-    CALL_STACK_MSG();
-    auto dm = this->problem->get_dm();
-    PETSC_CHECK(DMPlexTSComputeBoundary(dm, time, x, nullptr, this));
-}
-
 } // namespace godzilla


### PR DESCRIPTION
Moved from `TransientProblemInterface` to `ExplicitProblemInterface`. `TransientProblemInterface` should be agnostic of DM type while `compute_boundary_local` uses `DMPLEX`.