### PR TITLE
cmake: install FindPETSc.cmake during install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,12 @@ install(
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
 )
 
+install(
+    FILES
+        "${CMAKE_SOURCE_DIR}/cmake/FindPETSc.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/godzilla
+)
+
 # Tests
 
 if (GODZILLA_BUILD_TESTS)

--- a/cmake/godzilla-config.cmake.in
+++ b/cmake/godzilla-config.cmake.in
@@ -3,6 +3,8 @@ set(GODZILLA_WITH_TECIOCPP @GODZILLA_WITH_TECIOCPP@)
 
 @PACKAGE_INIT@
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
 include("${CMAKE_CURRENT_LIST_DIR}/godzilla-targets.cmake")
 include(FindPackageHandleStandardArgs)
 include(CMakeFindDependencyMacro)
@@ -10,6 +12,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(fmt 11)
 find_dependency(mpicpp-lite 2)
 find_dependency(HDF5 1.12 REQUIRED COMPONENTS C)
+find_dependency(PETSc 3.22 REQUIRED)
 if (${GODZILLA_WITH_TECIOCPP})
     find_dependency(teciocpp)
 endif()


### PR DESCRIPTION
So downstream apps can just use it