### PR TITLE
Adding `Mesh::get_coordinate_dim`

### DIFF
--- a/include/godzilla/Mesh.h
+++ b/include/godzilla/Mesh.h
@@ -83,6 +83,9 @@ public:
     /// @return Local section from the coordinate `DM`
     Section get_coordinate_section() const;
 
+    /// Retrieve the dimension of the embedding space for coordinate values.
+    Dimension get_coordinate_dim() const;
+
     /// Set the dimension of the embedding space for coordinate values
     ///
     /// @param dim The embedding dimension

--- a/src/Mesh.cpp
+++ b/src/Mesh.cpp
@@ -115,6 +115,15 @@ Mesh::get_coordinate_section() const
     return section;
 }
 
+Dimension
+Mesh::get_coordinate_dim() const
+{
+    CALL_STACK_MSG();
+    Int dim;
+    PETSC_CHECK(DMGetCoordinateDim(this->obj, &dim));
+    return Dimension::from_int(dim);
+}
+
 void
 Mesh::set_coordinate_dim(Dimension dim)
 {

--- a/src/UnstructuredMesh.cpp
+++ b/src/UnstructuredMesh.cpp
@@ -746,7 +746,7 @@ UnstructuredMesh::get_vertex_coordinates(Int pt) const
     auto coord_array = coord_vec.get_array_read();
     PETSC_CHECK(DMPlexPointLocalRead(dm_coord, pt, coord_array, &data));
     coord_vec.restore_array_read(coord_array);
-    auto dim = get_dimension();
+    auto dim = get_coordinate_dim();
     std::vector<Real> coord(dim);
     for (Int i = 0; i < dim; ++i)
         coord[i] = data[i];

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -143,6 +143,8 @@ TEST(UnstructuredMeshTest, api)
     EXPECT_TRUE(m->is_simplex());
 
     EXPECT_FALSE(m->is_distributed());
+
+    EXPECT_EQ(m->get_coordinate_dim(), 1_D);
 }
 
 TEST(UnstructuredMeshTest, api_ghosted)


### PR DESCRIPTION
Also fixing `get_vertex_cooridnates` to work with embedded spaces.
This now, we assumed mesh dimension was equal to spatial dimension.
Now, we can have lower order meshes in higher order spaces (like
1D lines in 3D space).
