### PR TITLE
Fail to compile when trying to generate Qtr dtor with an incomplete type

### DIFF
--- a/include/godzilla/Qtr.h
+++ b/include/godzilla/Qtr.h
@@ -22,6 +22,7 @@ struct DefaultDelete {
     void
     operator()(T * ptr) const noexcept
     {
+        static_assert(sizeof(T), "Qtr<T>: T must be complete at destruction time.");
         static_assert(!std::is_void<T>::value, "Can't delete incomplete type");
         delete ptr;
     }


### PR DESCRIPTION
This helps to find "hidden" memory leaks, when the code happily compiles, but an incorrect code is generated for the dtor causing memory not being freed.