### PR TITLE
Moving `operator<<` into godzilla namespace

### DIFF
--- a/include/godzilla/String.h
+++ b/include/godzilla/String.h
@@ -312,23 +312,23 @@ private:
     String(Rep * rep) : rep(rep) {}
 };
 
-} // namespace godzilla
-
 inline std::ostream &
-operator<<(std::ostream & os, const godzilla::String & obj)
+operator<<(std::ostream & os, const String & obj)
 {
     os << obj.c_str();
     return os;
 }
 
 inline std::istream &
-operator>>(std::istream & is, godzilla::String & obj)
+operator>>(std::istream & is, String & obj)
 {
     std::string str;
     is >> str;
     obj = str;
     return is;
 }
+
+} // namespace godzilla
 
 template <>
 struct fmt::formatter<godzilla::String> : fmt::formatter<fmt::string_view> {

--- a/test/src/Utils_test.cpp
+++ b/test/src/Utils_test.cpp
@@ -115,6 +115,13 @@ TEST(UtilsTest, join_std_vec_int)
     EXPECT_EQ(s, "1, 3, 5, 7, 9");
 }
 
+TEST(UtilsTest, join_std_vec_string)
+{
+    std::vector<String> vals = { "quick", "brown", "fox" };
+    auto s = join(" ", vals);
+    EXPECT_EQ(s, "quick brown fox");
+}
+
 TEST(UtilsTest, join_std_set_int)
 {
     std::set<Int> vals = { 1, 3, 5, 7, 9 };


### PR DESCRIPTION
Fixes #955