### PR TITLE
Modifying access rights in `CommandLineInterface`

### DIFF
--- a/include/godzilla/CommandLineInterface.h
+++ b/include/godzilla/CommandLineInterface.h
@@ -44,7 +44,6 @@ public:
 protected:
     std::string get_app_name() const;
 
-private:
     /// Create command line options
     ///
     virtual cxxopts::Options create_command_line_options();
@@ -54,6 +53,7 @@ private:
     /// @param result Result from calling `parse_command_line` or `cxxopt::parse`
     virtual void process_command_line(cxxopts::Options & opts, const cxxopts::ParseResult & result);
 
+private:
     /// Application we are part of
     App & app;
     /// Command line arguments


### PR DESCRIPTION
- `create_command_line_options` is protected
- `process_command_line` is protected

Child classes need to be able to do 2 things:

1. completely replace the behavior
2. use the current behavior and add to it

(1) is already possible. This patch allows (2).
