### PR TITLE
Refactoring `AuxiliaryField::get_field_id()`

### DIFF
--- a/include/godzilla/AuxiliaryField.h
+++ b/include/godzilla/AuxiliaryField.h
@@ -81,19 +81,16 @@ protected:
 private:
     /// Discrete problem this object is part of
     DiscreteProblemInterface * dpi;
-
     /// Unstructured mesh this field is defined on
     UnstructuredMesh * mesh;
-
     /// Field name
     String field;
-
+    /// Field ID this boundary condition is attached to
+    FieldID fid;
     /// Region name this auxiliary field is defined on
     const String region;
-
     /// Block here the auxiliary field lives
     Label label;
-
     /// Block ID associated with the label where this field is defined
     Int block_id;
 

--- a/src/AuxiliaryField.cpp
+++ b/src/AuxiliaryField.cpp
@@ -26,6 +26,7 @@ AuxiliaryField::AuxiliaryField(const Parameters & pars) :
     dpi(pars.get<DiscreteProblemInterface *>("_dpi")),
     mesh(nullptr),
     field(pars.get<String>("field")),
+    fid(FieldID::INVALID),
     region(pars.get<String>("region")),
     block_id(-1)
 {
@@ -67,6 +68,10 @@ AuxiliaryField::create()
         this->label = this->mesh->get_label(this->region);
         this->block_id = this->mesh->get_cell_set_id(this->region).value();
     }
+
+    auto id = this->dpi->get_aux_field_id(this->field);
+    expect_true(id.has_value(), "Auxiliary field '{}' does not exist. Typo?", this->field);
+    this->fid = id.value();
 }
 
 String
@@ -94,11 +99,7 @@ FieldID
 AuxiliaryField::get_field_id() const
 {
     CALL_STACK_MSG();
-    auto fid = this->dpi->get_aux_field_id(this->field);
-    if (fid.has_value())
-        return fid.value();
-    else
-        throw Exception("Auxiliary field '{}' does not exist", this->field);
+    return this->fid;
 }
 
 String

--- a/src/DiscreteProblemInterface.cpp
+++ b/src/DiscreteProblemInterface.cpp
@@ -310,9 +310,11 @@ DiscreteProblemInterface::set_up_auxiliary_dm(DM dm)
     bool no_errors = true;
     for (auto & aux : this->auxs) {
         try {
-            auto fid = aux->get_field_id();
-            Int aux_nc = aux->get_num_components();
-            auto field_nc = get_aux_field_num_components(fid).value();
+            auto fld_name = aux->get_field();
+            auto fid = get_aux_field_id(fld_name);
+            expect_true(fid.has_value(), "Auxiliary field '{}' does not exist", fld_name);
+            auto aux_nc = aux->get_num_components();
+            auto field_nc = get_aux_field_num_components(fid.value()).value();
             if (aux_nc == field_nc) {
                 String region_name = aux->get_region();
                 this->auxs_by_region[region_name].push_back(aux.get());

--- a/test/src/ConstantAuxiliaryField_test.cpp
+++ b/test/src/ConstantAuxiliaryField_test.cpp
@@ -22,8 +22,6 @@ TEST(ConstantAuxiliaryFieldTest, create)
     prob_params.set<Mesh *>("mesh", mesh.get());
     GTestFENonlinearProblem prob(prob_params);
 
-    prob.create();
-
     prob.set_aux_field(FieldID(0), "aux1", 1, Order(1));
     auto aux_params = ConstantAuxiliaryField::parameters();
     aux_params.set<App *>("app", &app)
@@ -32,8 +30,9 @@ TEST(ConstantAuxiliaryFieldTest, create)
         .set<std::vector<Real>>("value", { 1234 });
     auto aux = prob.add_auxiliary_field<ConstantAuxiliaryField>(aux_params);
 
-    EXPECT_EQ(aux->get_field_id(), FieldID(0));
+    prob.create();
 
+    EXPECT_EQ(aux->get_field_id(), FieldID(0));
     EXPECT_EQ(aux->get_num_components(), 1);
 
     Real time = 0;


### PR DESCRIPTION
AuxiliaryField now figures out its field ID in `create` like the other classes (BCs, ICs, etc.)