### PR TITLE
Changing `DiscreteProblemInterface::add_auxiliary_field` to accept Parameters

### DIFF
--- a/include/godzilla/AuxiliaryField.h
+++ b/include/godzilla/AuxiliaryField.h
@@ -118,4 +118,7 @@ AuxiliaryField::get_vector_value(Real time, const DenseVector<Real, DIM> & x)
     return val;
 }
 
+template <typename T>
+concept AuxiliaryFieldDerived = std::is_base_of_v<AuxiliaryField, T>;
+
 } // namespace godzilla

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -78,20 +78,6 @@ DiscreteProblemInterface::get_initial_condition(const std::string & name) const
         return {};
 }
 
-void
-DiscreteProblemInterface::add_auxiliary_field(AuxiliaryField * aux)
-{
-    CALL_STACK_MSG();
-    const std::string & name = aux->get_name();
-    auto it = this->auxs_by_name.find(name);
-    if (it == this->auxs_by_name.end()) {
-        this->auxs.push_back(aux);
-        this->auxs_by_name[name] = aux;
-    }
-    else
-        throw Exception("Cannot add auxiliary object '{}'. Name already taken.", name);
-}
-
 bool
 DiscreteProblemInterface::has_aux(const std::string & name) const
 {
@@ -329,7 +315,7 @@ DiscreteProblemInterface::set_up_auxiliary_dm(DM dm)
             Int field_nc = get_aux_field_num_components(fid);
             if (aux_nc == field_nc) {
                 const std::string & region_name = aux->get_region();
-                this->auxs_by_region[region_name].push_back(aux);
+                this->auxs_by_region[region_name].push_back(aux.get());
             }
             else {
                 no_errors = false;

--- a/src/GYMLFile.cpp
+++ b/src/GYMLFile.cpp
@@ -119,6 +119,7 @@ GYMLFile::build_auxiliary_fields()
     if (!get_root()["auxs"])
         return;
 
+#if 0
     lprintln(9, "- auxiliary fields");
     auto auxs_node = get_block(get_root(), "auxs");
     auto * fepi = dynamic_cast<FEProblemInterface *>(get_problem());
@@ -136,6 +137,7 @@ GYMLFile::build_auxiliary_fields()
     else
         log_error("Supplied problem type '{}' does not support auxiliary fields.",
                   get_problem()->get_type());
+#endif
 }
 
 void

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -50,25 +50,23 @@ TEST_F(AuxiliaryFieldTest, api)
     auto params = AuxiliaryField::parameters();
     params.set<App *>("_app", app)
         .set<std::string>("_name", "aux")
-        .set<DiscreteProblemInterface *>("_dpi", prob)
         .set<std::string>("field", "fld")
         .set<std::string>("region", "rgn");
-    TestAuxFld aux(params);
-    prob->add_auxiliary_field(&aux);
+    auto aux = prob->add_auxiliary_field<TestAuxFld>(params);
     prob->create();
 
-    EXPECT_EQ(aux.get_label(), nullptr);
-    EXPECT_EQ(aux.get_region(), "rgn");
-    EXPECT_EQ(aux.get_block_id(), -1);
-    EXPECT_EQ(aux.get_field(), "fld");
-    EXPECT_EQ(aux.get_field_id(), FieldID(0));
+    EXPECT_EQ(aux->get_label(), nullptr);
+    EXPECT_EQ(aux->get_region(), "rgn");
+    EXPECT_EQ(aux->get_block_id(), -1);
+    EXPECT_EQ(aux->get_field(), "fld");
+    EXPECT_EQ(aux->get_field_id(), FieldID(0));
     // EXPECT_EQ(aux.get_msh(), this->mesh->get_mesh<Mesh>());
-    EXPECT_EQ(aux.get_prblm(), prob);
-    EXPECT_EQ(aux.get_dimension(), 1_D);
+    EXPECT_EQ(aux->get_prblm(), prob);
+    EXPECT_EQ(aux->get_dimension(), 1_D);
 
     EXPECT_TRUE(prob->has_aux("aux"));
     EXPECT_FALSE(prob->has_aux("no-aux"));
-    EXPECT_EQ(prob->get_aux("aux"), &aux);
+    EXPECT_EQ(prob->get_aux("aux"), aux);
     EXPECT_EQ(prob->get_aux("no-aux"), nullptr);
 }
 
@@ -93,11 +91,9 @@ TEST_F(AuxiliaryFieldTest, non_existent_field)
     prob->set_aux_field(FieldID(0), "aux1", 1, Order(1));
 
     auto params = AuxiliaryField::parameters();
-    params.set<App *>("_app", app)
-        .set<std::string>("_name", "aux")
-        .set<DiscreteProblemInterface *>("_dpi", prob);
-    TestAuxFld aux(params);
-    prob->add_auxiliary_field(&aux);
+    params.set<App *>("_app", app);
+    params.set<std::string>("_name", "aux");
+    prob->add_auxiliary_field<TestAuxFld>(params);
 
     prob->create();
 
@@ -129,11 +125,9 @@ TEST_F(AuxiliaryFieldTest, inconsistent_comp_number)
     prob->set_aux_field(FieldID(0), "aux", 1, Order(1));
 
     auto params = AuxiliaryField::parameters();
-    params.set<App *>("_app", app)
-        .set<std::string>("_name", "aux")
-        .set<DiscreteProblemInterface *>("_dpi", prob);
-    TestAuxFld aux(params);
-    prob->add_auxiliary_field(&aux);
+    params.set<App *>("_app", app);
+    params.set<std::string>("_name", "aux");
+    prob->add_auxiliary_field<TestAuxFld>(params);
 
     prob->create();
 
@@ -168,10 +162,8 @@ TEST_F(AuxiliaryFieldTest, non_existent_region)
     auto params = AuxiliaryField::parameters();
     params.set<App *>("_app", app)
         .set<std::string>("_name", "aux")
-        .set<DiscreteProblemInterface *>("_dpi", prob)
         .set<std::string>("region", "asdf");
-    TestAuxFld aux(params);
-    prob->add_auxiliary_field(&aux);
+    prob->add_auxiliary_field<TestAuxFld>(params);
 
     prob->create();
 
@@ -189,12 +181,10 @@ TEST_F(AuxiliaryFieldTest, name_already_taken)
     auto params = ConstantAuxiliaryField::parameters();
     params.set<App *>("_app", app)
         .set<std::string>("_name", "aux")
-        .set<DiscreteProblemInterface *>("_dpi", prob)
         .set<std::vector<Real>>("value", { 1 });
-    ConstantAuxiliaryField aux(params);
-    prob->add_auxiliary_field(&aux);
+    prob->add_auxiliary_field<ConstantAuxiliaryField>(params);
 
-    EXPECT_THROW_MSG(prob->add_auxiliary_field(&aux),
+    EXPECT_THROW_MSG(prob->add_auxiliary_field<ConstantAuxiliaryField>(params),
                      "Cannot add auxiliary object 'aux'. Name already taken.");
 }
 
@@ -220,15 +210,13 @@ TEST_F(AuxiliaryFieldTest, get_value)
     auto params = AuxiliaryField::parameters();
     params.set<App *>("_app", app)
         .set<std::string>("_name", "aux")
-        .set<DiscreteProblemInterface *>("_dpi", prob)
         .set<std::string>("region", "asdf");
-    TestAuxFld aux(params);
-    prob->add_auxiliary_field(&aux);
+    auto aux = prob->add_auxiliary_field<TestAuxFld>(params);
 
     prob->create();
 
     DenseVector<Real, 1> coord({ 2. });
-    auto val = aux.get_value(3., coord);
+    auto val = aux->get_value(3., coord);
     EXPECT_DOUBLE_EQ(val, 3708.);
 }
 
@@ -256,15 +244,13 @@ TEST_F(AuxiliaryFieldTest, get_vector_value)
     auto params = AuxiliaryField::parameters();
     params.set<App *>("_app", app)
         .set<std::string>("_name", "aux")
-        .set<DiscreteProblemInterface *>("_dpi", prob)
         .set<std::string>("region", "asdf");
-    TestAuxFld aux(params);
-    prob->add_auxiliary_field(&aux);
+    auto aux = prob->add_auxiliary_field<TestAuxFld>(params);
 
     prob->create();
 
     DenseVector<Real, 1> coord({ 3. });
-    auto val = aux.get_vector_value<3>(2., coord);
+    auto val = aux->get_vector_value<3>(2., coord);
     EXPECT_DOUBLE_EQ(val(0), 5.);
     EXPECT_DOUBLE_EQ(val(1), 2.);
     EXPECT_DOUBLE_EQ(val(2), 42.);

--- a/test/src/ConstantAuxiliaryField_test.cpp
+++ b/test/src/ConstantAuxiliaryField_test.cpp
@@ -22,24 +22,23 @@ TEST(ConstantAuxiliaryFieldTest, create)
     prob_params.set<Mesh *>("mesh", mesh.get());
     GTestFENonlinearProblem prob(prob_params);
 
+    prob.create();
+
+    prob.set_aux_field(FieldID(0), "aux1", 1, Order(1));
     auto aux_params = ConstantAuxiliaryField::parameters();
     aux_params.set<App *>("_app", &app)
         .set<std::string>("_name", "aux1")
         .set<DiscreteProblemInterface *>("_dpi", &prob)
         .set<std::vector<Real>>("value", { 1234 });
-    ConstantAuxiliaryField aux(aux_params);
+    auto aux = prob.add_auxiliary_field<ConstantAuxiliaryField>(aux_params);
 
-    prob.create();
-    prob.set_aux_field(FieldID(0), "aux1", 1, Order(1));
-    prob.add_auxiliary_field(&aux);
+    EXPECT_EQ(aux->get_field_id(), FieldID(0));
 
-    EXPECT_EQ(aux.get_field_id(), FieldID(0));
-
-    EXPECT_EQ(aux.get_num_components(), 1);
+    EXPECT_EQ(aux->get_num_components(), 1);
 
     Real time = 0;
     Real x[1] = { 1. };
     Real u[1] = { 0 };
-    aux.evaluate(time, x, u);
+    aux->evaluate(time, x, u);
     EXPECT_EQ(u[0], 1234.);
 }


### PR DESCRIPTION
- it create the object and stores it (i.e. owns it)
- returns back the created object, in case application needs it
