### PR TITLE
`Parameter::type` returns demangled type

### DIFF
--- a/include/godzilla/Parameters.h
+++ b/include/godzilla/Parameters.h
@@ -8,6 +8,7 @@
 #include "godzilla/Types.h"
 #include "godzilla/Assert.h"
 #include "godzilla/Qtr.h"
+#include "godzilla/Utils.h"
 #include <map>
 #include <string>
 
@@ -60,7 +61,7 @@ protected:
         std::string
         type() const override
         {
-            return typeid(T).name();
+            return utils::demangle(typeid(T).name());
         }
 
         Value *

--- a/include/godzilla/Utils.h
+++ b/include/godzilla/Utils.h
@@ -120,6 +120,9 @@ human_number(T number)
     return num_str;
 }
 
+/// Convert C++ names into human readable names
+std::string human_type_name(const std::string & type);
+
 /// Get index of an value in a std::vector
 ///
 /// @tparam T Type

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -78,13 +78,6 @@ Parameters::is_param_private(const std::string & name) const
 }
 
 std::string
-Parameters::type(const std::string & name) const
-{
-    CALL_STACK_MSG();
-    return this->params.at(name)->type();
-}
-
-std::string
 Parameters::get_doc_string(const std::string & name) const
 {
     CALL_STACK_MSG();

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -6,40 +6,6 @@
 
 namespace godzilla {
 
-namespace {
-
-/// Convert C++ names into human readable names
-std::string
-human_type_name(const std::string & type)
-{
-    // clang-format off
-    if (type == "std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>" ||
-        type == "NSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEE" ||
-        type == "std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >")
-        return "String";
-    else if (type == "int" || type == "long" || type == "long long")
-        return "Integer";
-    else if (type == "double" || type == "float")
-        return "Real";
-    else if (type == "bool")
-        return "Boolean";
-    else if (type == "std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>" ||
-             type == "std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >")
-        return "[String, ...]";
-    else if (type == "std::__1::vector<int, std::__1::allocator<int>>")
-        return "[Integer, ...]";
-    else if (type == "std::__1::vector<long long, std::__1::allocator<long long>>")
-        return "[Integer, ...]";
-    else if (type == "std::__1::vector<double, std::__1::allocator<double>>" ||
-             type == "std::vector<double, std::allocator<double> >")
-        return "[Real, ...]";
-    // clang-format on
-    else
-        return type;
-}
-
-} // namespace
-
 bool
 Registry::exists(const std::string & class_name) const
 {
@@ -69,7 +35,7 @@ Registry::get_object_description() const
             if (!param->is_private) {
                 Registry::ObjectDescription::Parameter p;
                 p.name = name;
-                p.type = human_type_name(utils::demangle(param->type()));
+                p.type = utils::human_type_name(param->type());
                 p.description = param->doc_string;
                 p.required = param->required;
                 descr.parameters.push_back(p);

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -116,6 +116,35 @@ human_time(PetscLogDouble time)
 }
 
 std::string
+human_type_name(const std::string & type)
+{
+    // clang-format off
+    if (type == "std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>" ||
+        type == "NSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEE" ||
+        type == "std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >")
+        return "String";
+    else if (type == "int" || type == "long" || type == "long long")
+        return "Integer";
+    else if (type == "double" || type == "float")
+        return "Real";
+    else if (type == "bool")
+        return "Boolean";
+    else if (type == "std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>" ||
+             type == "std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >")
+        return "[String, ...]";
+    else if (type == "std::__1::vector<int, std::__1::allocator<int>>")
+        return "[Integer, ...]";
+    else if (type == "std::__1::vector<long long, std::__1::allocator<long long>>")
+        return "[Integer, ...]";
+    else if (type == "std::__1::vector<double, std::__1::allocator<double>>" ||
+             type == "std::vector<double, std::allocator<double> >")
+        return "[Real, ...]";
+    // clang-format on
+    else
+        return type;
+}
+
+std::string
 demangle(const std::string & mangled_name)
 {
 #ifdef HAVE_CXXABI_H

--- a/test/src/Parameters_test.cpp
+++ b/test/src/Parameters_test.cpp
@@ -38,7 +38,7 @@ TEST(ParametersTest, get_param_with_incorrect_type)
     Parameters params = Object::parameters();
     params.add_param<double>("param", "doco");
 
-    EXPECT_THROW_MSG(params.get<int>("param"), "Parameter 'param' has unexpected type (d)");
+    EXPECT_THROW_MSG(params.get<int>("param"), "Parameter 'param' has unexpected type (double)");
 }
 
 TEST(ParametersTest, param_value)
@@ -181,7 +181,7 @@ TEST(ParametersTest, get_optional_param_using_incorrect_type)
     params.set<int>("int", 1);
 
     EXPECT_THROW_MSG(params.get<Optional<double>>("int"),
-                     "Parameter 'int' has unexpected type (i)");
+                     "Parameter 'int' has unexpected type (int)");
 }
 
 TEST(ParametersTest, make_param_required)


### PR DESCRIPTION
So users would see `double` instead of `d`, etc.