### PR TITLE
Removing `Parameters` from `Object`

### DIFF
--- a/examples/advect-eqn/include/AdvectionEquation.h
+++ b/examples/advect-eqn/include/AdvectionEquation.h
@@ -8,7 +8,7 @@ using namespace godzilla;
 ///
 class AdvectionEquation : public ExplicitFVLinearProblem {
 public:
-    AdvectionEquation(const Parameters & parameters);
+    AdvectionEquation(const Parameters & pars);
     void create() override;
 
 protected:

--- a/examples/advect-eqn/include/InflowBC.h
+++ b/examples/advect-eqn/include/InflowBC.h
@@ -8,7 +8,7 @@ using namespace godzilla;
 ///
 class InflowBC : public NaturalRiemannBC {
 public:
-    InflowBC(const Parameters & params);
+    InflowBC(const Parameters & pars);
 
     const std::vector<Int> & get_components() const override;
     void

--- a/examples/advect-eqn/include/OutflowBC.h
+++ b/examples/advect-eqn/include/OutflowBC.h
@@ -8,7 +8,7 @@ using namespace godzilla;
 ///
 class OutflowBC : public NaturalRiemannBC {
 public:
-    OutflowBC(const Parameters & params);
+    OutflowBC(const Parameters & pars);
 
     const std::vector<Int> & get_components() const override;
     void

--- a/examples/advect-eqn/src/AdvectionEquation.cpp
+++ b/examples/advect-eqn/src/AdvectionEquation.cpp
@@ -12,8 +12,7 @@ AdvectionEquation::parameters()
     return params;
 }
 
-AdvectionEquation::AdvectionEquation(const Parameters & parameters) :
-    ExplicitFVLinearProblem(parameters)
+AdvectionEquation::AdvectionEquation(const Parameters & pars) : ExplicitFVLinearProblem(pars)
 {
     CALL_STACK_MSG();
 }

--- a/examples/advect-eqn/src/InflowBC.cpp
+++ b/examples/advect-eqn/src/InflowBC.cpp
@@ -9,9 +9,9 @@ InflowBC::parameters()
     return params;
 }
 
-InflowBC::InflowBC(const Parameters & params) :
-    NaturalRiemannBC(params),
-    inlet_vel(get_param<Real>("vel")),
+InflowBC::InflowBC(const Parameters & pars) :
+    NaturalRiemannBC(pars),
+    inlet_vel(pars.get<Real>("vel")),
     components({ 0 })
 {
     CALL_STACK_MSG();

--- a/examples/advect-eqn/src/OutflowBC.cpp
+++ b/examples/advect-eqn/src/OutflowBC.cpp
@@ -8,7 +8,7 @@ OutflowBC::parameters()
     return params;
 }
 
-OutflowBC::OutflowBC(const Parameters & params) : NaturalRiemannBC(params), components({ 0 })
+OutflowBC::OutflowBC(const Parameters & pars) : NaturalRiemannBC(pars), components({ 0 })
 {
     CALL_STACK_MSG();
 }

--- a/examples/burgers-eqn/include/BurgersEquation.h
+++ b/examples/burgers-eqn/include/BurgersEquation.h
@@ -9,7 +9,7 @@ using namespace godzilla;
 ///
 class BurgersEquation : public ExplicitFELinearProblem {
 public:
-    explicit BurgersEquation(const Parameters & parameters);
+    explicit BurgersEquation(const Parameters & pars);
     void create() override;
 
     const Real & get_viscosity() const;

--- a/examples/burgers-eqn/src/BurgersEquation.cpp
+++ b/examples/burgers-eqn/src/BurgersEquation.cpp
@@ -43,10 +43,10 @@ BurgersEquation::parameters()
     return params;
 }
 
-BurgersEquation::BurgersEquation(const Parameters & parameters) :
-    ExplicitFELinearProblem(parameters),
+BurgersEquation::BurgersEquation(const Parameters & pars) :
+    ExplicitFELinearProblem(pars),
     u_id(FieldID::INVALID),
-    viscosity(get_param<Real>("viscosity"))
+    viscosity(pars.get<Real>("viscosity"))
 {
     CALL_STACK_MSG();
 }

--- a/examples/heat-eqn/include/ConvectiveHeatFluxBC.h
+++ b/examples/heat-eqn/include/ConvectiveHeatFluxBC.h
@@ -6,7 +6,7 @@ using namespace godzilla;
 
 class ConvectiveHeatFluxBC : public NaturalBC {
 public:
-    ConvectiveHeatFluxBC(const Parameters & params);
+    ConvectiveHeatFluxBC(const Parameters & pars);
 
     const std::vector<Int> & get_components() const override;
 

--- a/examples/heat-eqn/include/HeatEquationExplicit.h
+++ b/examples/heat-eqn/include/HeatEquationExplicit.h
@@ -10,7 +10,7 @@ using namespace godzilla;
 ///
 class HeatEquationExplicit : public ExplicitFELinearProblem {
 public:
-    explicit HeatEquationExplicit(const Parameters & parameters);
+    explicit HeatEquationExplicit(const Parameters & pars);
     void create() override;
 
 protected:

--- a/examples/heat-eqn/include/HeatEquationProblem.h
+++ b/examples/heat-eqn/include/HeatEquationProblem.h
@@ -8,7 +8,7 @@ using namespace godzilla;
 ///
 class HeatEquationProblem : public ImplicitFENonlinearProblem {
 public:
-    explicit HeatEquationProblem(const Parameters & parameters);
+    explicit HeatEquationProblem(const Parameters & pars);
 
 protected:
     void set_up_fields() override;

--- a/examples/heat-eqn/src/ConvectiveHeatFluxBC.cpp
+++ b/examples/heat-eqn/src/ConvectiveHeatFluxBC.cpp
@@ -54,8 +54,8 @@ ConvectiveHeatFluxBC::parameters()
     return params;
 }
 
-ConvectiveHeatFluxBC::ConvectiveHeatFluxBC(const Parameters & params) :
-    NaturalBC(params),
+ConvectiveHeatFluxBC::ConvectiveHeatFluxBC(const Parameters & pars) :
+    NaturalBC(pars),
     components({ 0 })
 {
     CALL_STACK_MSG();

--- a/examples/heat-eqn/src/HeatEquationExplicit.cpp
+++ b/examples/heat-eqn/src/HeatEquationExplicit.cpp
@@ -59,11 +59,11 @@ HeatEquationExplicit::parameters()
     return params;
 }
 
-HeatEquationExplicit::HeatEquationExplicit(const Parameters & parameters) :
-    ExplicitFELinearProblem(parameters),
+HeatEquationExplicit::HeatEquationExplicit(const Parameters & pars) :
+    ExplicitFELinearProblem(pars),
     temp_id(FieldID::INVALID),
     ffn_aux_id(FieldID::INVALID),
-    order(get_param<Int>("order"))
+    order(pars.get<Int>("order"))
 {
     CALL_STACK_MSG();
 }

--- a/examples/heat-eqn/src/HeatEquationProblem.cpp
+++ b/examples/heat-eqn/src/HeatEquationProblem.cpp
@@ -97,13 +97,13 @@ HeatEquationProblem::parameters()
     return params;
 }
 
-HeatEquationProblem::HeatEquationProblem(const Parameters & parameters) :
-    ImplicitFENonlinearProblem(parameters),
+HeatEquationProblem::HeatEquationProblem(const Parameters & pars) :
+    ImplicitFENonlinearProblem(pars),
     temp_id(FieldID::INVALID),
     q_ppp_id(FieldID::INVALID),
     htc_aux_id(FieldID::INVALID),
     T_ambient_aux_id(FieldID::INVALID),
-    p_order(get_param<Int>("p_order"))
+    p_order(pars.get<Int>("p_order"))
 {
     CALL_STACK_MSG();
 }

--- a/examples/ns-incomp/include/NSIncompressibleProblem.h
+++ b/examples/ns-incomp/include/NSIncompressibleProblem.h
@@ -11,7 +11,7 @@ using namespace godzilla;
 ///
 class NSIncompressibleProblem : public ImplicitFENonlinearProblem {
 public:
-    explicit NSIncompressibleProblem(const Parameters & parameters);
+    explicit NSIncompressibleProblem(const Parameters & pars);
 
     const Real & get_reynolds_number() const;
 

--- a/examples/ns-incomp/src/NSIncompressibleProblem.cpp
+++ b/examples/ns-incomp/src/NSIncompressibleProblem.cpp
@@ -271,12 +271,12 @@ NSIncompressibleProblem::parameters()
     return params;
 }
 
-NSIncompressibleProblem::NSIncompressibleProblem(const Parameters & parameters) :
-    ImplicitFENonlinearProblem(parameters),
+NSIncompressibleProblem::NSIncompressibleProblem(const Parameters & pars) :
+    ImplicitFENonlinearProblem(pars),
     velocity_id(FieldID::INVALID),
     pressure_id(FieldID::INVALID),
     ffn_aid(FieldID::INVALID),
-    Re(get_param<Real>("Re"))
+    Re(pars.get<Real>("Re"))
 {
     CALL_STACK_MSG();
 }

--- a/examples/poisson/include/PoissonEquation.h
+++ b/examples/poisson/include/PoissonEquation.h
@@ -8,7 +8,7 @@ using namespace godzilla;
 ///
 class PoissonEquation : public FENonlinearProblem {
 public:
-    PoissonEquation(const Parameters & parameters);
+    PoissonEquation(const Parameters & pars);
 
 protected:
     void set_up_fields() override;

--- a/examples/poisson/src/PoissonEquation.cpp
+++ b/examples/poisson/src/PoissonEquation.cpp
@@ -15,9 +15,9 @@ PoissonEquation::parameters()
     return params;
 }
 
-PoissonEquation::PoissonEquation(const Parameters & parameters) :
-    FENonlinearProblem(parameters),
-    p_order(get_param<Int>("p_order")),
+PoissonEquation::PoissonEquation(const Parameters & pars) :
+    FENonlinearProblem(pars),
+    p_order(pars.get<Int>("p_order")),
     iu(FieldID::INVALID),
     affn(FieldID::INVALID)
 {

--- a/include/godzilla/AuxiliaryField.h
+++ b/include/godzilla/AuxiliaryField.h
@@ -19,7 +19,7 @@ class DiscreteProblemInterface;
 ///
 class AuxiliaryField : public Object, public PrintInterface {
 public:
-    explicit AuxiliaryField(const Parameters & params);
+    explicit AuxiliaryField(const Parameters & pars);
 
     void create() override;
 

--- a/include/godzilla/BasicTSAdapt.h
+++ b/include/godzilla/BasicTSAdapt.h
@@ -11,7 +11,7 @@ namespace godzilla {
 ///
 class BasicTSAdapt : public TimeSteppingAdaptor {
 public:
-    explicit BasicTSAdapt(const Parameters & params);
+    explicit BasicTSAdapt(const Parameters & pars);
 
     void create() override;
 

--- a/include/godzilla/BoundaryCondition.h
+++ b/include/godzilla/BoundaryCondition.h
@@ -17,7 +17,7 @@ class DiscreteProblemInterface;
 ///
 class BoundaryCondition : public Object, public PrintInterface {
 public:
-    explicit BoundaryCondition(const Parameters & params);
+    explicit BoundaryCondition(const Parameters & pars);
 
     /// Get problem spatial dimension
     ///

--- a/include/godzilla/BoxMesh.h
+++ b/include/godzilla/BoxMesh.h
@@ -13,7 +13,7 @@ namespace godzilla {
 class BoxMesh : public MeshObject {
 public:
     /// Constructor for building the object via Factory
-    explicit BoxMesh(const Parameters & parameters);
+    explicit BoxMesh(const Parameters & pars);
 
     /// Get lower limit in x-direction
     Real get_x_min() const;

--- a/include/godzilla/CSVOutput.h
+++ b/include/godzilla/CSVOutput.h
@@ -12,7 +12,7 @@ namespace godzilla {
 ///
 class CSVOutput : public FileOutput {
 public:
-    explicit CSVOutput(const Parameters & params);
+    explicit CSVOutput(const Parameters & pars);
     ~CSVOutput() override;
 
     void create() override;

--- a/include/godzilla/ConstantAuxiliaryField.h
+++ b/include/godzilla/ConstantAuxiliaryField.h
@@ -12,7 +12,7 @@ namespace godzilla {
 ///
 class ConstantAuxiliaryField : public AuxiliaryField {
 public:
-    explicit ConstantAuxiliaryField(const Parameters & params);
+    explicit ConstantAuxiliaryField(const Parameters & pars);
 
     Int get_num_components() const override;
     void evaluate(Real time, const Real x[], Scalar u[]) override;

--- a/include/godzilla/ConstantFunction.h
+++ b/include/godzilla/ConstantFunction.h
@@ -11,7 +11,7 @@ namespace godzilla {
 /// Constant function
 class ConstantFunction : public Function {
 public:
-    explicit ConstantFunction(const Parameters & params);
+    explicit ConstantFunction(const Parameters & pars);
 
     void create() override;
 

--- a/include/godzilla/ConstantInitialCondition.h
+++ b/include/godzilla/ConstantInitialCondition.h
@@ -15,7 +15,7 @@ namespace godzilla {
 /// value for each component
 class ConstantInitialCondition : public InitialCondition {
 public:
-    explicit ConstantInitialCondition(const Parameters & params);
+    explicit ConstantInitialCondition(const Parameters & pars);
 
     Int get_num_components() const override;
 

--- a/include/godzilla/Convert.h
+++ b/include/godzilla/Convert.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include "godzilla/Types.h"
 #include <string>
+#include <tuple>
 
 namespace godzilla {
 namespace conv {
@@ -13,6 +15,9 @@ namespace conv {
 /// @param value Value to convert
 template <typename T>
 std::string to_str(T value);
+
+/// Convert
+std::tuple<ExecuteOn, bool> to_execute_on(const std::vector<std::string> & vals);
 
 } // namespace conv
 } // namespace godzilla

--- a/include/godzilla/DGProblemInterface.h
+++ b/include/godzilla/DGProblemInterface.h
@@ -13,7 +13,7 @@ class AuxiliaryField;
 ///
 class DGProblemInterface : public DiscreteProblemInterface {
 public:
-    DGProblemInterface(Problem * problem, const Parameters & params);
+    DGProblemInterface(Problem * problem, const Parameters & pars);
     ~DGProblemInterface() override;
 
     Int get_num_fields() const override;

--- a/include/godzilla/DependencyEvaluator.h
+++ b/include/godzilla/DependencyEvaluator.h
@@ -78,7 +78,7 @@ public:
     /// @param name Name of the functional
     /// @param params Parameters needed to build the functional
     template <typename Fn>
-    void create_functional(const std::string & name, const Parameters & params);
+    void create_functional(const std::string & name, const Parameters & pars);
 
     /// Get a reference to a functional using its name
     ///
@@ -154,12 +154,12 @@ DependencyEvaluator::get_value(const std::string & val_name)
 
 template <typename Fn>
 void
-DependencyEvaluator::create_functional(const std::string & name, const Parameters & params)
+DependencyEvaluator::create_functional(const std::string & name, const Parameters & pars)
 {
     CALL_STACK_MSG();
     const auto & it = this->functionals.find(name);
     if (it == this->functionals.end()) {
-        auto * fnl = new Fn(params);
+        auto * fnl = new Fn(pars);
         this->functionals[name] = fnl;
     }
     else

--- a/include/godzilla/DirichletBC.h
+++ b/include/godzilla/DirichletBC.h
@@ -13,7 +13,7 @@ namespace godzilla {
 /// Can be used only on single-field problems
 class DirichletBC : public EssentialBC, protected FunctionInterface {
 public:
-    explicit DirichletBC(const Parameters & params);
+    explicit DirichletBC(const Parameters & pars);
 
     void create() override;
     void set_up() override;

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -62,7 +62,7 @@ private:
     };
 
 public:
-    DiscreteProblemInterface(Problem * problem, const Parameters & params);
+    DiscreteProblemInterface(Problem * problem, const Parameters & pars);
     virtual ~DiscreteProblemInterface();
 
     /// Get unstructured mesh associated with this problem

--- a/include/godzilla/EssentialBC.h
+++ b/include/godzilla/EssentialBC.h
@@ -12,7 +12,7 @@ namespace godzilla {
 ///
 class EssentialBC : public BoundaryCondition {
 public:
-    explicit EssentialBC(const Parameters & params);
+    explicit EssentialBC(const Parameters & pars);
 
     void create() override;
     void set_up() override;
@@ -44,6 +44,8 @@ public:
 private:
     /// Field ID this boundary condition is attached to
     FieldID fid;
+    ///
+    Optional<std::string> field_name;
 
 public:
     static Parameters parameters();

--- a/include/godzilla/ExodusIIMesh.h
+++ b/include/godzilla/ExodusIIMesh.h
@@ -11,7 +11,7 @@ namespace godzilla {
 ///
 class ExodusIIMesh : public FileMesh {
 public:
-    explicit ExodusIIMesh(const Parameters & parameters);
+    explicit ExodusIIMesh(const Parameters & pars);
 
 public:
     static Parameters parameters();

--- a/include/godzilla/ExodusIIOutput.h
+++ b/include/godzilla/ExodusIIOutput.h
@@ -12,6 +12,7 @@ namespace godzilla {
 
 class UnstructuredMesh;
 class DGProblemInterface;
+class MeshObject;
 
 /// ExodusII output
 ///
@@ -28,7 +29,7 @@ class DGProblemInterface;
 /// This output works only with finite element problems
 class ExodusIIOutput : public FileOutput {
 public:
-    explicit ExodusIIOutput(const Parameters & params);
+    explicit ExodusIIOutput(const Parameters & pars);
     ~ExodusIIOutput() override;
 
     void create() override;
@@ -70,6 +71,8 @@ private:
 
     bool cont;
     bool discont;
+    ///
+    MeshObject * mesh_object;
     /// Variable names to be stored
     std::vector<std::string> variable_names;
     /// DG problem interface

--- a/include/godzilla/ExplicitDGLinearProblem.h
+++ b/include/godzilla/ExplicitDGLinearProblem.h
@@ -14,7 +14,7 @@ class ExplicitDGLinearProblem :
     public DGProblemInterface,
     public ExplicitProblemInterface {
 public:
-    explicit ExplicitDGLinearProblem(const Parameters & params);
+    explicit ExplicitDGLinearProblem(const Parameters & pars);
 
     void create() override;
     void run() override;

--- a/include/godzilla/ExplicitFELinearProblem.h
+++ b/include/godzilla/ExplicitFELinearProblem.h
@@ -12,7 +12,7 @@ class ResidualFunc;
 
 class ExplicitFELinearProblem : public FENonlinearProblem, public ExplicitProblemInterface {
 public:
-    explicit ExplicitFELinearProblem(const Parameters & params);
+    explicit ExplicitFELinearProblem(const Parameters & pars);
 
     Real get_time() const override;
     Int get_step_num() const override;

--- a/include/godzilla/ExplicitFVLinearProblem.h
+++ b/include/godzilla/ExplicitFVLinearProblem.h
@@ -14,7 +14,7 @@ class ExplicitFVLinearProblem :
     public FVProblemInterface,
     public ExplicitProblemInterface {
 public:
-    explicit ExplicitFVLinearProblem(const Parameters & params);
+    explicit ExplicitFVLinearProblem(const Parameters & pars);
 
     void create() override;
     void run() override;

--- a/include/godzilla/ExplicitProblemInterface.h
+++ b/include/godzilla/ExplicitProblemInterface.h
@@ -14,7 +14,7 @@ namespace godzilla {
 
 class ExplicitProblemInterface : public TransientProblemInterface {
 public:
-    explicit ExplicitProblemInterface(NonlinearProblem * problem, const Parameters & params);
+    explicit ExplicitProblemInterface(NonlinearProblem * problem, const Parameters & pars);
 
     const Matrix & get_mass_matrix() const;
 

--- a/include/godzilla/FENonlinearProblem.h
+++ b/include/godzilla/FENonlinearProblem.h
@@ -17,7 +17,7 @@ class IndexSet;
 /// Non-linear problem that arises from a finite element discretization using the PetscFE system
 class FENonlinearProblem : public NonlinearProblem, public FEProblemInterface {
 public:
-    explicit FENonlinearProblem(const Parameters & parameters);
+    explicit FENonlinearProblem(const Parameters & pars);
 
     void create() override;
     Real get_time() const override;

--- a/include/godzilla/FEProblemInterface.h
+++ b/include/godzilla/FEProblemInterface.h
@@ -28,7 +28,7 @@ class FEProblemInterface : public DiscreteProblemInterface, public DependencyEva
     struct FieldInfo;
 
 public:
-    FEProblemInterface(Problem * problem, const Parameters & params);
+    FEProblemInterface(Problem * problem, const Parameters & pars);
     ~FEProblemInterface() override;
 
     Int get_num_fields() const override;

--- a/include/godzilla/FVProblemInterface.h
+++ b/include/godzilla/FVProblemInterface.h
@@ -18,7 +18,7 @@ public:
     using ComputeFluxDelegate =
         Delegate<void(const Real[], const Real[], const Scalar[], const Scalar[], Scalar[])>;
 
-    FVProblemInterface(Problem * problem, const Parameters & params);
+    FVProblemInterface(Problem * problem, const Parameters & pars);
     ~FVProblemInterface() override;
 
     Int get_num_fields() const override;

--- a/include/godzilla/FileMesh.h
+++ b/include/godzilla/FileMesh.h
@@ -14,7 +14,7 @@ class FileMesh : public MeshObject {
 public:
     enum FileFormat { UNKNOWN, EXODUSII, GMSH } file_format;
 
-    explicit FileMesh(const Parameters & parameters);
+    explicit FileMesh(const Parameters & pars);
 
     /// Return file name
     ///

--- a/include/godzilla/FileOutput.h
+++ b/include/godzilla/FileOutput.h
@@ -15,7 +15,7 @@ class UnstructuredMesh;
 ///
 class FileOutput : public Output {
 public:
-    explicit FileOutput(const Parameters & params);
+    explicit FileOutput(const Parameters & pars);
 
     void create() override;
 

--- a/include/godzilla/Function.h
+++ b/include/godzilla/Function.h
@@ -15,7 +15,7 @@ class Problem;
 ///
 class Function : public Object {
 public:
-    explicit Function(const Parameters & params);
+    explicit Function(const Parameters & pars);
 
     /// Register this function with the function parser
     ///

--- a/include/godzilla/FunctionAuxiliaryField.h
+++ b/include/godzilla/FunctionAuxiliaryField.h
@@ -13,7 +13,7 @@ namespace godzilla {
 ///
 class FunctionAuxiliaryField : public AuxiliaryField, protected FunctionInterface {
 public:
-    explicit FunctionAuxiliaryField(const Parameters & params);
+    explicit FunctionAuxiliaryField(const Parameters & pars);
 
     void create() override;
     Int get_num_components() const override;

--- a/include/godzilla/FunctionInitialCondition.h
+++ b/include/godzilla/FunctionInitialCondition.h
@@ -12,7 +12,7 @@ namespace godzilla {
 ///
 class FunctionInitialCondition : public InitialCondition, protected FunctionInterface {
 public:
-    explicit FunctionInitialCondition(const Parameters & params);
+    explicit FunctionInitialCondition(const Parameters & pars);
 
     void create() override;
     Int get_num_components() const override;

--- a/include/godzilla/FunctionInterface.h
+++ b/include/godzilla/FunctionInterface.h
@@ -15,7 +15,7 @@ class Problem;
 ///
 class FunctionInterface {
 public:
-    explicit FunctionInterface(const Parameters & params);
+    explicit FunctionInterface(const Parameters & pars);
 
     /// Build the evaluator
     void create();

--- a/include/godzilla/GmshMesh.h
+++ b/include/godzilla/GmshMesh.h
@@ -11,7 +11,7 @@ namespace godzilla {
 ///
 class GmshMesh : public FileMesh {
 public:
-    explicit GmshMesh(const Parameters & parameters);
+    explicit GmshMesh(const Parameters & pars);
 
 public:
     static Parameters parameters();

--- a/include/godzilla/ImplicitFENonlinearProblem.h
+++ b/include/godzilla/ImplicitFENonlinearProblem.h
@@ -10,7 +10,7 @@ namespace godzilla {
 
 class ImplicitFENonlinearProblem : public FENonlinearProblem, public TransientProblemInterface {
 public:
-    explicit ImplicitFENonlinearProblem(const Parameters & params);
+    explicit ImplicitFENonlinearProblem(const Parameters & pars);
 
     void create() override;
     void solve();

--- a/include/godzilla/InitialCondition.h
+++ b/include/godzilla/InitialCondition.h
@@ -16,7 +16,7 @@ class DiscreteProblemInterface;
 ///
 class InitialCondition : public Object, public PrintInterface {
 public:
-    explicit InitialCondition(const Parameters & params);
+    explicit InitialCondition(const Parameters & pars);
 
     void create() override;
 
@@ -52,7 +52,7 @@ private:
     DiscreteProblemInterface * dpi;
 
     /// Field name this initial condition is attached to
-    std::string field_name;
+    Optional<std::string> field_name;
 
     /// Field ID this initial condition is attached to
     FieldID fid;

--- a/include/godzilla/L2Diff.h
+++ b/include/godzilla/L2Diff.h
@@ -12,7 +12,7 @@ namespace godzilla {
 ///
 class L2Diff : public Postprocessor, public FunctionInterface {
 public:
-    explicit L2Diff(const Parameters & params);
+    explicit L2Diff(const Parameters & pars);
 
     void create() override;
     void compute() override;

--- a/include/godzilla/L2FieldDiff.h
+++ b/include/godzilla/L2FieldDiff.h
@@ -16,7 +16,7 @@ class ParsedFunction;
 ///
 class L2FieldDiff : public Postprocessor {
 public:
-    explicit L2FieldDiff(const Parameters & params);
+    explicit L2FieldDiff(const Parameters & pars);
 
     void create() override;
     void compute() override;

--- a/include/godzilla/LineMesh.h
+++ b/include/godzilla/LineMesh.h
@@ -12,7 +12,7 @@ namespace godzilla {
 ///
 class LineMesh : public MeshObject {
 public:
-    explicit LineMesh(const Parameters & parameters);
+    explicit LineMesh(const Parameters & pars);
 
     /// Get the lower bound in x-direction
     ///

--- a/include/godzilla/LinearProblem.h
+++ b/include/godzilla/LinearProblem.h
@@ -16,7 +16,7 @@ namespace godzilla {
 ///
 class LinearProblem : public Problem, public RestartInterface {
 public:
-    explicit LinearProblem(const Parameters & parameters);
+    explicit LinearProblem(const Parameters & pars);
 
     void create() override;
     void run() override;

--- a/include/godzilla/MeshObject.h
+++ b/include/godzilla/MeshObject.h
@@ -15,7 +15,7 @@ namespace godzilla {
 /// TODO: This needs a better name
 class MeshObject : public Object, public PrintInterface {
 public:
-    explicit MeshObject(const Parameters & parameters);
+    explicit MeshObject(const Parameters & pars);
 
     void create() override;
 

--- a/include/godzilla/MeshPartitioningOutput.h
+++ b/include/godzilla/MeshPartitioningOutput.h
@@ -11,7 +11,7 @@ namespace godzilla {
 ///
 class MeshPartitioningOutput : public FileOutput {
 public:
-    explicit MeshPartitioningOutput(const Parameters & params);
+    explicit MeshPartitioningOutput(const Parameters & pars);
 
     void output_step() override;
 

--- a/include/godzilla/NaturalBC.h
+++ b/include/godzilla/NaturalBC.h
@@ -16,7 +16,7 @@ class BndJacobianFunc;
 /// Base class for natural boundary conditions
 class NaturalBC : public BoundaryCondition {
 public:
-    explicit NaturalBC(const Parameters & params);
+    explicit NaturalBC(const Parameters & pars);
 
     void create() override;
     void set_up() override;
@@ -57,7 +57,8 @@ protected:
 private:
     /// Field ID this boundary condition is attached to
     FieldID fid;
-
+    ///
+    Optional<std::string> field_name;
     /// Finite element problem this object is part of
     FEProblemInterface * fepi;
 

--- a/include/godzilla/NaturalRiemannBC.h
+++ b/include/godzilla/NaturalRiemannBC.h
@@ -12,7 +12,7 @@ namespace godzilla {
 /// Base class for natural Riemann boundary conditions
 class NaturalRiemannBC : public BoundaryCondition {
 public:
-    explicit NaturalRiemannBC(const Parameters & params);
+    explicit NaturalRiemannBC(const Parameters & pars);
 
     void create() override;
     void set_up() override;

--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -16,7 +16,7 @@ namespace godzilla {
 ///
 class NonlinearProblem : public Problem, public RestartInterface {
 public:
-    explicit NonlinearProblem(const Parameters & parameters);
+    explicit NonlinearProblem(const Parameters & pars);
 
     void create() override;
     void run() override;

--- a/include/godzilla/Object.h
+++ b/include/godzilla/Object.h
@@ -19,7 +19,7 @@ class App;
 class Object : public LoggingInterface {
 public:
     /// Constructor for building the object via Factory
-    explicit Object(const Parameters & parameters);
+    explicit Object(const Parameters & pars);
     virtual ~Object() = default;
 
     /// Get the type of this object.
@@ -30,22 +30,7 @@ public:
     /// @return The name of the object
     const std::string & get_name() const;
 
-    /// Get the parameters of the object
-    /// @return The parameters of the object
-    const Parameters & get_parameters() const;
-
-    /// Retrieve a parameter for the object
-    /// @param par_name The name of the parameter
-    /// @return The value of the parameter
-    template <typename T>
-    T get_param(const std::string & par_name) const;
-
-    /// Test if the supplied parameter is valid
-    /// @param par_name The name of the parameter to test
-    bool is_param_valid(const std::string & par_name) const;
-
     /// Get the App this object is associated with
-
     App * get_app() const;
 
     /// Get the MPI comm this object works on
@@ -58,9 +43,6 @@ public:
     virtual void create();
 
 private:
-    /// Parameters of this object
-    const Parameters pars;
-
     /// The application owning this object
     App * app;
 
@@ -74,12 +56,5 @@ public:
     /// Method for building Parameters for this class
     static Parameters parameters();
 };
-
-template <typename T>
-T
-Object::get_param(const std::string & par_name) const
-{
-    return this->pars.get<T>(par_name);
-}
 
 } // namespace godzilla

--- a/include/godzilla/Output.h
+++ b/include/godzilla/Output.h
@@ -15,7 +15,7 @@ class Problem;
 ///
 class Output : public Object, public PrintInterface {
 public:
-    explicit Output(const Parameters & params);
+    explicit Output(const Parameters & pars);
 
     void create() override;
 
@@ -27,7 +27,12 @@ public:
     /// Get execution mask
     ///
     /// @return execution mask
-    ExecuteOn get_exec_mask() const;
+    [[deprecated("Use execute_on()")]] ExecuteOn get_exec_mask() const;
+
+    /// Get execution mask
+    ///
+    /// @return execution mask
+    ExecuteOn execute_on() const;
 
     /// Should output happen at a specified occasion
     ///
@@ -45,7 +50,7 @@ protected:
     Problem * get_problem() const;
 
     /// Set up the execution mask
-    void set_up_exec();
+    // void set_up_exec();
 
 private:
     /// Problem to get data from

--- a/include/godzilla/ParsedFunction.h
+++ b/include/godzilla/ParsedFunction.h
@@ -14,7 +14,7 @@ namespace godzilla {
 ///
 class ParsedFunction : public Function {
 public:
-    explicit ParsedFunction(const Parameters & params);
+    explicit ParsedFunction(const Parameters & pars);
 
     /// Register this function with the function parser
     ///

--- a/include/godzilla/PiecewiseConstant.h
+++ b/include/godzilla/PiecewiseConstant.h
@@ -14,7 +14,7 @@ namespace godzilla {
 /// User have to specify at least 1 point
 class PiecewiseConstant : public Function {
 public:
-    explicit PiecewiseConstant(const Parameters & params);
+    explicit PiecewiseConstant(const Parameters & pars);
 
     void create() override;
 

--- a/include/godzilla/PiecewiseLinear.h
+++ b/include/godzilla/PiecewiseLinear.h
@@ -18,7 +18,7 @@ class LinearInterpolation;
 /// User have to specify at least 2 points
 class PiecewiseLinear : public Function {
 public:
-    explicit PiecewiseLinear(const Parameters & params);
+    explicit PiecewiseLinear(const Parameters & pars);
 
     void register_callback(mu::Parser & parser) override;
 

--- a/include/godzilla/Postprocessor.h
+++ b/include/godzilla/Postprocessor.h
@@ -15,7 +15,7 @@ class Problem;
 ///
 class Postprocessor : public Object, public PrintInterface {
 public:
-    explicit Postprocessor(const Parameters & params);
+    explicit Postprocessor(const Parameters & pars);
 
     /// Compute the postprocessor value
     ///

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -44,7 +44,7 @@ public:
         void destroy();
     };
 
-    explicit Problem(const Parameters & parameters);
+    explicit Problem(const Parameters & pars);
 
     /// Build the problem to solve
     void create() override;
@@ -174,6 +174,9 @@ public:
 
     /// Set default execute on flags
     void set_default_output_on(ExecuteOn flags);
+
+    /// Get default execute on flags for outputs
+    ExecuteOn get_default_output_on() const;
 
     /// Create field decomposition
     FieldDecomposition create_field_decomposition();

--- a/include/godzilla/RZSymmetry.h
+++ b/include/godzilla/RZSymmetry.h
@@ -13,7 +13,7 @@ class DiscreteProblemInterface;
 
 class RZSymmetry : public Object {
 public:
-    RZSymmetry(const Parameters & params);
+    RZSymmetry(const Parameters & pars);
 
     void create() override;
     Real get_value(Real time, const DenseVector<Real, 2> & x);

--- a/include/godzilla/RectangleMesh.h
+++ b/include/godzilla/RectangleMesh.h
@@ -12,7 +12,7 @@ namespace godzilla {
 ///
 class RectangleMesh : public MeshObject {
 public:
-    explicit RectangleMesh(const Parameters & parameters);
+    explicit RectangleMesh(const Parameters & pars);
 
     ///
     Real get_x_min() const;

--- a/include/godzilla/Registry.h
+++ b/include/godzilla/Registry.h
@@ -15,13 +15,13 @@ using ObjectPtr = Object *;
 
 using ParamsPtr = Parameters (*)();
 
-using BuildPtr = ObjectPtr (*)(const Parameters & parameters);
+using BuildPtr = ObjectPtr (*)(const Parameters & pars);
 
 template <typename T>
 ObjectPtr
-build_obj(const Parameters & parameters)
+build_obj(const Parameters & pars)
 {
-    return new T(parameters);
+    return new T(pars);
 }
 
 template <typename T>

--- a/include/godzilla/RestartOutput.h
+++ b/include/godzilla/RestartOutput.h
@@ -10,7 +10,7 @@ namespace godzilla {
 
 class RestartOutput : public FileOutput {
 public:
-    explicit RestartOutput(const Parameters & params);
+    explicit RestartOutput(const Parameters & pars);
 
     void create() override;
     void output_step() override;

--- a/include/godzilla/TecplotOutput.h
+++ b/include/godzilla/TecplotOutput.h
@@ -19,7 +19,7 @@ class UnstructuredMesh;
 /// This output works only with finite element problems
 class TecplotOutput : public FileOutput {
 public:
-    explicit TecplotOutput(const Parameters & params);
+    explicit TecplotOutput(const Parameters & pars);
     ~TecplotOutput() override;
 
     void create() override;

--- a/include/godzilla/TimeSteppingAdaptor.h
+++ b/include/godzilla/TimeSteppingAdaptor.h
@@ -16,7 +16,7 @@ class TransientProblemInterface;
 ///
 class TimeSteppingAdaptor : public Object {
 public:
-    explicit TimeSteppingAdaptor(const Parameters & params);
+    explicit TimeSteppingAdaptor(const Parameters & pars);
 
     void create() override;
 

--- a/include/godzilla/TransientProblemInterface.h
+++ b/include/godzilla/TransientProblemInterface.h
@@ -63,7 +63,7 @@ public:
         NONLINEAR = TS_NONLINEAR,
     };
 
-    TransientProblemInterface(Problem * problem, const Parameters & params);
+    TransientProblemInterface(Problem * problem, const Parameters & pars);
     virtual ~TransientProblemInterface();
 
     /// Set time stepping adaptivity using an adaptor class
@@ -404,9 +404,9 @@ private:
     /// Simulation start time
     Real start_time;
     /// Simulation end time
-    std::optional<Real> end_time;
+    Optional<Real> end_time;
     /// Number of steps
-    std::optional<Int> num_steps;
+    Optional<Int> num_steps;
     /// Initial time step size
     Real dt_initial;
     /// Time step number

--- a/include/godzilla/Types.h
+++ b/include/godzilla/Types.h
@@ -7,6 +7,7 @@
 #include "godzilla/Flags.h"
 #include "godzilla/Delegate.h"
 #include "petscsystypes.h"
+#include <optional>
 
 namespace godzilla {
 
@@ -235,5 +236,14 @@ constexpr Int N_NODES = SimplexSelector<D>::N_NODES;
 
 template <typename T>
 concept FloatingPoint = std::is_floating_point_v<T>;
+
+template <typename T>
+using Optional = std::optional<T>;
+
+template <typename T>
+concept IsOptional = requires {
+    typename T::value_type;
+    requires std::same_as<T, Optional<typename T::value_type>>;
+};
 
 } // namespace godzilla

--- a/include/godzilla/VTKOutput.h
+++ b/include/godzilla/VTKOutput.h
@@ -20,7 +20,7 @@ namespace godzilla {
 /// ```
 class VTKOutput : public FileOutput {
 public:
-    explicit VTKOutput(const Parameters & params);
+    explicit VTKOutput(const Parameters & pars);
     ~VTKOutput() override;
 
     void create() override;

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -19,13 +19,13 @@ AuxiliaryField::parameters()
     return params;
 }
 
-AuxiliaryField::AuxiliaryField(const Parameters & params) :
-    Object(params),
+AuxiliaryField::AuxiliaryField(const Parameters & pars) :
+    Object(pars),
     PrintInterface(this),
-    dpi(get_param<DiscreteProblemInterface *>("_dpi")),
+    dpi(pars.get<DiscreteProblemInterface *>("_dpi")),
     mesh(nullptr),
-    field(get_param<std::string>("field")),
-    region(get_param<std::string>("region")),
+    field(pars.get<std::string>("field")),
+    region(pars.get<std::string>("region")),
     block_id(-1)
 {
     CALL_STACK_MSG();

--- a/src/BasicTSAdapt.cpp
+++ b/src/BasicTSAdapt.cpp
@@ -13,7 +13,7 @@ BasicTSAdapt::parameters()
     return params;
 }
 
-BasicTSAdapt::BasicTSAdapt(const Parameters & params) : TimeSteppingAdaptor(params) {}
+BasicTSAdapt::BasicTSAdapt(const Parameters & pars) : TimeSteppingAdaptor(pars) {}
 
 void
 BasicTSAdapt::create()

--- a/src/BoundaryCondition.cpp
+++ b/src/BoundaryCondition.cpp
@@ -18,11 +18,11 @@ BoundaryCondition::parameters()
     return params;
 }
 
-BoundaryCondition::BoundaryCondition(const Parameters & params) :
-    Object(params),
+BoundaryCondition::BoundaryCondition(const Parameters & pars) :
+    Object(pars),
     PrintInterface(this),
-    dpi(get_param<DiscreteProblemInterface *>("_dpi")),
-    boundary(get_param<std::vector<std::string>>("boundary"))
+    dpi(pars.get<DiscreteProblemInterface *>("_dpi")),
+    boundary(pars.get<std::vector<std::string>>("boundary"))
 {
     CALL_STACK_MSG();
 }

--- a/src/BoxMesh.cpp
+++ b/src/BoxMesh.cpp
@@ -26,18 +26,18 @@ BoxMesh::parameters()
     return params;
 }
 
-BoxMesh::BoxMesh(const Parameters & parameters) :
-    MeshObject(parameters),
-    xmin(get_param<Real>("xmin")),
-    xmax(get_param<Real>("xmax")),
-    ymin(get_param<Real>("ymin")),
-    ymax(get_param<Real>("ymax")),
-    zmin(get_param<Real>("zmin")),
-    zmax(get_param<Real>("zmax")),
-    nx(get_param<Int>("nx")),
-    ny(get_param<Int>("ny")),
-    nz(get_param<Int>("nz")),
-    simplex(get_param<bool>("simplex") ? PETSC_TRUE : PETSC_FALSE),
+BoxMesh::BoxMesh(const Parameters & pars) :
+    MeshObject(pars),
+    xmin(pars.get<Real>("xmin")),
+    xmax(pars.get<Real>("xmax")),
+    ymin(pars.get<Real>("ymin")),
+    ymax(pars.get<Real>("ymax")),
+    zmin(pars.get<Real>("zmin")),
+    zmax(pars.get<Real>("zmax")),
+    nx(pars.get<Int>("nx")),
+    ny(pars.get<Int>("ny")),
+    nz(pars.get<Int>("nz")),
+    simplex(pars.get<bool>("simplex") ? PETSC_TRUE : PETSC_FALSE),
     interpolate(PETSC_TRUE)
 {
     CALL_STACK_MSG();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ target_code_coverage(${PROJECT_NAME})
 target_sanitization(${PROJECT_NAME})
 target_compile_options(${PROJECT_NAME}
     PRIVATE
-        $<$<CONFIG:Debug>:-Wall -Werror>
+        -Wall
         -ffile-prefix-map=${CMAKE_SOURCE_DIR}/include=include
         -ffile-prefix-map=${CMAKE_SOURCE_DIR}/src=godzilla/src
 )

--- a/src/CSVOutput.cpp
+++ b/src/CSVOutput.cpp
@@ -18,9 +18,7 @@ CSVOutput::parameters()
     return params;
 }
 
-CSVOutput::CSVOutput(const Parameters & params) : FileOutput(params), f(nullptr), has_header(false)
-{
-}
+CSVOutput::CSVOutput(const Parameters & pars) : FileOutput(pars), f(nullptr), has_header(false) {}
 
 CSVOutput::~CSVOutput()
 {

--- a/src/ConstantAuxiliaryField.cpp
+++ b/src/ConstantAuxiliaryField.cpp
@@ -15,9 +15,9 @@ ConstantAuxiliaryField::parameters()
     return params;
 }
 
-ConstantAuxiliaryField::ConstantAuxiliaryField(const Parameters & params) :
-    AuxiliaryField(params),
-    values(params.get<std::vector<Real>>("value"))
+ConstantAuxiliaryField::ConstantAuxiliaryField(const Parameters & pars) :
+    AuxiliaryField(pars),
+    values(pars.get<std::vector<Real>>("value"))
 {
     CALL_STACK_MSG();
     if (this->values.empty())

--- a/src/ConstantFunction.cpp
+++ b/src/ConstantFunction.cpp
@@ -27,9 +27,9 @@ ConstantFunction::parameters()
     return params;
 }
 
-ConstantFunction::ConstantFunction(const Parameters & params) :
-    Function(params),
-    val(get_param<Real>("value"))
+ConstantFunction::ConstantFunction(const Parameters & pars) :
+    Function(pars),
+    val(pars.get<Real>("value"))
 {
     CALL_STACK_MSG();
 }

--- a/src/ConstantInitialCondition.cpp
+++ b/src/ConstantInitialCondition.cpp
@@ -15,9 +15,9 @@ ConstantInitialCondition::parameters()
     return params;
 }
 
-ConstantInitialCondition::ConstantInitialCondition(const Parameters & params) :
-    InitialCondition(params),
-    values(get_param<std::vector<Real>>("value"))
+ConstantInitialCondition::ConstantInitialCondition(const Parameters & pars) :
+    InitialCondition(pars),
+    values(pars.get<std::vector<Real>>("value"))
 {
     CALL_STACK_MSG();
 }

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -179,5 +179,24 @@ to_str(SNESolver::LineSearch::LineSearchType type)
         return "unknown";
 }
 
+std::tuple<ExecuteOn, bool>
+to_execute_on(const std::vector<std::string> & vals)
+{
+    bool none = false;
+    ExecuteOn mask;
+    for (auto s : vals) {
+        s = utils::to_lower(s);
+        if (s == "initial")
+            mask |= EXECUTE_ON_INITIAL;
+        else if (s == "timestep")
+            mask |= EXECUTE_ON_TIMESTEP;
+        else if (s == "final")
+            mask |= EXECUTE_ON_FINAL;
+        else if (s == "none")
+            none = true;
+    }
+    return { mask, none };
+}
+
 } // namespace conv
 } // namespace godzilla

--- a/src/DGProblemInterface.cpp
+++ b/src/DGProblemInterface.cpp
@@ -18,8 +18,8 @@ namespace godzilla {
 
 const std::string DGProblemInterface::empty_name;
 
-DGProblemInterface::DGProblemInterface(Problem * problem, const Parameters & params) :
-    DiscreteProblemInterface(problem, params),
+DGProblemInterface::DGProblemInterface(Problem * problem, const Parameters & pars) :
+    DiscreteProblemInterface(problem, pars),
     qorder(PETSC_DETERMINE)
 {
     CALL_STACK_MSG();

--- a/src/DirichletBC.cpp
+++ b/src/DirichletBC.cpp
@@ -16,9 +16,9 @@ DirichletBC::parameters()
     return params;
 }
 
-DirichletBC::DirichletBC(const Parameters & params) :
-    EssentialBC(params),
-    FunctionInterface(params),
+DirichletBC::DirichletBC(const Parameters & pars) :
+    EssentialBC(pars),
+    FunctionInterface(pars),
     components(get_num_components(), 0)
 {
     CALL_STACK_MSG();

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -62,11 +62,11 @@ DiscreteProblemInterface::invoke_natural_riemann_bc_delegate(Real time,
     return 0;
 }
 
-DiscreteProblemInterface::DiscreteProblemInterface(Problem * problem, const Parameters & params) :
+DiscreteProblemInterface::DiscreteProblemInterface(Problem * problem, const Parameters & pars) :
     problem(problem),
-    mesh_obj(params.get<MeshObject *>("_mesh_obj")),
+    mesh_obj(pars.get<MeshObject *>("_mesh_obj")),
     unstr_mesh(nullptr),
-    logger(params.get<App *>("_app")->get_logger()),
+    logger(pars.get<App *>("_app")->get_logger()),
     ds(nullptr),
     dm_aux(nullptr),
     ds_aux(nullptr)

--- a/src/ExodusIIMesh.cpp
+++ b/src/ExodusIIMesh.cpp
@@ -14,7 +14,7 @@ ExodusIIMesh::parameters()
     return params;
 }
 
-ExodusIIMesh::ExodusIIMesh(const Parameters & parameters) : FileMesh(parameters)
+ExodusIIMesh::ExodusIIMesh(const Parameters & pars) : FileMesh(pars)
 {
     CALL_STACK_MSG();
     set_file_format(EXODUSII);

--- a/src/ExodusIIOutput.cpp
+++ b/src/ExodusIIOutput.cpp
@@ -99,15 +99,17 @@ ExodusIIOutput::parameters()
     params.add_private_param<MeshObject *>("_mesh_obj", nullptr)
         .add_param<std::vector<std::string>>(
             "variables",
+            std::vector<std::string> {},
             "List of variables to be stored. If not specified, all variables will be stored.");
     return params;
 }
 
-ExodusIIOutput::ExodusIIOutput(const Parameters & params) :
-    FileOutput(params),
+ExodusIIOutput::ExodusIIOutput(const Parameters & pars) :
+    FileOutput(pars),
     cont(false),
     discont(false),
-    variable_names(get_param<std::vector<std::string>>("variables")),
+    mesh_object(pars.get<MeshObject *>("_mesh_obj")),
+    variable_names(pars.get<std::vector<std::string>>("variables"), {}),
     dgpi(dynamic_cast<DGProblemInterface *>(get_problem())),
     step_num(1),
     mesh_stored(false)
@@ -140,9 +142,7 @@ ExodusIIOutput::create()
     FileOutput::create();
 
     auto dpi = get_discrete_problem_interface();
-
-    this->mesh =
-        dpi ? dpi->get_mesh() : get_param<MeshObject *>("_mesh_obj")->get_mesh<UnstructuredMesh>();
+    this->mesh = dpi ? dpi->get_mesh() : this->mesh_object->get_mesh<UnstructuredMesh>();
     if (this->mesh == nullptr)
         log_error("ExodusII output can be only used with unstructured meshes.");
 

--- a/src/ExplicitDGLinearProblem.cpp
+++ b/src/ExplicitDGLinearProblem.cpp
@@ -15,10 +15,10 @@ ExplicitDGLinearProblem::parameters()
     return params;
 }
 
-ExplicitDGLinearProblem::ExplicitDGLinearProblem(const Parameters & params) :
-    NonlinearProblem(params),
-    DGProblemInterface(this, params),
-    ExplicitProblemInterface(this, params)
+ExplicitDGLinearProblem::ExplicitDGLinearProblem(const Parameters & pars) :
+    NonlinearProblem(pars),
+    DGProblemInterface(this, pars),
+    ExplicitProblemInterface(this, pars)
 {
     CALL_STACK_MSG();
     set_default_output_on(EXECUTE_ON_INITIAL | EXECUTE_ON_TIMESTEP);

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -41,9 +41,9 @@ ExplicitFELinearProblem::parameters()
     return params;
 }
 
-ExplicitFELinearProblem::ExplicitFELinearProblem(const Parameters & params) :
-    FENonlinearProblem(params),
-    ExplicitProblemInterface(this, params)
+ExplicitFELinearProblem::ExplicitFELinearProblem(const Parameters & pars) :
+    FENonlinearProblem(pars),
+    ExplicitProblemInterface(this, pars)
 {
     CALL_STACK_MSG();
     set_default_output_on(EXECUTE_ON_INITIAL | EXECUTE_ON_TIMESTEP);

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -14,10 +14,10 @@ ExplicitFVLinearProblem::parameters()
     return params;
 }
 
-ExplicitFVLinearProblem::ExplicitFVLinearProblem(const Parameters & params) :
-    NonlinearProblem(params),
-    FVProblemInterface(this, params),
-    ExplicitProblemInterface(this, params)
+ExplicitFVLinearProblem::ExplicitFVLinearProblem(const Parameters & pars) :
+    NonlinearProblem(pars),
+    FVProblemInterface(this, pars),
+    ExplicitProblemInterface(this, pars)
 {
     CALL_STACK_MSG();
     set_default_output_on(EXECUTE_ON_INITIAL | EXECUTE_ON_TIMESTEP);

--- a/src/ExplicitProblemInterface.cpp
+++ b/src/ExplicitProblemInterface.cpp
@@ -20,10 +20,10 @@ ExplicitProblemInterface::parameters()
 }
 
 ExplicitProblemInterface::ExplicitProblemInterface(NonlinearProblem * problem,
-                                                   const Parameters & params) :
-    TransientProblemInterface(problem, params),
+                                                   const Parameters & pars) :
+    TransientProblemInterface(problem, pars),
     nl_problem(problem),
-    scheme(params.get<std::string>("scheme"))
+    scheme(pars.get<std::string>("scheme"))
 {
     if (!validation::in(this->scheme, { "euler", "ssp-rk-2", "ssp-rk-3", "rk-2", "heun" }))
         this->nl_problem->log_error("The 'scheme' parameter can be either 'euler', 'ssp-rk-2', "

--- a/src/FENonlinearProblem.cpp
+++ b/src/FENonlinearProblem.cpp
@@ -62,9 +62,9 @@ FENonlinearProblem::parameters()
     return params;
 }
 
-FENonlinearProblem::FENonlinearProblem(const Parameters & parameters) :
-    NonlinearProblem(parameters),
-    FEProblemInterface(this, parameters),
+FENonlinearProblem::FENonlinearProblem(const Parameters & pars) :
+    NonlinearProblem(pars),
+    FEProblemInterface(this, pars),
     state(INITIAL)
 {
     CALL_STACK_MSG();

--- a/src/FEProblemInterface.cpp
+++ b/src/FEProblemInterface.cpp
@@ -51,8 +51,8 @@ FEProblemInterface::AssemblyData::AssemblyData(Dimension dim) :
 {
 }
 
-FEProblemInterface::FEProblemInterface(Problem * problem, const Parameters & params) :
-    DiscreteProblemInterface(problem, params),
+FEProblemInterface::FEProblemInterface(Problem * problem, const Parameters & pars) :
+    DiscreteProblemInterface(problem, pars),
     DependencyEvaluator(),
     qorder(PETSC_DETERMINE)
 {

--- a/src/FVProblemInterface.cpp
+++ b/src/FVProblemInterface.cpp
@@ -33,8 +33,8 @@ FVProblemInterface::compute_flux(Int dim,
 
 const std::string FVProblemInterface::empty_name;
 
-FVProblemInterface::FVProblemInterface(Problem * problem, const Parameters & params) :
-    DiscreteProblemInterface(problem, params),
+FVProblemInterface::FVProblemInterface(Problem * problem, const Parameters & pars) :
+    DiscreteProblemInterface(problem, pars),
     fvm(nullptr)
 {
     CALL_STACK_MSG();

--- a/src/FileMesh.cpp
+++ b/src/FileMesh.cpp
@@ -21,11 +21,11 @@ FileMesh::parameters()
     return params;
 }
 
-FileMesh::FileMesh(const Parameters & parameters) : MeshObject(parameters), file_format(UNKNOWN)
+FileMesh::FileMesh(const Parameters & pars) : MeshObject(pars), file_format(UNKNOWN)
 {
     CALL_STACK_MSG();
 
-    std::filesystem::path file(get_param<std::string>("file"));
+    std::filesystem::path file(pars.get<std::string>("file"));
     if (file.is_absolute())
         this->file_name = file;
     else

--- a/src/FileOutput.cpp
+++ b/src/FileOutput.cpp
@@ -19,9 +19,9 @@ FileOutput::parameters()
     return params;
 }
 
-FileOutput::FileOutput(const Parameters & params) :
-    Output(params),
-    file_base(get_param<std::string>("file")),
+FileOutput::FileOutput(const Parameters & pars) :
+    Output(pars),
+    file_base(pars.get<std::string>("file")),
     dpi(dynamic_cast<DiscreteProblemInterface *>(get_problem()))
 {
     CALL_STACK_MSG();

--- a/src/Function.cpp
+++ b/src/Function.cpp
@@ -15,7 +15,7 @@ Function::parameters()
     return params;
 }
 
-Function::Function(const Parameters & params) : Object(params)
+Function::Function(const Parameters & pars) : Object(pars)
 {
     CALL_STACK_MSG();
 }

--- a/src/FunctionAuxiliaryField.cpp
+++ b/src/FunctionAuxiliaryField.cpp
@@ -15,9 +15,9 @@ FunctionAuxiliaryField::parameters()
     return params;
 }
 
-FunctionAuxiliaryField::FunctionAuxiliaryField(const Parameters & params) :
-    AuxiliaryField(params),
-    FunctionInterface(params)
+FunctionAuxiliaryField::FunctionAuxiliaryField(const Parameters & pars) :
+    AuxiliaryField(pars),
+    FunctionInterface(pars)
 {
     CALL_STACK_MSG();
 }

--- a/src/FunctionInitialCondition.cpp
+++ b/src/FunctionInitialCondition.cpp
@@ -14,9 +14,9 @@ FunctionInitialCondition::parameters()
     return params;
 }
 
-FunctionInitialCondition::FunctionInitialCondition(const Parameters & params) :
-    InitialCondition(params),
-    FunctionInterface(params)
+FunctionInitialCondition::FunctionInitialCondition(const Parameters & pars) :
+    InitialCondition(pars),
+    FunctionInterface(pars)
 {
 }
 

--- a/src/FunctionInterface.cpp
+++ b/src/FunctionInterface.cpp
@@ -26,13 +26,12 @@ FunctionInterface::valid_params_t()
     return params;
 }
 
-FunctionInterface::FunctionInterface(const Parameters & params) :
-    fi_app(params.get<App *>("_app")),
+FunctionInterface::FunctionInterface(const Parameters & pars) :
+    fi_app(pars.get<App *>("_app")),
     problem(nullptr),
-    expression(params.get<std::vector<std::string>>("value")),
-    expression_t(params.has<std::vector<std::string>>("value_t")
-                     ? params.get<std::vector<std::string>>("value_t")
-                     : std::vector<std::string>())
+    expression(pars.get<std::vector<std::string>>("value")),
+    expression_t(pars.is_param_valid("value_t") ? pars.get<std::vector<std::string>>("value_t")
+                                                : std::vector<std::string>())
 {
     this->num_comps = this->expression.size();
     // TODO: turn this into `log_error`

--- a/src/GmshMesh.cpp
+++ b/src/GmshMesh.cpp
@@ -13,7 +13,7 @@ GmshMesh::parameters()
     return params;
 }
 
-GmshMesh::GmshMesh(const Parameters & parameters) : FileMesh(parameters)
+GmshMesh::GmshMesh(const Parameters & pars) : FileMesh(pars)
 {
     CALL_STACK_MSG();
     set_file_format(GMSH);

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -40,10 +40,10 @@ ImplicitFENonlinearProblem::parameters()
     return params;
 }
 
-ImplicitFENonlinearProblem::ImplicitFENonlinearProblem(const Parameters & params) :
-    FENonlinearProblem(params),
-    TransientProblemInterface(this, params),
-    scheme(get_param<std::string>("scheme"))
+ImplicitFENonlinearProblem::ImplicitFENonlinearProblem(const Parameters & pars) :
+    FENonlinearProblem(pars),
+    TransientProblemInterface(this, pars),
+    scheme(pars.get<std::string>("scheme"))
 {
     CALL_STACK_MSG();
     set_default_output_on(EXECUTE_ON_INITIAL | EXECUTE_ON_TIMESTEP);

--- a/src/L2Diff.cpp
+++ b/src/L2Diff.cpp
@@ -17,10 +17,7 @@ L2Diff::parameters()
     return params;
 }
 
-L2Diff::L2Diff(const Parameters & params) :
-    Postprocessor(params),
-    FunctionInterface(params),
-    l2_diff(0.)
+L2Diff::L2Diff(const Parameters & pars) : Postprocessor(pars), FunctionInterface(pars), l2_diff(0.)
 {
 }
 

--- a/src/L2FieldDiff.cpp
+++ b/src/L2FieldDiff.cpp
@@ -19,12 +19,12 @@ L2FieldDiff::parameters()
     return params;
 }
 
-L2FieldDiff::L2FieldDiff(const Parameters & params) :
-    Postprocessor(params),
+L2FieldDiff::L2FieldDiff(const Parameters & pars) :
+    Postprocessor(pars),
     fepi(dynamic_cast<const FEProblemInterface *>(get_problem()))
 {
     CALL_STACK_MSG();
-    const auto & fn_map = get_param<std::map<std::string, std::vector<std::string>>>("functions");
+    const auto fn_map = pars.get<std::map<std::string, std::vector<std::string>>>("functions");
 
     if (this->fepi != nullptr) {
         for (const auto & [field_name, fn_names] : fn_map) {

--- a/src/LineMesh.cpp
+++ b/src/LineMesh.cpp
@@ -20,11 +20,11 @@ LineMesh::parameters()
     return params;
 }
 
-LineMesh::LineMesh(const Parameters & parameters) :
-    MeshObject(parameters),
-    xmin(get_param<Real>("xmin")),
-    xmax(get_param<Real>("xmax")),
-    nx(get_param<Int>("nx")),
+LineMesh::LineMesh(const Parameters & pars) :
+    MeshObject(pars),
+    xmin(pars.get<Real>("xmin")),
+    xmax(pars.get<Real>("xmax")),
+    nx(pars.get<Int>("nx")),
     interpolate(PETSC_TRUE)
 {
     CALL_STACK_MSG();

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -50,13 +50,13 @@ LinearProblem::parameters()
     return params;
 }
 
-LinearProblem::LinearProblem(const Parameters & parameters) :
-    Problem(parameters),
+LinearProblem::LinearProblem(const Parameters & pars) :
+    Problem(pars),
     RestartInterface(),
-    ksp_type(get_param<std::string>("ksp_type")),
-    lin_rel_tol(get_param<Real>("lin_rel_tol")),
-    lin_abs_tol(get_param<Real>("lin_abs_tol")),
-    lin_max_iter(get_param<Int>("lin_max_iter"))
+    ksp_type(pars.get<std::string>("ksp_type")),
+    lin_rel_tol(pars.get<Real>("lin_rel_tol")),
+    lin_abs_tol(pars.get<Real>("lin_abs_tol")),
+    lin_max_iter(pars.get<Int>("lin_max_iter"))
 {
     CALL_STACK_MSG();
     set_default_output_on(EXECUTE_ON_FINAL);

--- a/src/MeshObject.cpp
+++ b/src/MeshObject.cpp
@@ -17,7 +17,7 @@ MeshObject::parameters()
     return params;
 }
 
-MeshObject::MeshObject(const Parameters & parameters) : Object(parameters), PrintInterface(this) {}
+MeshObject::MeshObject(const Parameters & pars) : Object(pars), PrintInterface(this) {}
 
 void
 MeshObject::create()

--- a/src/MeshPartitioningOutput.cpp
+++ b/src/MeshPartitioningOutput.cpp
@@ -17,7 +17,7 @@ MeshPartitioningOutput::parameters()
     return params;
 }
 
-MeshPartitioningOutput::MeshPartitioningOutput(const Parameters & params) : FileOutput(params)
+MeshPartitioningOutput::MeshPartitioningOutput(const Parameters & pars) : FileOutput(pars)
 {
     CALL_STACK_MSG();
     set_file_base("part");

--- a/src/NaturalRiemannBC.cpp
+++ b/src/NaturalRiemannBC.cpp
@@ -15,8 +15,8 @@ NaturalRiemannBC::parameters()
     return params;
 }
 
-NaturalRiemannBC::NaturalRiemannBC(const Parameters & params) :
-    BoundaryCondition(params),
+NaturalRiemannBC::NaturalRiemannBC(const Parameters & pars) :
+    BoundaryCondition(pars),
     fid(FieldID::INVALID)
 {
     CALL_STACK_MSG();

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -37,18 +37,18 @@ NonlinearProblem::parameters()
     return params;
 }
 
-NonlinearProblem::NonlinearProblem(const Parameters & parameters) :
-    Problem(parameters),
+NonlinearProblem::NonlinearProblem(const Parameters & pars) :
+    Problem(pars),
     snes(),
     ksp(),
-    line_search_type(get_param<std::string>("line_search")),
-    nl_rel_tol(get_param<Real>("nl_rel_tol")),
-    nl_abs_tol(get_param<Real>("nl_abs_tol")),
-    nl_step_tol(get_param<Real>("nl_step_tol")),
-    nl_max_iter(get_param<Int>("nl_max_iter")),
-    lin_rel_tol(get_param<Real>("lin_rel_tol")),
-    lin_abs_tol(get_param<Real>("lin_abs_tol")),
-    lin_max_iter(get_param<Int>("lin_max_iter"))
+    line_search_type(pars.get<std::string>("line_search")),
+    nl_rel_tol(pars.get<Real>("nl_rel_tol")),
+    nl_abs_tol(pars.get<Real>("nl_abs_tol")),
+    nl_step_tol(pars.get<Real>("nl_step_tol")),
+    nl_max_iter(pars.get<Int>("nl_max_iter")),
+    lin_rel_tol(pars.get<Real>("lin_rel_tol")),
+    lin_abs_tol(pars.get<Real>("lin_abs_tol")),
+    lin_max_iter(pars.get<Int>("lin_max_iter"))
 {
     CALL_STACK_MSG();
     set_default_output_on(EXECUTE_ON_FINAL);

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -17,13 +17,11 @@ Object::parameters()
     return params;
 }
 
-Object::Object(const Parameters & parameters) :
-    LoggingInterface(parameters.get<App *>("_app")->get_logger(),
-                     parameters.get<std::string>("_name")),
-    pars(parameters),
-    app(get_param<App *>("_app")),
-    type(get_param<std::string>("_type")),
-    name(get_param<std::string>("_name"))
+Object::Object(const Parameters & pars) :
+    LoggingInterface(pars.get<App *>("_app")->get_logger(), pars.get<std::string>("_name")),
+    app(pars.get<App *>("_app")),
+    type(pars.get<std::string>("_type")),
+    name(pars.get<std::string>("_name"))
 {
     CALL_STACK_MSG();
 }
@@ -40,20 +38,6 @@ Object::get_name() const
 {
     CALL_STACK_MSG();
     return this->name;
-}
-
-const Parameters &
-Object::get_parameters() const
-{
-    CALL_STACK_MSG();
-    return this->pars;
-}
-
-bool
-Object::is_param_valid(const std::string & par_name) const
-{
-    CALL_STACK_MSG();
-    return this->pars.is_param_valid(par_name);
 }
 
 App *

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -12,18 +12,21 @@ Parameters::~Parameters()
 
 Parameters::Parameters(const Parameters & other)
 {
+    CALL_STACK_MSG();
     for (const auto & [key, val] : other.params)
         params[key] = val->copy();
 }
 
 Parameters::Parameters(Parameters && other) noexcept : params(std::move(other.params))
 {
+    CALL_STACK_MSG();
     other.params.clear();
 }
 
 Parameters &
 Parameters::operator=(const Parameters & other)
 {
+    CALL_STACK_MSG();
     if (this != &other) {
         clear();
         for (const auto & [key, val] : other.params)
@@ -35,6 +38,7 @@ Parameters::operator=(const Parameters & other)
 Parameters &
 Parameters::operator=(Parameters && other) noexcept
 {
+    CALL_STACK_MSG();
     if (this != &other) {
         clear();
         params = std::move(other.params);
@@ -46,6 +50,7 @@ Parameters::operator=(Parameters && other) noexcept
 Parameters &
 Parameters::operator+=(const Parameters & rhs)
 {
+    CALL_STACK_MSG();
     for (const auto & [name, value] : rhs) {
         auto jt = this->params.find(name);
         if (jt != this->params.end())
@@ -58,30 +63,35 @@ Parameters::operator+=(const Parameters & rhs)
 bool
 Parameters::is_param_required(const std::string & name) const
 {
+    CALL_STACK_MSG();
     return this->params.count(name) > 0 && this->params.at(name)->required;
 }
 
 bool
 Parameters::is_param_valid(const std::string & name) const
 {
+    CALL_STACK_MSG();
     return this->params.count(name) > 0 && this->params.at(name)->valid;
 }
 
 bool
 Parameters::is_private(const std::string & name) const
 {
+    CALL_STACK_MSG();
     return this->params.count(name) > 0 && this->params.at(name)->is_private;
 }
 
 std::string
 Parameters::type(const std::string & name) const
 {
+    CALL_STACK_MSG();
     return this->params.at(name)->type();
 }
 
 std::string
 Parameters::get_doc_string(const std::string & name) const
 {
+    CALL_STACK_MSG();
     auto it = this->params.find(name);
     if (it != this->params.end())
         return it->second->doc_string;
@@ -92,30 +102,35 @@ Parameters::get_doc_string(const std::string & name) const
 Parameters::iterator
 Parameters::begin()
 {
+    CALL_STACK_MSG();
     return this->params.begin();
 }
 
 Parameters::const_iterator
 Parameters::begin() const
 {
+    CALL_STACK_MSG();
     return this->params.begin();
 }
 
 Parameters::iterator
 Parameters ::end()
 {
+    CALL_STACK_MSG();
     return this->params.end();
 }
 
 Parameters::const_iterator
 Parameters::end() const
 {
+    CALL_STACK_MSG();
     return this->params.end();
 }
 
 void
 Parameters::clear()
 {
+    CALL_STACK_MSG();
     for (auto & [_, value] : this->params)
         delete value;
     this->params.clear();

--- a/src/ParsedFunction.cpp
+++ b/src/ParsedFunction.cpp
@@ -28,10 +28,10 @@ ParsedFunction::parameters()
     return params;
 }
 
-ParsedFunction::ParsedFunction(const Parameters & params) :
-    Function(params),
-    function(get_param<std::vector<std::string>>("function")),
-    constants(get_param<std::map<std::string, Real>>("constants"))
+ParsedFunction::ParsedFunction(const Parameters & pars) :
+    Function(pars),
+    function(pars.get<std::vector<std::string>>("function")),
+    constants(pars.get<std::map<std::string, Real>>("constants"))
 {
     CALL_STACK_MSG();
     this->evalr.create(this->function);

--- a/src/PiecewiseConstant.cpp
+++ b/src/PiecewiseConstant.cpp
@@ -25,11 +25,11 @@ PiecewiseConstant::parameters()
     return params;
 }
 
-PiecewiseConstant::PiecewiseConstant(const Parameters & params) :
-    Function(params),
+PiecewiseConstant::PiecewiseConstant(const Parameters & pars) :
+    Function(pars),
     continuity(RIGHT),
-    x(get_param<std::vector<Real>>("x")),
-    y(get_param<std::vector<Real>>("y"))
+    x(pars.get<std::vector<Real>>("x")),
+    y(pars.get<std::vector<Real>>("y"))
 {
     CALL_STACK_MSG();
     if (this->x.size() + 1 != this->y.size())
@@ -46,6 +46,16 @@ PiecewiseConstant::PiecewiseConstant(const Parameters & params) :
                 log_error("Values in 'x' must be increasing. Failed at index '{}'.", i + 1);
         }
     }
+
+    auto cont = utils::to_lower(pars.get<std::string>("continuity"));
+    if (validation::in(cont, { "left", "right" })) {
+        if (cont == "left")
+            this->continuity = LEFT;
+        else if (cont == "right")
+            this->continuity = RIGHT;
+    }
+    else
+        log_error("The 'continuity' parameter can be either 'left' or 'right'.");
 }
 
 void
@@ -59,16 +69,6 @@ void
 PiecewiseConstant::create()
 {
     CALL_STACK_MSG();
-    auto cont = get_param<std::string>("continuity");
-    if (validation::in(cont, { "left", "right" })) {
-        std::string cont_lc = utils::to_lower(cont);
-        if (cont_lc == "left")
-            this->continuity = LEFT;
-        else if (cont_lc == "right")
-            this->continuity = RIGHT;
-    }
-    else
-        log_error("The 'continuity' parameter can be either 'left' or 'right'.");
 }
 
 Real

--- a/src/PiecewiseLinear.cpp
+++ b/src/PiecewiseLinear.cpp
@@ -22,12 +22,12 @@ PiecewiseLinear::parameters()
     return params;
 }
 
-PiecewiseLinear::PiecewiseLinear(const Parameters & params) : Function(params), linpol(nullptr)
+PiecewiseLinear::PiecewiseLinear(const Parameters & pars) : Function(pars), linpol(nullptr)
 {
     CALL_STACK_MSG();
     try {
-        this->linpol = Qtr<LinearInterpolation>::alloc(get_param<std::vector<Real>>("x"),
-                                                       get_param<std::vector<Real>>("y"));
+        this->linpol = Qtr<LinearInterpolation>::alloc(pars.get<std::vector<Real>>("x"),
+                                                       pars.get<std::vector<Real>>("y"));
     }
     catch (std::exception & e) {
         log_error("{}", e.what());

--- a/src/Postprocessor.cpp
+++ b/src/Postprocessor.cpp
@@ -14,10 +14,10 @@ Postprocessor::parameters()
     return params;
 }
 
-Postprocessor::Postprocessor(const Parameters & params) :
-    Object(params),
+Postprocessor::Postprocessor(const Parameters & pars) :
+    Object(pars),
     PrintInterface(this),
-    problem(get_param<Problem *>("_problem"))
+    problem(pars.get<Problem *>("_problem"))
 {
 }
 

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -39,10 +39,10 @@ Problem::parameters()
     return params;
 }
 
-Problem::Problem(const Parameters & parameters) :
-    Object(parameters),
+Problem::Problem(const Parameters & pars) :
+    Object(pars),
     PrintInterface(this),
-    mesh(get_param<MeshObject *>("_mesh_obj")),
+    mesh(pars.get<MeshObject *>("_mesh_obj")),
     partitioner(nullptr),
     partition_overlap(0),
     default_output_on()
@@ -157,8 +157,6 @@ void
 Problem::add_output(Output * output)
 {
     CALL_STACK_MSG();
-    if (!output->is_param_valid("on"))
-        output->set_exec_mask(this->default_output_on);
     this->outputs.push_back(output);
     auto fo = dynamic_cast<FileOutput *>(output);
     if (fo)
@@ -337,6 +335,12 @@ void
 Problem::set_default_output_on(ExecuteOn flags)
 {
     this->default_output_on = flags;
+}
+
+ExecuteOn
+Problem::get_default_output_on() const
+{
+    return this->default_output_on;
 }
 
 Problem::FieldDecomposition

--- a/src/RZSymmetry.cpp
+++ b/src/RZSymmetry.cpp
@@ -20,11 +20,11 @@ RZSymmetry::parameters()
     return params;
 }
 
-RZSymmetry::RZSymmetry(const Parameters & params) :
-    Object(params),
-    dpi(get_param<DiscreteProblemInterface *>("_dpi")),
-    axis(get_param<std::vector<Real>>("axis")),
-    pt(get_param<std::vector<Real>>("point"))
+RZSymmetry::RZSymmetry(const Parameters & pars) :
+    Object(pars),
+    dpi(pars.get<DiscreteProblemInterface *>("_dpi")),
+    axis(pars.get<std::vector<Real>>("axis")),
+    pt(pars.get<std::vector<Real>>("point"))
 {
     CALL_STACK_MSG();
 }

--- a/src/RectangleMesh.cpp
+++ b/src/RectangleMesh.cpp
@@ -23,15 +23,15 @@ RectangleMesh::parameters()
     return params;
 }
 
-RectangleMesh::RectangleMesh(const Parameters & parameters) :
-    MeshObject(parameters),
-    xmin(get_param<Real>("xmin")),
-    xmax(get_param<Real>("xmax")),
-    ymin(get_param<Real>("ymin")),
-    ymax(get_param<Real>("ymax")),
-    nx(get_param<Int>("nx")),
-    ny(get_param<Int>("ny")),
-    simplex(get_param<bool>("simplex") ? PETSC_TRUE : PETSC_FALSE),
+RectangleMesh::RectangleMesh(const Parameters & pars) :
+    MeshObject(pars),
+    xmin(pars.get<Real>("xmin")),
+    xmax(pars.get<Real>("xmax")),
+    ymin(pars.get<Real>("ymin")),
+    ymax(pars.get<Real>("ymax")),
+    nx(pars.get<Int>("nx")),
+    ny(pars.get<Int>("ny")),
+    simplex(pars.get<bool>("simplex") ? PETSC_TRUE : PETSC_FALSE),
     interpolate(PETSC_TRUE)
 {
     CALL_STACK_MSG();

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "godzilla/Registry.h"
+#include "godzilla/Utils.h"
 
 namespace godzilla {
 

--- a/src/RestartOutput.cpp
+++ b/src/RestartOutput.cpp
@@ -18,8 +18,8 @@ RestartOutput::parameters()
     return params;
 }
 
-RestartOutput::RestartOutput(const Parameters & params) :
-    FileOutput(params),
+RestartOutput::RestartOutput(const Parameters & pars) :
+    FileOutput(pars),
     ri(dynamic_cast<RestartInterface *>(get_problem()))
 {
 }

--- a/src/TecplotOutput.cpp
+++ b/src/TecplotOutput.cpp
@@ -79,14 +79,14 @@ TecplotOutput::parameters()
     return params;
 }
 
-TecplotOutput::TecplotOutput(const Parameters & params) :
-    FileOutput(params),
+TecplotOutput::TecplotOutput(const Parameters & pars) :
+    FileOutput(pars),
 #ifdef GODZILLA_WITH_TECIOCPP
     mesh(nullptr),
     file(nullptr),
     n_zones(0),
 #endif
-    variable_names(get_param<std::vector<std::string>>("variables"))
+    variable_names(pars.get<std::vector<std::string>>("variables"))
 {
     CALL_STACK_MSG();
 #ifdef GODZILLA_WITH_TECIOCPP

--- a/src/TimeSteppingAdaptor.cpp
+++ b/src/TimeSteppingAdaptor.cpp
@@ -18,13 +18,13 @@ TimeSteppingAdaptor::parameters()
     return params;
 }
 
-TimeSteppingAdaptor::TimeSteppingAdaptor(const Parameters & params) :
-    Object(params),
-    problem(get_param<Problem *>("_problem")),
+TimeSteppingAdaptor::TimeSteppingAdaptor(const Parameters & pars) :
+    Object(pars),
+    problem(pars.get<Problem *>("_problem")),
     tpi(dynamic_cast<TransientProblemInterface *>(problem)),
     ts_adapt(nullptr),
-    dt_min(get_param<Real>("dt_min")),
-    dt_max(get_param<Real>("dt_max"))
+    dt_min(pars.get<Real>("dt_min")),
+    dt_max(pars.get<Real>("dt_max"))
 {
     CALL_STACK_MSG();
     if (this->tpi)

--- a/src/TransientProblemInterface.cpp
+++ b/src/TransientProblemInterface.cpp
@@ -194,12 +194,14 @@ TransientProblemInterface::parameters()
     return params;
 }
 
-TransientProblemInterface::TransientProblemInterface(Problem * problem, const Parameters & params) :
+TransientProblemInterface::TransientProblemInterface(Problem * problem, const Parameters & pars) :
     ts(nullptr),
     problem(problem),
     ts_adaptor(nullptr),
-    start_time(params.get<Real>("start_time")),
-    dt_initial(params.get<Real>("dt")),
+    start_time(pars.get<Real>("start_time")),
+    end_time(pars.get<Optional<Real>>("end_time")),
+    num_steps(pars.get<Optional<Int>>("num_steps")),
+    dt_initial(pars.get<Real>("dt")),
     step_num(0)
 {
     CALL_STACK_MSG();
@@ -207,16 +209,11 @@ TransientProblemInterface::TransientProblemInterface(Problem * problem, const Pa
     PETSC_CHECK(TSSetApplicationContext(this->ts, this));
     this->time_step_adapt = TimeStepAdapt::from_ts(this->ts);
 
-    if (params.is_param_valid("end_time") && params.is_param_valid("num_steps"))
+    if (this->end_time.has_value() && this->num_steps.has_value())
         this->problem->log_error(
             "Cannot provide 'end_time' and 'num_steps' together. Specify one or the other.");
-    if (!params.is_param_valid("end_time") && !params.is_param_valid("num_steps"))
+    if (!this->end_time.has_value() && !this->num_steps.has_value())
         this->problem->log_error("You must provide either 'end_time' or 'num_steps' parameter.");
-
-    if (params.is_param_valid("end_time"))
-        this->end_time = params.get<Real>("end_time");
-    if (params.is_param_valid("num_steps"))
-        this->num_steps = params.get<Int>("num_steps");
 }
 
 TransientProblemInterface::~TransientProblemInterface()

--- a/test/common/GTest2FieldsFENonlinearProblem.cpp
+++ b/test/common/GTest2FieldsFENonlinearProblem.cpp
@@ -1,7 +1,7 @@
 #include "GTest2FieldsFENonlinearProblem.h"
 
-GTest2FieldsFENonlinearProblem::GTest2FieldsFENonlinearProblem(const Parameters & params) :
-    GTestFENonlinearProblem(params),
+GTest2FieldsFENonlinearProblem::GTest2FieldsFENonlinearProblem(const Parameters & pars) :
+    GTestFENonlinearProblem(pars),
     iv(1)
 {
 }

--- a/test/common/GTest2FieldsFENonlinearProblem.h
+++ b/test/common/GTest2FieldsFENonlinearProblem.h
@@ -8,7 +8,7 @@ using namespace godzilla;
 /// Test problem for simple FE solver with 2 fields
 class GTest2FieldsFENonlinearProblem : public GTestFENonlinearProblem {
 public:
-    GTest2FieldsFENonlinearProblem(const Parameters & params);
+    GTest2FieldsFENonlinearProblem(const Parameters & pars);
 
 protected:
     virtual void set_up_fields() override;

--- a/test/common/GTestFENonlinearProblem.cpp
+++ b/test/common/GTestFENonlinearProblem.cpp
@@ -56,8 +56,8 @@ protected:
 
 } // namespace
 
-GTestFENonlinearProblem::GTestFENonlinearProblem(const Parameters & params) :
-    FENonlinearProblem(params),
+GTestFENonlinearProblem::GTestFENonlinearProblem(const Parameters & pars) :
+    FENonlinearProblem(pars),
     iu(0)
 {
 }

--- a/test/common/GTestFENonlinearProblem.h
+++ b/test/common/GTestFENonlinearProblem.h
@@ -7,7 +7,7 @@ using namespace godzilla;
 /// Test problem for simple FE solver
 class GTestFENonlinearProblem : public FENonlinearProblem {
 public:
-    explicit GTestFENonlinearProblem(const Parameters & params);
+    explicit GTestFENonlinearProblem(const Parameters & pars);
 
     PetscDS get_ds();
     void set_up_initial_guess() override;

--- a/test/common/GTestImplicitFENonlinearProblem.cpp
+++ b/test/common/GTestImplicitFENonlinearProblem.cpp
@@ -86,8 +86,8 @@ protected:
 
 } // namespace
 
-GTestImplicitFENonlinearProblem::GTestImplicitFENonlinearProblem(const Parameters & params) :
-    ImplicitFENonlinearProblem(params),
+GTestImplicitFENonlinearProblem::GTestImplicitFENonlinearProblem(const Parameters & pars) :
+    ImplicitFENonlinearProblem(pars),
     iu(0)
 {
 }

--- a/test/common/GTestImplicitFENonlinearProblem.h
+++ b/test/common/GTestImplicitFENonlinearProblem.h
@@ -7,7 +7,7 @@ using namespace godzilla;
 /// Test problem for simple FE solver
 class GTestImplicitFENonlinearProblem : public ImplicitFENonlinearProblem {
 public:
-    explicit GTestImplicitFENonlinearProblem(const Parameters & params);
+    explicit GTestImplicitFENonlinearProblem(const Parameters & pars);
     void set_up_initial_guess() override;
 
 protected:

--- a/test/common/TestMesh1D.cpp
+++ b/test/common/TestMesh1D.cpp
@@ -9,7 +9,7 @@ TestMesh1D::parameters()
     return params;
 }
 
-TestMesh1D::TestMesh1D(const Parameters & parameters) : MeshObject(parameters) {}
+TestMesh1D::TestMesh1D(const Parameters & pars) : MeshObject(pars) {}
 
 Qtr<Mesh>
 TestMesh1D::create_mesh()

--- a/test/common/TestMesh1D.h
+++ b/test/common/TestMesh1D.h
@@ -8,7 +8,7 @@
 
 class TestMesh1D : public godzilla::MeshObject {
 public:
-    explicit TestMesh1D(const godzilla::Parameters & parameters);
+    explicit TestMesh1D(const godzilla::Parameters & pars);
 
     godzilla::Qtr<godzilla::Mesh> create_mesh() override;
 

--- a/test/common/TestMesh2D.cpp
+++ b/test/common/TestMesh2D.cpp
@@ -9,7 +9,7 @@ TestMesh2D::parameters()
     return params;
 }
 
-TestMesh2D::TestMesh2D(const Parameters & parameters) : MeshObject(parameters) {}
+TestMesh2D::TestMesh2D(const Parameters & pars) : MeshObject(pars) {}
 
 Qtr<Mesh>
 TestMesh2D::create_mesh()

--- a/test/common/TestMesh2D.h
+++ b/test/common/TestMesh2D.h
@@ -7,7 +7,7 @@
 
 class TestMesh2D : public godzilla::MeshObject {
 public:
-    explicit TestMesh2D(const godzilla::Parameters & parameters);
+    explicit TestMesh2D(const godzilla::Parameters & pars);
 
     godzilla::Qtr<godzilla::Mesh> create_mesh() override;
 

--- a/test/common/TestMesh3D.cpp
+++ b/test/common/TestMesh3D.cpp
@@ -9,7 +9,7 @@ TestMesh3D::parameters()
     return params;
 }
 
-TestMesh3D::TestMesh3D(const godzilla::Parameters & parameters) : MeshObject(parameters) {}
+TestMesh3D::TestMesh3D(const godzilla::Parameters & pars) : MeshObject(pars) {}
 
 Qtr<Mesh>
 TestMesh3D::create_mesh()

--- a/test/common/TestMesh3D.h
+++ b/test/common/TestMesh3D.h
@@ -8,7 +8,7 @@
 
 class TestMesh3D : public godzilla::MeshObject {
 public:
-    explicit TestMesh3D(const godzilla::Parameters & parameters);
+    explicit TestMesh3D(const godzilla::Parameters & pars);
 
     godzilla::Qtr<godzilla::Mesh> create_mesh() override;
 

--- a/test/src/App_test.cpp
+++ b/test/src/App_test.cpp
@@ -14,7 +14,7 @@ namespace {
 
 class MockProblem : public Problem {
 public:
-    explicit MockProblem(const Parameters & params) : Problem(params) {}
+    explicit MockProblem(const Parameters & pars) : Problem(pars) {}
 
     MOCK_METHOD(void, create, ());
     MOCK_METHOD(void, run, ());
@@ -25,7 +25,7 @@ public:
 
 class TestProblem : public Problem {
 public:
-    explicit TestProblem(const Parameters & params) : Problem(params) {}
+    explicit TestProblem(const Parameters & pars) : Problem(pars) {}
 
     void
     create() override

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -20,7 +20,8 @@ TEST_F(AuxiliaryFieldTest, api)
 {
     class TestAuxFld : public AuxiliaryField {
     public:
-        explicit TestAuxFld(const Parameters & params) : AuxiliaryField(params) {}
+        explicit TestAuxFld(const Parameters & pars) : AuxiliaryField(pars) {}
+
         Int
         get_num_components() const override
         {

--- a/test/src/BndJacobianFunc_test.cpp
+++ b/test/src/BndJacobianFunc_test.cpp
@@ -13,7 +13,7 @@ namespace {
 
 class TestBC : public NaturalBC {
 public:
-    explicit TestBC(const Parameters & params) : NaturalBC(params), components({ 0 }) {}
+    explicit TestBC(const Parameters & pars) : NaturalBC(pars), components({ 0 }) {}
 
     const std::vector<Int> &
     get_components() const override
@@ -32,7 +32,7 @@ protected:
 
 class GTestProblem : public ImplicitFENonlinearProblem {
 public:
-    explicit GTestProblem(const Parameters & params) : ImplicitFENonlinearProblem(params) {}
+    explicit GTestProblem(const Parameters & pars) : ImplicitFENonlinearProblem(pars) {}
 
 protected:
     void

--- a/test/src/BndResidualFunc_test.cpp
+++ b/test/src/BndResidualFunc_test.cpp
@@ -13,7 +13,7 @@ namespace {
 
 class TestBC : public NaturalBC {
 public:
-    explicit TestBC(const Parameters & params) : NaturalBC(params), components({ 0 }) {}
+    explicit TestBC(const Parameters & pars) : NaturalBC(pars), components({ 0 }) {}
 
     const std::vector<Int> &
     get_components() const override
@@ -32,7 +32,7 @@ protected:
 
 class GTestProblem : public ImplicitFENonlinearProblem {
 public:
-    explicit GTestProblem(const Parameters & params) : ImplicitFENonlinearProblem(params) {}
+    explicit GTestProblem(const Parameters & pars) : ImplicitFENonlinearProblem(pars) {}
 
 protected:
     void

--- a/test/src/BoundaryCondition_test.cpp
+++ b/test/src/BoundaryCondition_test.cpp
@@ -14,7 +14,7 @@ public:
 
 class MockBoundaryCondition : public BoundaryCondition {
 public:
-    explicit MockBoundaryCondition(const Parameters & params) : BoundaryCondition(params) {}
+    explicit MockBoundaryCondition(const Parameters & pars) : BoundaryCondition(pars) {}
 
     MOCK_METHOD((DMBoundaryConditionType), get_bc_type, (), (const));
     MOCK_METHOD(void, evaluate, (Int, Real, const Real x[], Int Nc, Scalar u[]), ());

--- a/test/src/DirichletBC_test.cpp
+++ b/test/src/DirichletBC_test.cpp
@@ -32,6 +32,7 @@ TEST(DirichletBCTest, api)
     auto params = DirichletBC::parameters();
     params.set<App *>("_app", &app)
         .set<DiscreteProblemInterface *>("_dpi", &problem)
+        .set<std::vector<std::string>>("boundary", {})
         .set<std::vector<std::string>>("value", { "t * (x + y + z)" })
         .set<std::vector<std::string>>("value_t", { "1" });
     DirichletBC obj(params);
@@ -80,6 +81,7 @@ TEST(DirichletBCTest, with_user_defined_fn)
     auto bc_pars = DirichletBC::parameters();
     bc_pars.set<App *>("_app", &app)
         .set<DiscreteProblemInterface *>("_dpi", &problem)
+        .set<std::vector<std::string>>("boundary", {})
         .set<std::vector<std::string>>("value", { "ipol(x)" });
     DirichletBC bc(bc_pars);
 

--- a/test/src/EssentialBC_test.cpp
+++ b/test/src/EssentialBC_test.cpp
@@ -47,8 +47,9 @@ TEST(EssentialBCTest, api)
     app.set_problem(&problem);
 
     auto params = TestEssentialBC::parameters();
-    params.set<App *>("_app", &app);
-    params.set<DiscreteProblemInterface *>("_dpi", &problem);
+    params.set<App *>("_app", &app)
+        .set<DiscreteProblemInterface *>("_dpi", &problem)
+        .set<std::vector<std::string>>("boundary", {});
     TestEssentialBC bc(params);
 
     mesh.create();
@@ -79,9 +80,10 @@ TEST(EssentialBCTest, non_existing_field)
     app.set_problem(&problem);
 
     Parameters params = TestEssentialBC::parameters();
-    params.set<App *>("_app", &app);
-    params.set<DiscreteProblemInterface *>("_dpi", &problem);
-    params.set<std::string>("field", "asdf");
+    params.set<App *>("_app", &app)
+        .set<DiscreteProblemInterface *>("_dpi", &problem)
+        .set<std::string>("field", "asdf")
+        .set<std::vector<std::string>>("boundary", {});
     TestEssentialBC bc(params);
 
     mesh.create();
@@ -113,8 +115,9 @@ TEST(EssentialBCTest, field_param_not_specified)
     app.set_problem(&problem);
 
     auto params = TestEssentialBC::parameters();
-    params.set<App *>("_app", &app);
-    params.set<DiscreteProblemInterface *>("_dpi", &problem);
+    params.set<App *>("_app", &app)
+        .set<DiscreteProblemInterface *>("_dpi", &problem)
+        .set<std::vector<std::string>>("boundary", {});
     TestEssentialBC bc(params);
 
     mesh.create();

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -101,7 +101,7 @@ TEST(ExodusIIOutputTest, fe_check)
 
     class TestMesh : public MeshObject {
     public:
-        explicit TestMesh(const Parameters & params) : MeshObject(params) {}
+        explicit TestMesh(const Parameters & pars) : MeshObject(pars) {}
 
         Qtr<Mesh>
         create_mesh() override
@@ -112,7 +112,7 @@ TEST(ExodusIIOutputTest, fe_check)
 
     class TestLinearProblem : public Problem {
     public:
-        explicit TestLinearProblem(const Parameters & params) : Problem(params) {}
+        explicit TestLinearProblem(const Parameters & pars) : Problem(pars) {}
 
         void
         run()

--- a/test/src/ExplicitFELinearProblem_test.cpp
+++ b/test/src/ExplicitFELinearProblem_test.cpp
@@ -15,10 +15,7 @@ namespace {
 
 class TestExplicitFELinearProblem : public ExplicitFELinearProblem {
 public:
-    explicit TestExplicitFELinearProblem(const Parameters & params) :
-        ExplicitFELinearProblem(params)
-    {
-    }
+    explicit TestExplicitFELinearProblem(const Parameters & pars) : ExplicitFELinearProblem(pars) {}
 
     void
     create() override

--- a/test/src/ExplicitFVLinearProblem_test.cpp
+++ b/test/src/ExplicitFVLinearProblem_test.cpp
@@ -15,9 +15,9 @@ namespace {
 
 class TestBC : public NaturalRiemannBC {
 public:
-    explicit TestBC(const Parameters & params) :
-        NaturalRiemannBC(params),
-        inlet(get_param<bool>("inlet")),
+    explicit TestBC(const Parameters & pars) :
+        NaturalRiemannBC(pars),
+        inlet(pars.get<bool>("inlet")),
         components({ 0 })
     {
     }
@@ -57,10 +57,7 @@ class TestExplicitFVLinearProblem;
 
 class TestExplicitFVLinearProblem : public ExplicitFVLinearProblem {
 public:
-    explicit TestExplicitFVLinearProblem(const Parameters & params) :
-        ExplicitFVLinearProblem(params)
-    {
-    }
+    explicit TestExplicitFVLinearProblem(const Parameters & pars) : ExplicitFVLinearProblem(pars) {}
 
     void
     create() override

--- a/test/src/FENonlinearProblemJFNK_test.cpp
+++ b/test/src/FENonlinearProblemJFNK_test.cpp
@@ -17,7 +17,7 @@ namespace {
 /// Test problem for simple FE solver using JFNK
 class GTestFENonlinearProblemJFNK : public FENonlinearProblem {
 public:
-    explicit GTestFENonlinearProblemJFNK(const Parameters & params);
+    explicit GTestFENonlinearProblemJFNK(const Parameters & pars);
 
 protected:
     void set_up_fields() override;
@@ -81,8 +81,8 @@ protected:
     const Dimension & dim;
 };
 
-GTestFENonlinearProblemJFNK::GTestFENonlinearProblemJFNK(const Parameters & params) :
-    FENonlinearProblem(params),
+GTestFENonlinearProblemJFNK::GTestFENonlinearProblemJFNK(const Parameters & pars) :
+    FENonlinearProblem(pars),
     iu(0)
 {
 }

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -21,7 +21,7 @@ namespace {
 /// Test IC with 2 components
 class GTest2CompIC : public InitialCondition {
 public:
-    explicit GTest2CompIC(const Parameters & params) : InitialCondition(params) {}
+    explicit GTest2CompIC(const Parameters & pars) : InitialCondition(pars) {}
 
     Int
     get_num_components() const override

--- a/test/src/Factory_test.cpp
+++ b/test/src/Factory_test.cpp
@@ -12,7 +12,7 @@ namespace {
 
 class TestObject : public Object {
 public:
-    explicit TestObject(const Parameters & parameters) : Object(parameters) {}
+    explicit TestObject(const Parameters & pars) : Object(pars) {}
 };
 
 } // namespace

--- a/test/src/GYMLFile_test.cpp
+++ b/test/src/GYMLFile_test.cpp
@@ -27,9 +27,9 @@ public:
 
 class GTestProblem : public Problem, public TransientProblemInterface {
 public:
-    explicit GTestProblem(const Parameters & params) :
-        Problem(params),
-        TransientProblemInterface(this, params)
+    explicit GTestProblem(const Parameters & pars) :
+        Problem(pars),
+        TransientProblemInterface(this, pars)
     {
     }
 
@@ -206,17 +206,6 @@ TEST_F(GYMLFileTest, build)
 
     auto problem = file.get_problem();
     EXPECT_NE(problem, nullptr);
-
-    EXPECT_EQ(problem->get_param<std::string>("str"), "input_str");
-    EXPECT_EQ(problem->get_param<int>("i"), -4321);
-    EXPECT_EQ(problem->get_param<unsigned int>("ui"), 7890);
-    EXPECT_EQ(problem->get_param<double>("d"), 34.567);
-    EXPECT_THAT(problem->get_param<std::vector<double>>("arr_d"), testing::ElementsAre(2.));
-    EXPECT_THAT(problem->get_param<std::vector<int>>("arr_i"), testing::ElementsAre(5));
-    EXPECT_THAT(problem->get_param<std::vector<std::string>>("arr_str"),
-                testing::ElementsAre("xyz"));
-    EXPECT_EQ(problem->get_param<bool>("bool1"), true);
-    EXPECT_EQ(problem->get_param<bool>("bool2"), false);
 }
 
 TEST_F(GYMLFileTest, funcs)

--- a/test/src/InitialCondition_test.cpp
+++ b/test/src/InitialCondition_test.cpp
@@ -20,7 +20,7 @@ public:
 
 class MockInitialCondition : public InitialCondition {
 public:
-    explicit MockInitialCondition(const Parameters & params) : InitialCondition(params) {}
+    explicit MockInitialCondition(const Parameters & pars) : InitialCondition(pars) {}
 
     Int
     get_num_components() const override
@@ -32,7 +32,7 @@ public:
 
 class TestInitialCondition : public InitialCondition {
 public:
-    explicit TestInitialCondition(const Parameters & params) : InitialCondition(params) {}
+    explicit TestInitialCondition(const Parameters & pars) : InitialCondition(pars) {}
 
     Int
     get_num_components() const override
@@ -49,7 +49,7 @@ public:
 
 class TestVectorInitialCondition : public InitialCondition {
 public:
-    explicit TestVectorInitialCondition(const Parameters & params) : InitialCondition(params) {}
+    explicit TestVectorInitialCondition(const Parameters & pars) : InitialCondition(pars) {}
 
     Int
     get_num_components() const override
@@ -162,8 +162,6 @@ TEST_F(InitialConditionTest, duplicate_ic_name)
 
 TEST_F(InitialCondition2FieldTest, no_field_param)
 {
-    testing::internal::CaptureStderr();
-
     auto params = InitialCondition::parameters();
     params.set<App *>("_app", this->app);
     params.set<DiscreteProblemInterface *>("_dpi", this->prob);
@@ -173,15 +171,7 @@ TEST_F(InitialCondition2FieldTest, no_field_param)
     this->mesh->create();
 
     this->prob->add_initial_condition(&ic);
-    this->prob->create();
-
-    EXPECT_FALSE(this->app->check_integrity());
-    this->app->get_logger()->print();
-
-    EXPECT_THAT(
-        testing::internal::GetCapturedStderr(),
-        testing::HasSubstr(
-            "Use the 'field' parameter to assign this initial condition to an existing field"));
+    EXPECT_THROW(this->prob->create(), Exception);
 }
 
 TEST_F(InitialCondition2FieldTest, non_existing_field)

--- a/test/src/JacobianFunc_test.cpp
+++ b/test/src/JacobianFunc_test.cpp
@@ -12,7 +12,7 @@ namespace {
 
 class GTestProblem : public ImplicitFENonlinearProblem {
 public:
-    explicit GTestProblem(const Parameters & params) : ImplicitFENonlinearProblem(params) {}
+    explicit GTestProblem(const Parameters & pars) : ImplicitFENonlinearProblem(pars) {}
 
 protected:
     void

--- a/test/src/LinearProblem_test.cpp
+++ b/test/src/LinearProblem_test.cpp
@@ -14,7 +14,7 @@ namespace {
 
 class CustomLinearProblem : public LinearProblem {
 public:
-    explicit CustomLinearProblem(const Parameters & params) : LinearProblem(params) {}
+    explicit CustomLinearProblem(const Parameters & pars) : LinearProblem(pars) {}
 
     void
     create() override

--- a/test/src/MeshPartitioningOutput_test.cpp
+++ b/test/src/MeshPartitioningOutput_test.cpp
@@ -17,7 +17,7 @@ public:
 
 class EmptyMeshObject : public MeshObject {
 public:
-    explicit EmptyMeshObject(const Parameters & params) : MeshObject(params) {}
+    explicit EmptyMeshObject(const Parameters & pars) : MeshObject(pars) {}
 
     Qtr<Mesh>
     create_mesh() override
@@ -28,7 +28,7 @@ public:
 
 class TestProblem : public LinearProblem {
 public:
-    explicit TestProblem(const Parameters & params) : LinearProblem(params) {}
+    explicit TestProblem(const Parameters & pars) : LinearProblem(pars) {}
 };
 
 } // namespace

--- a/test/src/Mesh_test.cpp
+++ b/test/src/Mesh_test.cpp
@@ -12,7 +12,7 @@ namespace {
 
 class TestMesh : public MeshObject {
 public:
-    explicit TestMesh(const Parameters & params) : MeshObject(params) {}
+    explicit TestMesh(const Parameters & pars) : MeshObject(pars) {}
 
     Qtr<Mesh>
     create_mesh() override

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -28,7 +28,7 @@ TEST(NaturalBCTest, api)
 
     class MockNaturalBC : public NaturalBC {
     public:
-        explicit MockNaturalBC(const Parameters & params) : NaturalBC(params), comps({ 3, 5 }) {}
+        explicit MockNaturalBC(const Parameters & pars) : NaturalBC(pars), comps({ 3, 5 }) {}
 
         const std::vector<Int> &
         get_components() const override
@@ -89,7 +89,7 @@ public:
 
 class TestNaturalBC : public NaturalBC {
 public:
-    explicit TestNaturalBC(const Parameters & params) : NaturalBC(params), comps({ 0 }) {}
+    explicit TestNaturalBC(const Parameters & pars) : NaturalBC(pars), comps({ 0 }) {}
 
     const std::vector<Int> &
     get_components() const override

--- a/test/src/NaturalRiemannBC_test.cpp
+++ b/test/src/NaturalRiemannBC_test.cpp
@@ -12,7 +12,7 @@ namespace {
 
 class TestBC : public NaturalRiemannBC {
 public:
-    explicit TestBC(const Parameters & params) : NaturalRiemannBC(params), comps({ 0 }) {}
+    explicit TestBC(const Parameters & pars) : NaturalRiemannBC(pars), comps({ 0 }) {}
 
     const std::vector<Int> &
     get_components() const override
@@ -38,10 +38,7 @@ public:
 
 class TestExplicitFVLinearProblem : public ExplicitFVLinearProblem {
 public:
-    explicit TestExplicitFVLinearProblem(const Parameters & params) :
-        ExplicitFVLinearProblem(params)
-    {
-    }
+    explicit TestExplicitFVLinearProblem(const Parameters & pars) : ExplicitFVLinearProblem(pars) {}
 
 protected:
     void

--- a/test/src/NeumannProblem_test.cpp
+++ b/test/src/NeumannProblem_test.cpp
@@ -16,7 +16,7 @@ namespace {
 
 class TestNeumannProblem : public FENonlinearProblem {
 public:
-    explicit TestNeumannProblem(const Parameters & params);
+    explicit TestNeumannProblem(const Parameters & pars);
 
 protected:
     void set_up_fields() override;
@@ -92,11 +92,7 @@ protected:
     const Dimension & dim;
 };
 
-TestNeumannProblem::TestNeumannProblem(const Parameters & params) :
-    FENonlinearProblem(params),
-    iu(0)
-{
-}
+TestNeumannProblem::TestNeumannProblem(const Parameters & pars) : FENonlinearProblem(pars), iu(0) {}
 
 void
 TestNeumannProblem::set_up_fields()
@@ -139,7 +135,7 @@ public:
 
 class TestNeumannBC : public NaturalBC {
 public:
-    explicit TestNeumannBC(const Parameters & params) : NaturalBC(params), comps({ 0 }) {}
+    explicit TestNeumannBC(const Parameters & pars) : NaturalBC(pars), comps({ 0 }) {}
 
     const std::vector<Int> &
     get_components() const override

--- a/test/src/NonlinearProblem_test.cpp
+++ b/test/src/NonlinearProblem_test.cpp
@@ -13,7 +13,7 @@ namespace {
 
 class G1DTestNonlinearProblem : public NonlinearProblem {
 public:
-    explicit G1DTestNonlinearProblem(const Parameters & params);
+    explicit G1DTestNonlinearProblem(const Parameters & pars);
     ~G1DTestNonlinearProblem() override;
     void create() override;
     void call_initial_guess();
@@ -28,8 +28,8 @@ protected:
 
 } // namespace
 
-G1DTestNonlinearProblem::G1DTestNonlinearProblem(const Parameters & params) :
-    NonlinearProblem(params),
+G1DTestNonlinearProblem::G1DTestNonlinearProblem(const Parameters & pars) :
+    NonlinearProblem(pars),
     s(nullptr)
 {
 }
@@ -143,7 +143,7 @@ TEST(NonlinearProblemTest, run)
 {
     class MockNonlinearProblem : public NonlinearProblem {
     public:
-        explicit MockNonlinearProblem(const Parameters & params) : NonlinearProblem(params) {}
+        explicit MockNonlinearProblem(const Parameters & pars) : NonlinearProblem(pars) {}
 
         MOCK_METHOD(void, set_up_initial_guess, ());
         MOCK_METHOD(void, on_initial, ());
@@ -197,7 +197,7 @@ TEST(NonlinearProblemTest, line_search_type)
 {
     class MockNonlinearProblem : public NonlinearProblem {
     public:
-        explicit MockNonlinearProblem(const Parameters & params) : NonlinearProblem(params) {}
+        explicit MockNonlinearProblem(const Parameters & pars) : NonlinearProblem(pars) {}
 
         SNESolver
         get_snes()
@@ -238,7 +238,7 @@ TEST(NonlinearProblemTest, invalid_line_search_type)
 
     class MockNonlinearProblem : public NonlinearProblem {
     public:
-        explicit MockNonlinearProblem(const Parameters & params) : NonlinearProblem(params) {}
+        explicit MockNonlinearProblem(const Parameters & pars) : NonlinearProblem(pars) {}
     };
 
     TestApp app;

--- a/test/src/Object_test.cpp
+++ b/test/src/Object_test.cpp
@@ -17,10 +17,6 @@ TEST(ObjectTest, api)
 
     EXPECT_EQ(obj->get_name(), "name");
 
-    [[maybe_unused]] const auto & p = obj->get_parameters();
-
-    EXPECT_TRUE(obj->is_param_valid("_name"));
-
     EXPECT_EQ(obj->get_processor_id(), 0);
 
     int sz;

--- a/test/src/Output_test.cpp
+++ b/test/src/Output_test.cpp
@@ -15,7 +15,7 @@ public:
 
 class MockOutput : public Output {
 public:
-    explicit MockOutput(const Parameters & params) : Output(params) {}
+    explicit MockOutput(const Parameters & pars) : Output(pars) {}
 
     void
     output_step() override
@@ -48,7 +48,7 @@ TEST_F(OutputTest, exec_masks_2)
     MockOutput out(pars);
     out.create();
 
-    EXPECT_TRUE(out.get_exec_mask() & EXECUTE_ON_FINAL);
+    EXPECT_TRUE(out.execute_on() & EXECUTE_ON_FINAL);
     EXPECT_TRUE(out.should_output(EXECUTE_ON_FINAL));
     EXPECT_FALSE(out.should_output(EXECUTE_ON_INITIAL));
     EXPECT_FALSE(out.should_output(EXECUTE_ON_TIMESTEP));
@@ -63,9 +63,9 @@ TEST_F(OutputTest, exec_masks_3)
     MockOutput out(pars);
     out.create();
 
-    EXPECT_TRUE(out.get_exec_mask() & EXECUTE_ON_FINAL);
-    EXPECT_TRUE(out.get_exec_mask() & EXECUTE_ON_INITIAL);
-    EXPECT_TRUE(out.get_exec_mask() & EXECUTE_ON_TIMESTEP);
+    EXPECT_TRUE(out.execute_on() & EXECUTE_ON_FINAL);
+    EXPECT_TRUE(out.execute_on() & EXECUTE_ON_INITIAL);
+    EXPECT_TRUE(out.execute_on() & EXECUTE_ON_TIMESTEP);
 
     this->prob->set_time(0.);
     EXPECT_TRUE(out.should_output(EXECUTE_ON_INITIAL));

--- a/test/src/PCShell_test.cpp
+++ b/test/src/PCShell_test.cpp
@@ -13,7 +13,7 @@ namespace {
 
 class CustomLinearProblem : public LinearProblem {
 public:
-    explicit CustomLinearProblem(const Parameters & params) : LinearProblem(params) {}
+    explicit CustomLinearProblem(const Parameters & pars) : LinearProblem(pars) {}
 
     void
     create() override

--- a/test/src/Parameters_test.cpp
+++ b/test/src/Parameters_test.cpp
@@ -112,3 +112,21 @@ TEST(ParametersTest, move_oper)
 
     EXPECT_FALSE(params1.has<Int>("i"));
 }
+
+TEST(ParametersTest, get_optional_param)
+{
+    Parameters params1;
+    params1.set<Int>("i", 1);
+
+    auto p1 = params1.get<Optional<Int>>("i");
+    EXPECT_TRUE(p1.has_value());
+    EXPECT_EQ(p1.value(), 1);
+
+    // getting param with incorrect type means the param was not specified
+    auto p2 = params1.get<Optional<Real>>("i");
+    EXPECT_FALSE(p2.has_value());
+
+    // auto p2 = params1.get_optional<Real>("f");
+    auto p3 = params1.get<Optional<Real>>("f");
+    EXPECT_FALSE(p3.has_value());
+}

--- a/test/src/PrintInterface_test.cpp
+++ b/test/src/PrintInterface_test.cpp
@@ -14,7 +14,7 @@ TEST(PrintInterfaceTest, lprint)
 
     class TestObject : public Object, public PrintInterface {
     public:
-        explicit TestObject(const Parameters & params) : Object(params), PrintInterface(this) {}
+        explicit TestObject(const Parameters & pars) : Object(pars), PrintInterface(this) {}
 
         void
         create() override
@@ -39,7 +39,7 @@ TEST(PrintInterfaceTest, timed_event)
 
     class TestObject : public Object, public PrintInterface {
     public:
-        explicit TestObject(const Parameters & params) : Object(params), PrintInterface(this) {}
+        explicit TestObject(const Parameters & pars) : Object(pars), PrintInterface(this) {}
 
         void
         create() override

--- a/test/src/Problem_test.cpp
+++ b/test/src/Problem_test.cpp
@@ -21,7 +21,7 @@ namespace {
 
 class TestProblem : public Problem {
 public:
-    explicit TestProblem(const Parameters & params) : Problem(params) {}
+    explicit TestProblem(const Parameters & pars) : Problem(pars) {}
 
     void
     run() override
@@ -46,7 +46,7 @@ TEST(ProblemTest, add_pp)
 
     class TestPostprocessor : public Postprocessor {
     public:
-        explicit TestPostprocessor(const Parameters & params) : Postprocessor(params) {}
+        explicit TestPostprocessor(const Parameters & pars) : Postprocessor(pars) {}
 
         void
         compute() override
@@ -62,7 +62,7 @@ TEST(ProblemTest, add_pp)
 
     class TestFunction : public Function {
     public:
-        explicit TestFunction(const Parameters & params) : Function(params) {}
+        explicit TestFunction(const Parameters & pars) : Function(pars) {}
 
         void
         register_callback(mu::Parser & parser) override
@@ -72,7 +72,7 @@ TEST(ProblemTest, add_pp)
 
     class TestOutput : public FileOutput {
     public:
-        explicit TestOutput(const Parameters & params) : FileOutput(params) {}
+        explicit TestOutput(const Parameters & pars) : FileOutput(pars) {}
 
         MOCK_METHOD(void, output_step, ());
 

--- a/test/src/Registry_test.cpp
+++ b/test/src/Registry_test.cpp
@@ -11,7 +11,7 @@ namespace {
 
 class ASDF : public Object {
 public:
-    explicit ASDF(const Parameters & parameters) : Object(parameters) {}
+    explicit ASDF(const Parameters & pars) : Object(pars) {}
 
     static Parameters parameters();
 };

--- a/test/src/ResidualFunc_test.cpp
+++ b/test/src/ResidualFunc_test.cpp
@@ -12,7 +12,7 @@ TEST(ResidualFuncTest, test)
 {
     class GTestProblem : public ImplicitFENonlinearProblem {
     public:
-        explicit GTestProblem(const Parameters & params) : ImplicitFENonlinearProblem(params) {}
+        explicit GTestProblem(const Parameters & pars) : ImplicitFENonlinearProblem(pars) {}
 
     protected:
         void
@@ -78,7 +78,7 @@ TEST(ResidualFuncTest, test_vals)
 {
     class GTestProblem : public ImplicitFENonlinearProblem {
     public:
-        explicit GTestProblem(const Parameters & params) : ImplicitFENonlinearProblem(params) {}
+        explicit GTestProblem(const Parameters & pars) : ImplicitFENonlinearProblem(pars) {}
 
     protected:
         void

--- a/test/src/TSAbstract_test.cpp
+++ b/test/src/TSAbstract_test.cpp
@@ -35,9 +35,9 @@ register_scheme()
 
 class GTestProblem : public Problem, public TransientProblemInterface {
 public:
-    explicit GTestProblem(const Parameters & params) :
-        Problem(params),
-        TransientProblemInterface(this, params)
+    explicit GTestProblem(const Parameters & pars) :
+        Problem(pars),
+        TransientProblemInterface(this, pars)
     {
     }
 

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -15,7 +15,7 @@ namespace {
 
 class TestUnstructuredMesh : public MeshObject {
 public:
-    explicit TestUnstructuredMesh(const Parameters & params) : MeshObject(params) {}
+    explicit TestUnstructuredMesh(const Parameters & pars) : MeshObject(pars) {}
 
     Qtr<Mesh>
     create_mesh() override
@@ -55,11 +55,11 @@ public:
 
 class TestUnstructuredMesh3D : public MeshObject {
 public:
-    explicit TestUnstructuredMesh3D(const Parameters & params) :
-        MeshObject(params),
-        nx(get_param<Int>("nx")),
-        ny(get_param<Int>("ny")),
-        nz(get_param<Int>("nz"))
+    explicit TestUnstructuredMesh3D(const Parameters & pars) :
+        MeshObject(pars),
+        nx(pars.get<Int>("nx")),
+        ny(pars.get<Int>("ny")),
+        nz(pars.get<Int>("nz"))
     {
     }
 

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -12,7 +12,7 @@ namespace {
 
 class TestProblem : public LinearProblem {
 public:
-    explicit TestProblem(const Parameters & params) : LinearProblem(params) {}
+    explicit TestProblem(const Parameters & pars) : LinearProblem(pars) {}
 };
 
 } // namespace
@@ -31,7 +31,7 @@ TEST(VTKOutputTest, wrong_mesh_type)
 
     class TestMesh : public MeshObject {
     public:
-        explicit TestMesh(const Parameters & params) : MeshObject(params) {}
+        explicit TestMesh(const Parameters & pars) : MeshObject(pars) {}
 
         Qtr<Mesh>
         create_mesh() override

--- a/test/src/WeakForm_test.cpp
+++ b/test/src/WeakForm_test.cpp
@@ -15,7 +15,7 @@ namespace {
 
 class TestBC : public NaturalBC {
 public:
-    explicit TestBC(const Parameters & params) : NaturalBC(params), comps({ 1 }) {}
+    explicit TestBC(const Parameters & pars) : NaturalBC(pars), comps({ 1 }) {}
 
     const std::vector<Int> &
     get_components() const override


### PR DESCRIPTION
Object no longer stores its parameters. `Parameters` only deliver values
and all objects should just grab what they need and store it in their
member variables.

This also removes the API to get parameters from Objects.
Internal modifications were made to accomodate above changes.
