### PR TITLE
`App::run_problem` creates the problem before it runs it

### DIFF
--- a/examples/advect-eqn/src/main.cpp
+++ b/examples/advect-eqn/src/main.cpp
@@ -43,8 +43,6 @@ main(int argc, char * argv[])
         out_pars.set<fs::path>("file", "out");
         prob->add_output<ExodusIIOutput>(out_pars);
 
-        prob->create();
-
         app.run();
 
         return 0;

--- a/examples/heat-eqn/src/2d-explicit.cpp
+++ b/examples/heat-eqn/src/2d-explicit.cpp
@@ -88,8 +88,6 @@ main(int argc, char * argv[])
             .set<std::vector<String>>("variables", { "temp" });
         prob->add_output<ExodusIIOutput>(out_pars);
 
-        prob->create();
-
         app.run();
 
         return 0;

--- a/examples/heat-eqn/src/2d.cpp
+++ b/examples/heat-eqn/src/2d.cpp
@@ -78,8 +78,6 @@ main(int argc, char * argv[])
             .set<std::vector<String>>("variables", { "temp" });
         prob->add_output<ExodusIIOutput>(out_pars);
 
-        prob->create();
-
         app.run();
 
         return 0;

--- a/examples/heat-eqn/src/mms-1d.cpp
+++ b/examples/heat-eqn/src/mms-1d.cpp
@@ -91,8 +91,6 @@ main(int argc, char * argv[])
             .set<std::vector<String>>("variables", { "temp" });
         prob->add_output<ExodusIIOutput>(out_pars);
 
-        prob->create();
-
         app.run();
 
         return 0;

--- a/examples/ns-incomp/src/main.cpp
+++ b/examples/ns-incomp/src/main.cpp
@@ -143,8 +143,6 @@ main(int argc, char * argv[])
         out_pars.set<fs::path>("file", "mms-2d");
         prob->add_output<ExodusIIOutput>(out_pars);
 
-        prob->create();
-
         app.run();
 
         return 0;

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -196,8 +196,10 @@ void
 App::run_problem()
 {
     CALL_STACK_MSG();
-    lprintln(9, "Running");
     expect_true(this->problem != nullptr, "Problem is null");
+    this->problem->create();
+
+    lprintln(9, "Running");
     this->problem->run();
 }
 


### PR DESCRIPTION
This way, users only need to build their problem using the `add_XYZ` APIs. And then they `app.run` it.

NOTE: they can still do Problem::create, Problem::run if they want to.