### PR TITLE
Correcting `NonlinearProblem` API

### DIFF
--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -30,7 +30,9 @@ public:
     SNESolver & get_snes();
 
     /// Get underlying KSP
-    KrylovSolver get_ksp() const;
+    const KrylovSolver & get_ksp() const;
+
+    KrylovSolver & get_ksp();
 
     /// Set KSP operators
     void set_ksp_operators(const Matrix & A, const Matrix & B);

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -125,8 +125,15 @@ NonlinearProblem::set_jacobian_matrix(const Matrix & J)
     this->J.set_name("Jac");
 }
 
-KrylovSolver
+const KrylovSolver &
 NonlinearProblem::get_ksp() const
+{
+    CALL_STACK_MSG();
+    return this->ksp;
+}
+
+KrylovSolver &
+NonlinearProblem::get_ksp()
 {
     CALL_STACK_MSG();
     return this->ksp;


### PR DESCRIPTION
- `get_snes()` returns reference, so applications can customize the object
- `get_ksp()` returns reference, so applications can customize the object