### PR TITLE
Adding `Parameters::add_private_param` with no default

### DIFF
--- a/include/godzilla/Parameters.h
+++ b/include/godzilla/Parameters.h
@@ -252,6 +252,24 @@ public:
         this->params[name] = std::move(param);
         return *this;
     }
+
+    template <typename T>
+    Parameters &
+    add_private_param(const std::string & name)
+    {
+        CALL_STACK_MSG();
+        assert_true(!this->has<T>(name),
+                    fmt::format("Private parameter '{}' already exists", name));
+
+        auto param = Qtr<Parameter<T>>::alloc();
+        param->value = {};
+        param->required = true;
+        param->is_private = true;
+        param->valid = false;
+        this->params[name] = std::move(param);
+        return *this;
+    }
+
     ///@}
 
     inline void
@@ -273,7 +291,7 @@ public:
     /// the input file
     bool is_param_valid(const std::string & name) const;
 
-    bool is_private(const std::string & name) const;
+    bool is_param_private(const std::string & name) const;
 
     ///
     std::string type(const std::string & name) const;

--- a/src/InputFile.cpp
+++ b/src/InputFile.cpp
@@ -213,7 +213,7 @@ InputFile::build_params(const Block & block)
 
     for (auto & kv : *params) {
         const std::string & param_name = kv.first;
-        if (!params->is_private(param_name)) {
+        if (!params->is_param_private(param_name)) {
             set_parameter_from_yml(params, block.values(), param_name);
             unused_param_names.erase(param_name);
         }

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -71,7 +71,7 @@ Parameters::is_param_valid(const std::string & name) const
 }
 
 bool
-Parameters::is_private(const std::string & name) const
+Parameters::is_param_private(const std::string & name) const
 {
     CALL_STACK_MSG();
     return this->params.count(name) > 0 && this->params.at(name)->is_private;

--- a/test/src/Parameters_test.cpp
+++ b/test/src/Parameters_test.cpp
@@ -193,3 +193,19 @@ TEST(ParametersTest, make_param_required)
     params.make_param_required("number");
     EXPECT_TRUE(params.is_param_required("number"));
 }
+
+TEST(ParametersTest, private_param)
+{
+    Parameters params;
+    params.add_private_param<Int>("number", 10);
+    EXPECT_TRUE(params.is_param_private("number"));
+    EXPECT_FALSE(params.is_param_required("number"));
+}
+
+TEST(ParametersTest, required_private_param)
+{
+    Parameters params;
+    params.add_private_param<Int>("number");
+    EXPECT_TRUE(params.is_param_private("number"));
+    EXPECT_TRUE(params.is_param_required("number"));
+}


### PR DESCRIPTION
When used, the private parameter must be supplied (i.e. it is required).