### PR TITLE
Locking versions of `cmake` and `rhash`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Install dependencies
         run: |
           conda install \
-            cmake \
+            cmake=3.31.2 \
+            rhash=1.4.3 \
             make \
             mpich-mpicxx \
             mpicpp-lite=2.* \

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Install dependencies
         run: |
           conda install \
-            cmake \
+            cmake=3.31.2 \
+            rhash=1.4.3 \
             make \
             mpich-mpicxx \
             mpicpp-lite=2.* \

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Install dependencies
         run: |
           conda install \
-            cmake \
+            cmake=3.31.2 \
+            rhash=1.4.3 \
             make \
             mpich-mpicxx \
             mpicpp-lite=2.* \
@@ -88,7 +89,8 @@ jobs:
       - name: Install dependencies
         run: |
           conda install \
-            cmake \
+            cmake=3.31.2 \
+            rhash=1.4.3 \
             make \
             mpich-mpicxx \
             mpicpp-lite=2.* \


### PR DESCRIPTION
Apparently `rhash` was updated to 1.4.6 in `main` which builds as
librhash.1, but cmake 3.31.2 links against rhash.0, which makes it
unusable and break our environment.
