### PR TITLE
Adding API wrappers for StructuredMesh

### DIFF
--- a/include/godzilla/StructuredMesh.h
+++ b/include/godzilla/StructuredMesh.h
@@ -17,6 +17,13 @@ public:
     /// @return Clone of this object
     StructuredMesh clone() const;
 
+    /// Sets the size of the per-processor overlap.
+    ///
+    /// @param x Overlap in the x direction
+    /// @param y Overlap in the y direction
+    /// @param z Overlap in the z direction
+    void set_overlap(Int x, Int y = 0, Int z = 0);
+
 public:
     /// Creates an object that will manage the communication of one-dimensional regular array data
     /// that is distributed across one or more MPI processes.

--- a/include/godzilla/StructuredMesh.h
+++ b/include/godzilla/StructuredMesh.h
@@ -17,6 +17,11 @@ public:
     /// @return Clone of this object
     StructuredMesh clone() const;
 
+    ///
+    void set_boundary_type(DMBoundaryType bx,
+                           DMBoundaryType by = DM_BOUNDARY_NONE,
+                           DMBoundaryType bz = DM_BOUNDARY_NONE);
+
     /// Sets the size of the per-processor overlap.
     ///
     /// @param x Overlap in the x direction

--- a/include/godzilla/StructuredMesh.h
+++ b/include/godzilla/StructuredMesh.h
@@ -25,6 +25,9 @@ public:
     /// Sets the type of the communication stencil
     void set_stencil_type(DMDAStencilType stype);
 
+    /// Sets the number of grid points in the three dimensional directions
+    void set_sizes(Int M, Int N = 0, Int P = 0);
+
     /// Sets the size of the per-processor overlap.
     ///
     /// @param x Overlap in the x direction

--- a/include/godzilla/StructuredMesh.h
+++ b/include/godzilla/StructuredMesh.h
@@ -28,6 +28,9 @@ public:
     /// Sets the number of grid points in the three dimensional directions
     void set_sizes(Int M, Int N = 0, Int P = 0);
 
+    /// Sets the number of processes in each dimension
+    void set_num_procs(Int m, Int n = 0, Int p = 0);
+
     /// Sets the size of the per-processor overlap.
     ///
     /// @param x Overlap in the x direction

--- a/include/godzilla/StructuredMesh.h
+++ b/include/godzilla/StructuredMesh.h
@@ -22,6 +22,9 @@ public:
                            DMBoundaryType by = DM_BOUNDARY_NONE,
                            DMBoundaryType bz = DM_BOUNDARY_NONE);
 
+    /// Sets the type of the communication stencil
+    void set_stencil_type(DMDAStencilType stype);
+
     /// Sets the size of the per-processor overlap.
     ///
     /// @param x Overlap in the x direction

--- a/include/godzilla/StructuredMesh.h
+++ b/include/godzilla/StructuredMesh.h
@@ -31,6 +31,9 @@ public:
     /// Sets the number of processes in each dimension
     void set_num_procs(Int m, Int n = 0, Int p = 0);
 
+    /// Sets the number of degrees of freedom per vertex
+    void set_dof(Int n_dofs);
+
     /// Sets the size of the per-processor overlap.
     ///
     /// @param x Overlap in the x direction

--- a/include/godzilla/StructuredMesh.h
+++ b/include/godzilla/StructuredMesh.h
@@ -29,6 +29,17 @@ public:
     /// @param s Stencil width
     static StructuredMesh
     create_1d(const mpi::Communicator comm, DMBoundaryType bx, Int M, Int dof, Int s);
+
+    static StructuredMesh create_2d(const mpi::Communicator comm,
+                                    DMBoundaryType bx,
+                                    DMBoundaryType by,
+                                    DMDAStencilType stencil_type,
+                                    Int M,
+                                    Int N,
+                                    Int m,
+                                    Int n,
+                                    Int dof,
+                                    Int s);
 };
 
 } // namespace godzilla

--- a/include/godzilla/StructuredMesh.h
+++ b/include/godzilla/StructuredMesh.h
@@ -25,6 +25,9 @@ public:
     /// Sets the type of the communication stencil
     void set_stencil_type(DMDAStencilType stype);
 
+    /// Sets the width of the communication stencil
+    void set_stencil_width(Int width);
+
     /// Sets the number of grid points in the three dimensional directions
     void set_sizes(Int M, Int N = 0, Int P = 0);
 

--- a/src/StructuredMesh.cpp
+++ b/src/StructuredMesh.cpp
@@ -37,6 +37,13 @@ StructuredMesh::set_boundary_type(DMBoundaryType bx, DMBoundaryType by, DMBounda
 }
 
 void
+StructuredMesh::set_stencil_type(DMDAStencilType stype)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMDASetStencilType(get_dm(), stype));
+}
+
+void
 StructuredMesh::set_overlap(Int x, Int y, Int z)
 {
     CALL_STACK_MSG();

--- a/src/StructuredMesh.cpp
+++ b/src/StructuredMesh.cpp
@@ -29,6 +29,13 @@ StructuredMesh::clone() const
     return StructuredMesh(dm);
 }
 
+void
+StructuredMesh::set_overlap(Int x, Int y, Int z)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMDASetOverlap(get_dm(), x, y, z));
+}
+
 StructuredMesh
 StructuredMesh::create_1d(const mpi::Communicator comm, DMBoundaryType bx, Int M, Int dof, Int s)
 {

--- a/src/StructuredMesh.cpp
+++ b/src/StructuredMesh.cpp
@@ -50,6 +50,13 @@ StructuredMesh::set_overlap(Int x, Int y, Int z)
     PETSC_CHECK(DMDASetOverlap(get_dm(), x, y, z));
 }
 
+void
+StructuredMesh::set_sizes(Int M, Int N, Int P)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMDASetSizes(get_dm(), M, N, P));
+}
+
 StructuredMesh
 StructuredMesh::create_1d(const mpi::Communicator comm, DMBoundaryType bx, Int M, Int dof, Int s)
 {

--- a/src/StructuredMesh.cpp
+++ b/src/StructuredMesh.cpp
@@ -52,6 +52,13 @@ StructuredMesh::set_num_procs(Int m, Int n, Int p)
 }
 
 void
+StructuredMesh::set_dof(Int n_dofs)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMDASetDof(get_dm(), n_dofs));
+}
+
+void
 StructuredMesh::set_overlap(Int x, Int y, Int z)
 {
     CALL_STACK_MSG();

--- a/src/StructuredMesh.cpp
+++ b/src/StructuredMesh.cpp
@@ -3,6 +3,7 @@
 
 #include "godzilla/StructuredMesh.h"
 #include "godzilla/CallStack.h"
+#include "godzilla/Error.h"
 #include <petscdmda.h>
 
 namespace godzilla {
@@ -41,6 +42,13 @@ StructuredMesh::set_stencil_type(DMDAStencilType stype)
 {
     CALL_STACK_MSG();
     PETSC_CHECK(DMDASetStencilType(get_dm(), stype));
+}
+
+void
+StructuredMesh::set_num_procs(Int m, Int n, Int p)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMDASetNumProcs(get_dm(), m, n, p));
 }
 
 void

--- a/src/StructuredMesh.cpp
+++ b/src/StructuredMesh.cpp
@@ -30,6 +30,13 @@ StructuredMesh::clone() const
 }
 
 void
+StructuredMesh::set_boundary_type(DMBoundaryType bx, DMBoundaryType by, DMBoundaryType bz)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMDASetBoundaryType(get_dm(), bx, by, bz));
+}
+
+void
 StructuredMesh::set_overlap(Int x, Int y, Int z)
 {
     CALL_STACK_MSG();

--- a/src/StructuredMesh.cpp
+++ b/src/StructuredMesh.cpp
@@ -45,6 +45,13 @@ StructuredMesh::set_stencil_type(DMDAStencilType stype)
 }
 
 void
+StructuredMesh::set_stencil_width(Int width)
+{
+    CALL_STACK_MSG();
+    PETSC_CHECK(DMDASetStencilWidth(get_dm(), width));
+}
+
+void
 StructuredMesh::set_num_procs(Int m, Int n, Int p)
 {
     CALL_STACK_MSG();

--- a/src/StructuredMesh.cpp
+++ b/src/StructuredMesh.cpp
@@ -38,4 +38,22 @@ StructuredMesh::create_1d(const mpi::Communicator comm, DMBoundaryType bx, Int M
     return StructuredMesh(dm);
 }
 
+StructuredMesh
+StructuredMesh::create_2d(const mpi::Communicator comm,
+                          DMBoundaryType bx,
+                          DMBoundaryType by,
+                          DMDAStencilType stencil_type,
+                          Int M,
+                          Int N,
+                          Int m,
+                          Int n,
+                          Int dof,
+                          Int s)
+{
+    CALL_STACK_MSG();
+    DM dm;
+    PETSC_CHECK(DMDACreate2d(comm, bx, by, stencil_type, M, N, m, n, dof, s, NULL, NULL, &dm));
+    return StructuredMesh(dm);
+}
+
 } // namespace godzilla


### PR DESCRIPTION
- Adding `StructuredMesh::create_2d`
- Adding `StructuredMesh::set_overlap`
- Adding `StructuredMesh::set_boundary_type`
- Adding `StructuredMesh::set_stencil_type`
- Adding `StructuredMesh::set_sizes`
- Adding `StructuredMesh::set_num_procs`
- Adding `StructuredMesh::set_dof`
- Adding `StructuredMesh::set_stencil_width`
