### PR TITLE
Fixing `Parameters::get(name, default_value)`

### DIFF
--- a/include/godzilla/Parameters.h
+++ b/include/godzilla/Parameters.h
@@ -146,7 +146,11 @@ public:
         if (!this->has<T>(name))
             return default_value;
         auto it = this->params.find(name);
-        return dynamic_cast<Parameter<T> *>(it->second)->get();
+        auto par = dynamic_cast<Parameter<T> *>(it->second);
+        if (par->valid)
+            return par->get();
+        else
+            return default_value;
     }
 
     /// Set parameter


### PR DESCRIPTION
When returning parameter with default value, only do so then param is not valid