### PR TITLE
`CallStack` prints file names and line numbers

### DIFF
--- a/include/godzilla/CallStack.h
+++ b/include/godzilla/CallStack.h
@@ -13,30 +13,30 @@ namespace internal {
     // In Release builds these macros do nothing
     #define CALL_STACK_MSG(...)
 #else
-    // clang-format off
+// clang-format off
     #define CALL_STK_MSG0() \
-        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__PRETTY_FUNCTION__)
+        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__FILE__, __LINE__, __PRETTY_FUNCTION__)
     #define CALL_STK_MSG1(fmt) \
-        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(fmt)
+        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__FILE__, __LINE__, fmt)
     #define CALL_STK_MSG2(fmt, p1) \
-        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(fmt, p1)
+        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__FILE__, __LINE__, fmt, p1)
     #define CALL_STK_MSG3(fmt, p1, p2) \
-        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(fmt, p1, p2)
+        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__FILE__, __LINE__, fmt, p1, p2)
     #define CALL_STK_MSG4(fmt, p1, p2, p3) \
-        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(fmt, p1, p2, p3)
+        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__FILE__, __LINE__, fmt, p1, p2, p3)
     #define CALL_STK_MSG5(fmt, p1, p2, p3, p4) \
-        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(fmt, p1, p2, p3, p4)
+        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__FILE__, __LINE__, fmt, p1, p2, p3, p4)
     #define CALL_STK_MSG6(fmt, p1, p2, p3, p4, p5) \
-        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(fmt, p1, p2, p3, p4, p5)
+        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__FILE__, __LINE__, fmt, p1, p2, p3, p4, p5)
     #define CALL_STK_MSG7(fmt, p1, p2, p3, p4, p5, p6) \
-        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(fmt, p1, p2, p3, p4, p5, p6)
+        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__FILE__, __LINE__, fmt, p1, p2, p3, p4, p5, p6)
     #define CALL_STK_MSG8(fmt, p1, p2, p3, p4, p5, p6, p7) \
-        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(fmt, p1, p2, p3, p4, p5, p6, p7)
+        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__FILE__, __LINE__, fmt, p1, p2, p3, p4, p5, p6, p7)
     #define CALL_STK_MSG9(fmt, p1, p2, p3, p4, p5, p6, p7, p8) \
-        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(fmt, p1, p2, p3, p4, p5, p6, p7, p8)
+        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__FILE__, __LINE__, fmt, p1, p2, p3, p4, p5, p6, p7, p8)
     #define CALL_STK_MSG10(fmt, p1, p2, p3, p4, p5, p6, p7, p8, p9) \
-        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(fmt, p1, p2, p3, p4, p5, p6, p7, p8, p9)
-    #define GET_CALL_STK_MACRO(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, NAME, ...) NAME
+        godzilla::internal::CallStack::Msg __call_stack_msg##__COUNTER__(__FILE__, __LINE__, fmt, p1, p2, p3, p4, p5, p6, p7, p8, p9)
+    #define GET_CALL_STK_MACRO(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, NAME, ...) NAME
 // clang-format on
 
 /// Place at the beginning of a method/function
@@ -59,6 +59,7 @@ namespace internal {
 /// @endcode
     #define CALL_STACK_MSG(...)            \
         GET_CALL_STK_MACRO(_0,             \
+                           _1,             \
                            ##__VA_ARGS__,  \
                            CALL_STK_MSG10, \
                            CALL_STK_MSG9,  \
@@ -86,16 +87,22 @@ public:
     struct Msg {
         /// Construct call stack object
         ///
+        /// @param location File name
+        /// @param line_no Line number
         /// @param func Function name
-        Msg(const char * func);
+        Msg(const char * location, int line_no, const char * func);
 
         template <typename... T>
-        Msg(fmt::format_string<T...> format, T... args);
+        Msg(const char * location, int line_no, fmt::format_string<T...> format, T... args);
 
         ~Msg();
 
         /// Message
         std::string msg;
+        /// Location
+        std::string location;
+        /// Line number
+        int line_no;
     };
 
 public:
@@ -136,9 +143,11 @@ public:
 CallStack & get_callstack();
 
 template <typename... T>
-CallStack::Msg::Msg(fmt::format_string<T...> format, T... args)
+CallStack::Msg::Msg(const char * loc, int ln, fmt::format_string<T...> format, T... args)
 {
     this->msg = fmt::format(format, std::forward<T>(args)...);
+    this->location = loc;
+    this->line_no = ln;
     get_callstack().add(this);
 }
 

--- a/include/godzilla/DynamicLibrary.h
+++ b/include/godzilla/DynamicLibrary.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "godzilla/Exception.h"
+#include "godzilla/CallStack.h"
 #include "fmt/format.h"
 #include <filesystem>
 #include <vector>

--- a/include/godzilla/Exception.h
+++ b/include/godzilla/Exception.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "godzilla/CallStack.h"
 #include "fmt/format.h"
 #include <exception>
 #include <string>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,8 @@ target_sanitization(${PROJECT_NAME})
 target_compile_options(${PROJECT_NAME}
     PRIVATE
         $<$<CONFIG:Debug>:-Wall -Werror>
+        -ffile-prefix-map=${CMAKE_SOURCE_DIR}/include=include
+        -ffile-prefix-map=${CMAKE_SOURCE_DIR}/src=godzilla/src
 )
 
 set_target_properties(

--- a/src/CallStack.cpp
+++ b/src/CallStack.cpp
@@ -11,11 +11,13 @@ namespace internal {
 // global instance of the call stack object
 static CallStack callstack;
 
-// Call Stack Object ////
+// Call Stack Object
 
-CallStack::Msg::Msg(const char * func)
+CallStack::Msg::Msg(const char * loc, int line_no, const char * func)
 {
     this->msg = fmt::format("{}", func);
+    this->location = loc;
+    this->line_no = line_no;
     callstack.add(this);
 }
 
@@ -24,7 +26,7 @@ CallStack::Msg::~Msg()
     callstack.remove(this);
 }
 
-// Signals ////
+// Signals
 
 static void
 sighandler(int signo)
@@ -62,7 +64,13 @@ CallStack::dump()
         PetscFPrintf(PETSC_COMM_WORLD, PETSC_STDERR, "Call stack:\n");
         for (int n = 0, i = this->size - 1; i >= 0; --i, ++n) {
             Msg * m = this->stack[i];
-            PetscFPrintf(PETSC_COMM_WORLD, PETSC_STDERR, "  #%d: %s\n", n, m->msg.c_str());
+            PetscFPrintf(PETSC_COMM_WORLD,
+                         PETSC_STDERR,
+                         "  #%d: %s (%s:%d)\n",
+                         n,
+                         m->msg.c_str(),
+                         m->location.c_str(),
+                         m->line_no);
         }
     }
     else

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "godzilla/Exception.h"
+#include "godzilla/CallStack.h"
 #include "petscsys.h"
 
 namespace godzilla {
@@ -12,7 +13,8 @@ Exception::store_call_stack()
     auto & cs = internal::get_callstack();
     for (int n = 0, i = cs.get_size() - 1; i >= 0; --i, ++n) {
         auto m = cs.at(i);
-        this->call_stack.push_back(m->msg);
+        auto msg = fmt::format("{} ({}:{})", m->msg, m->location, m->line_no);
+        this->call_stack.push_back(msg);
     }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,13 @@ add_executable(${PROJECT_NAME}
 target_code_coverage(${PROJECT_NAME})
 target_sanitization(${PROJECT_NAME})
 
+target_compile_options(${PROJECT_NAME}
+    PRIVATE
+        -ffile-prefix-map=${CMAKE_SOURCE_DIR}/include=include
+        -ffile-prefix-map=${CMAKE_SOURCE_DIR}/src=godzilla/src
+        -ffile-prefix-map=${CMAKE_SOURCE_DIR}/test=godzilla/test
+)
+
 target_compile_definitions(${PROJECT_NAME}
     PRIVATE
         -DGODZILLA_UNIT_TESTS_ROOT="${GODZILLA_UNIT_TESTS_ROOT}"

--- a/test/src/CallStack_test.cpp
+++ b/test/src/CallStack_test.cpp
@@ -67,8 +67,8 @@ TEST(CallStackTest, dump)
 
 TEST(CallStackTest, stack)
 {
-    godzilla::internal::CallStack::Msg msg1("fn1");
-    godzilla::internal::CallStack::Msg msg2("fn2");
+    godzilla::internal::CallStack::Msg msg1(__FILE__, __LINE__, "fn1");
+    godzilla::internal::CallStack::Msg msg2(__FILE__, __LINE__, "fn2");
 
     auto & cs = godzilla::internal::get_callstack();
     ASSERT_EQ(cs.get_size(), 2);

--- a/test/src/Exception_test.cpp
+++ b/test/src/Exception_test.cpp
@@ -1,5 +1,6 @@
 #include "gmock/gmock.h"
 #include "godzilla/Exception.h"
+#include "godzilla/CallStack.h"
 
 using namespace godzilla;
 
@@ -20,7 +21,7 @@ namespace {
 void
 raise()
 {
-    internal::CallStack::Msg msg2("fn2");
+    internal::CallStack::Msg msg2(__FILE__, __LINE__, "fn2");
     throw Exception("error");
 }
 
@@ -28,7 +29,7 @@ raise()
 
 TEST(Exception, call_stack)
 {
-    internal::CallStack::Msg msg1("fn1");
+    internal::CallStack::Msg msg1(__FILE__, __LINE__, "fn1");
     try {
         raise();
         FAIL();
@@ -36,8 +37,8 @@ TEST(Exception, call_stack)
     catch (Exception & e) {
         auto & cs = e.get_call_stack();
         EXPECT_EQ(cs.size(), 2);
-        EXPECT_EQ(cs.at(0), "fn2");
-        EXPECT_EQ(cs.at(1), "fn1");
+        EXPECT_THAT(cs.at(0), testing::HasSubstr("fn2"));
+        EXPECT_THAT(cs.at(1), testing::HasSubstr("fn1"));
     }
 }
 


### PR DESCRIPTION
Using `-ffile-prefix-map` compiler flag to remove the prefix of the
absolute path, so usr really only see th relevant part of the file
path.
