### PR TITLE
`common_cells_by_vertex` in no longer member function

### DIFF
--- a/include/godzilla/UnstructuredMesh.h
+++ b/include/godzilla/UnstructuredMesh.h
@@ -331,11 +331,6 @@ public:
     /// @return The cell volume
     Real compute_cell_volume(Int cell) const;
 
-    /// Compute a map of cells common to a vertex
-    ///
-    /// @return A mapping [vertex index -> list of cell indices]
-    const std::map<Int, std::vector<Int>> & common_cells_by_vertex();
-
     /// Mark all faces on the boundary
     ///
     /// @param val The marker value
@@ -402,11 +397,6 @@ private:
     /// Vertex set IDs
     std::map<std::string, Int> vertex_set_ids;
 
-    /// Cells common to a vertex
-    std::map<Int, std::vector<Int>> common_cells_by_vtx;
-    /// Flag indicating if `common_cells_by_vtx` was computed
-    bool common_cells_by_vtx_computed;
-
 public:
     static int get_num_cell_nodes(PolytopeType cell_type);
 
@@ -471,5 +461,10 @@ boundary_vertices(const UnstructuredMesh * mesh, const IndexSet & facets)
     vertices.sort_remove_dups();
     return vertices;
 }
+
+/// Compute a map of cells common to a vertex
+///
+/// @return A mapping [vertex index -> list of cell indices]
+std::map<Int, std::vector<Int>> common_cells_by_vertex(const UnstructuredMesh & mesh);
 
 } // namespace godzilla

--- a/test/src/UnstructuredMesh_test.cpp
+++ b/test/src/UnstructuredMesh_test.cpp
@@ -435,7 +435,7 @@ TEST(UnstructuredMesh, common_cells_by_vertex)
     auto mesh_qtr = MeshFactory::create<TestUnstructuredMesh3D>(params);
     auto m = mesh_qtr.get();
 
-    auto map = m->common_cells_by_vertex();
+    auto map = common_cells_by_vertex(*m);
     EXPECT_EQ(map.size(), 12);
     EXPECT_THAT(map[2], UnorderedElementsAre(0));
     EXPECT_THAT(map[3], UnorderedElementsAre(0, 1));
@@ -449,22 +449,6 @@ TEST(UnstructuredMesh, common_cells_by_vertex)
     EXPECT_THAT(map[11], UnorderedElementsAre(0));
     EXPECT_THAT(map[12], UnorderedElementsAre(0, 1));
     EXPECT_THAT(map[13], UnorderedElementsAre(1));
-
-    // subsequent calls to `common_cells_by_vertex()` must give back the same map
-    auto map1 = m->common_cells_by_vertex();
-    EXPECT_EQ(map1.size(), 12);
-    EXPECT_THAT(map1[2], UnorderedElementsAre(0));
-    EXPECT_THAT(map1[3], UnorderedElementsAre(0, 1));
-    EXPECT_THAT(map1[4], UnorderedElementsAre(1));
-    EXPECT_THAT(map1[5], UnorderedElementsAre(0));
-    EXPECT_THAT(map1[6], UnorderedElementsAre(0, 1));
-    EXPECT_THAT(map1[7], UnorderedElementsAre(1));
-    EXPECT_THAT(map1[8], UnorderedElementsAre(0));
-    EXPECT_THAT(map1[9], UnorderedElementsAre(0, 1));
-    EXPECT_THAT(map1[10], UnorderedElementsAre(1));
-    EXPECT_THAT(map1[11], UnorderedElementsAre(0));
-    EXPECT_THAT(map1[12], UnorderedElementsAre(0, 1));
-    EXPECT_THAT(map1[13], UnorderedElementsAre(1));
 }
 
 TEST(UnstructuredMesh, build_from_cell_list_2d)


### PR DESCRIPTION
This needs to be a free function and apps call that for thier purposes.