### PR TITLE
Adding `get_block_id_from_region`

### DIFF
--- a/include/godzilla/Utils.h
+++ b/include/godzilla/Utils.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "godzilla/Types.h"
 #include <vector>
 #include <map>
 #include <string>
@@ -14,6 +15,7 @@
 namespace godzilla {
 
 class PrintInterface;
+class UnstructuredMesh;
 
 namespace utils {
 
@@ -221,5 +223,15 @@ enumerate(ITERABLE && iterable)
 }
 
 void print_converged_reason(PrintInterface & pi, bool converged);
+
+/// Get block ID from region name
+///
+/// If block ID is a number, then it is returned as a `Int` type. If it is anything else, we assume
+/// it is a cell set name and we try to convert it into cell set ID.
+///
+/// @param mesh Unstructure mesh we operate on for cell set lookups
+/// @param region Region name/Block ID
+/// @return Block ID corresponding to the region
+Int get_block_id_from_region(const UnstructuredMesh & mesh, const std::string & region);
 
 } // namespace godzilla

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -5,6 +5,7 @@
 #include "godzilla/CallStack.h"
 #include "godzilla/PrintInterface.h"
 #include "godzilla/Terminal.h"
+#include "godzilla/UnstructuredMesh.h"
 #include <sys/stat.h>
 #include <chrono>
 #include <fmt/printf.h>
@@ -13,6 +14,26 @@
 #endif
 
 namespace godzilla {
+
+namespace {
+
+Optional<Int>
+parse_region(const std::string & s)
+{
+    if (s.empty())
+        return std::nullopt;
+
+    Int value = 0;
+    auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
+
+    if (ec == std::errc() && ptr == s.data() + s.size() && value >= 0)
+        return value;
+
+    return std::nullopt;
+}
+
+} // namespace
+
 namespace utils {
 
 bool
@@ -119,6 +140,16 @@ print_converged_reason(PrintInterface & pi, bool converged)
         pi.lprintln(8, Terminal::green, "Converged");
     else
         pi.lprintln(8, Terminal::red, "Not converged");
+}
+
+Int
+get_block_id_from_region(const godzilla::UnstructuredMesh & mesh, const std::string & region)
+{
+    auto id = parse_region(region);
+    if (id.has_value())
+        return id.value();
+    else
+        return mesh.get_cell_set_id(region);
 }
 
 } // namespace godzilla

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -1,15 +1,19 @@
 #include "gmock/gmock.h"
 #include <petscsystypes.h>
 #include "GodzillaApp_test.h"
+#include "godzilla/FileMesh.h"
 #include "godzilla/LineMesh.h"
 #include "godzilla/MeshFactory.h"
 #include "godzilla/UnstructuredMesh.h"
 #include "godzilla/Parameters.h"
 #include "ExceptionTestMacros.h"
+#include "godzilla/Utils.h"
 #include "petscdmplex.h"
+#include <filesystem>
 
 using namespace godzilla;
 using namespace testing;
+namespace fs = std::filesystem;
 
 namespace {
 
@@ -713,4 +717,31 @@ TEST(UnstructuredMeshTest, clone)
     EXPECT_EQ(clone.get_num_faces(), 3);
     EXPECT_EQ(clone.get_num_cells(), 2);
     EXPECT_TRUE(clone.is_simplex());
+}
+
+TEST(UnstructuredMeshTest, get_block_id_from_region_via_number)
+{
+    TestApp app;
+
+    auto params = TestUnstructuredMesh::parameters();
+    params.set<App *>("_app", &app);
+    auto mesh_qtr = MeshFactory::create<TestUnstructuredMesh>(params);
+    auto m = mesh_qtr.get();
+
+    EXPECT_EQ(get_block_id_from_region(*m, "0"), 0);
+}
+
+TEST(UnstructuredMeshTest, get_block_id_from_region_via_name)
+{
+    TestApp app;
+
+    auto file = fs::path(GODZILLA_UNIT_TESTS_ROOT) / "assets" / "mesh" / "square.e";
+
+    auto params = FileMesh::parameters();
+    params.set<App *>("_app", &app);
+    params.set<std::string>("file", file.string());
+    auto mesh_qtr = MeshFactory::create<FileMesh>(params);
+    auto m = mesh_qtr.get();
+
+    EXPECT_EQ(get_block_id_from_region(*m, "block"), 1);
 }


### PR DESCRIPTION
Get the block ID from region.
- if it is a number, it is converted from string to integer
- if it is anythong else, it is assumed to be a cell set name and
  is converted into it si corresponding ID.
