### PR TITLE
Redesigning output execute on to the new approach

### DIFF
--- a/include/godzilla/ExplicitDGLinearProblem.h
+++ b/include/godzilla/ExplicitDGLinearProblem.h
@@ -33,6 +33,12 @@ protected:
     void post_step() override;
 
     ExecuteOnFlags
+    default_execute_on(OutputTag) const override
+    {
+        return ExecuteOn::INITIAL | ExecuteOn::TIMESTEP;
+    }
+
+    ExecuteOnFlags
     default_execute_on(PostprocessorTag) const override
     {
         return ExecuteOn::INITIAL | ExecuteOn::TIMESTEP;

--- a/include/godzilla/ExplicitFELinearProblem.h
+++ b/include/godzilla/ExplicitFELinearProblem.h
@@ -34,6 +34,12 @@ protected:
     void post_step() override;
 
     ExecuteOnFlags
+    default_execute_on(OutputTag) const override
+    {
+        return ExecuteOn::INITIAL | ExecuteOn::TIMESTEP;
+    }
+
+    ExecuteOnFlags
     default_execute_on(PostprocessorTag) const override
     {
         return ExecuteOn::INITIAL | ExecuteOn::TIMESTEP;

--- a/include/godzilla/ExplicitFVLinearProblem.h
+++ b/include/godzilla/ExplicitFVLinearProblem.h
@@ -33,6 +33,12 @@ protected:
     void post_step() override;
 
     ExecuteOnFlags
+    default_execute_on(OutputTag) const override
+    {
+        return ExecuteOn::INITIAL | ExecuteOn::TIMESTEP;
+    }
+
+    ExecuteOnFlags
     default_execute_on(PostprocessorTag) const override
     {
         return ExecuteOn::INITIAL | ExecuteOn::TIMESTEP;

--- a/include/godzilla/ImplicitFENonlinearProblem.h
+++ b/include/godzilla/ImplicitFENonlinearProblem.h
@@ -39,6 +39,12 @@ protected:
     }
 
     ExecuteOnFlags
+    default_execute_on(OutputTag) const override
+    {
+        return ExecuteOn::INITIAL | ExecuteOn::TIMESTEP;
+    }
+
+    ExecuteOnFlags
     default_execute_on(PostprocessorTag) const override
     {
         return ExecuteOn::INITIAL | ExecuteOn::TIMESTEP;

--- a/include/godzilla/LinearProblem.h
+++ b/include/godzilla/LinearProblem.h
@@ -94,6 +94,12 @@ protected:
     }
 
     ExecuteOnFlags
+    default_execute_on(OutputTag) const override
+    {
+        return ExecuteOn::FINAL;
+    }
+
+    ExecuteOnFlags
     default_execute_on(PostprocessorTag) const override
     {
         return ExecuteOn::FINAL;

--- a/include/godzilla/NonlinearProblem.h
+++ b/include/godzilla/NonlinearProblem.h
@@ -116,6 +116,12 @@ protected:
     }
 
     ExecuteOnFlags
+    default_execute_on(OutputTag) const override
+    {
+        return ExecuteOn::FINAL;
+    }
+
+    ExecuteOnFlags
     default_execute_on(PostprocessorTag) const override
     {
         return ExecuteOn::FINAL;

--- a/include/godzilla/Output.h
+++ b/include/godzilla/Output.h
@@ -11,10 +11,14 @@ namespace godzilla {
 
 class Problem;
 
+struct OutputTag {};
+
 /// Base class for doing output
 ///
 class Output : public Object, public PrintInterface {
 public:
+    using category = OutputTag;
+
     explicit Output(const Parameters & pars);
 
     void create() override;
@@ -23,11 +27,6 @@ public:
     ///
     /// @param mask Bit flags for execution
     void set_exec_mask(ExecuteOnFlags flags);
-
-    /// Get execution mask
-    ///
-    /// @return execution mask
-    [[deprecated("Use execute_on()")]] ExecuteOnFlags get_exec_mask() const;
 
     /// Get execution mask
     ///
@@ -48,9 +47,6 @@ protected:
     ///
     /// @return Problem this output is part of
     Ref<Problem> get_problem() const;
-
-    /// Set up the execution mask
-    // void set_up_exec();
 
 private:
     /// Problem to get data from

--- a/src/ExplicitDGLinearProblem.cpp
+++ b/src/ExplicitDGLinearProblem.cpp
@@ -21,7 +21,6 @@ ExplicitDGLinearProblem::ExplicitDGLinearProblem(const Parameters & pars) :
     ExplicitProblemInterface(*this, pars)
 {
     CALL_STACK_MSG();
-    set_default_output_on(ExecuteOn::INITIAL | ExecuteOn::TIMESTEP);
 }
 
 Real

--- a/src/ExplicitFELinearProblem.cpp
+++ b/src/ExplicitFELinearProblem.cpp
@@ -46,7 +46,6 @@ ExplicitFELinearProblem::ExplicitFELinearProblem(const Parameters & pars) :
     ExplicitProblemInterface(*this, pars)
 {
     CALL_STACK_MSG();
-    set_default_output_on(ExecuteOn::INITIAL | ExecuteOn::TIMESTEP);
 }
 
 Real

--- a/src/ExplicitFVLinearProblem.cpp
+++ b/src/ExplicitFVLinearProblem.cpp
@@ -20,7 +20,6 @@ ExplicitFVLinearProblem::ExplicitFVLinearProblem(const Parameters & pars) :
     ExplicitProblemInterface(*this, pars)
 {
     CALL_STACK_MSG();
-    set_default_output_on(ExecuteOn::INITIAL | ExecuteOn::TIMESTEP);
 }
 
 Real

--- a/src/ImplicitFENonlinearProblem.cpp
+++ b/src/ImplicitFENonlinearProblem.cpp
@@ -46,7 +46,6 @@ ImplicitFENonlinearProblem::ImplicitFENonlinearProblem(const Parameters & pars) 
     scheme(pars.get<String>("scheme"))
 {
     CALL_STACK_MSG();
-    set_default_output_on(ExecuteOn::INITIAL | ExecuteOn::TIMESTEP);
     expect_true(validation::in(this->scheme, { "beuler", "cn" }),
                 "The 'scheme' parameter can be either 'beuler' or 'cn'.");
 }

--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -59,7 +59,6 @@ LinearProblem::LinearProblem(const Parameters & pars) :
     lin_max_iter(pars.get<Int>("lin_max_iter"))
 {
     CALL_STACK_MSG();
-    set_default_output_on(ExecuteOn::FINAL);
 }
 
 String

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -51,7 +51,6 @@ NonlinearProblem::NonlinearProblem(const Parameters & pars) :
     lin_max_iter(pars.get<Int>("lin_max_iter"))
 {
     CALL_STACK_MSG();
-    set_default_output_on(ExecuteOn::FINAL);
     this->line_search_type = this->line_search_type.to_lower();
     expect_true(
         validation::in(this->line_search_type, { "bt", "basic", "l2", "cp", "nleqerr", "shell" }),

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -23,24 +23,18 @@ Output::Output(const Parameters & pars) :
     Object(pars),
     PrintInterface(this),
     problem(pars.get<Ref<Problem>>("_problem")),
+    on_mask(pars.get<ExecuteOnFlags>("on")),
     interval(pars.get<Int>("interval", 1)),
     last_output_time(std::nan(""))
 {
     CALL_STACK_MSG();
-    if (pars.is_param_valid("on")) {
-        const auto on = pars.get<ExecuteOnFlags>("on");
-        if (on.has_flags()) {
-            if (none_with_flags(on))
-                error("The 'none' execution flag can be used only by itself.");
-            else
-                this->on_mask = on;
-        }
-        else
-            error("The 'on' parameter can be either 'none' or a combination of 'initial', "
-                  "'timestep' and/or 'final'.");
+    if (this->on_mask.has_flags()) {
+        if (none_with_flags(this->on_mask))
+            error("The 'none' execution flag can be used only by itself.");
     }
     else
-        this->on_mask = this->problem->get_default_output_on();
+        error("The 'on' parameter can be either 'none' or a combination of 'initial', "
+              "'timestep' and/or 'final'.");
 
     if (pars.is_param_valid("interval") && ((this->on_mask & ExecuteOn::TIMESTEP) == 0))
         warning("Parameter 'interval' was specified, but 'on' is missing 'timestep'.");
@@ -64,13 +58,6 @@ Output::get_problem() const
 {
     CALL_STACK_MSG();
     return this->problem;
-}
-
-ExecuteOnFlags
-Output::get_exec_mask() const
-{
-    CALL_STACK_MSG();
-    return this->on_mask;
 }
 
 ExecuteOnFlags

--- a/src/Problem.cpp
+++ b/src/Problem.cpp
@@ -43,8 +43,7 @@ Problem::Problem(const Parameters & pars) :
     mesh(pars.is_param_valid("mesh") ? pars.get<Ref<Mesh>>("mesh")
                                      : Optional<Ref<Mesh>>(std::nullopt)),
     partitioner(nullptr),
-    partition_overlap(0),
-    default_output_on()
+    partition_overlap(0)
 {
     set_output_monitor(ref(*this), &Problem::output_monitor);
     this->partitioner.create(get_comm());
@@ -301,18 +300,6 @@ Problem::set_global_section(const Section & section) const
 {
     CALL_STACK_MSG();
     PETSC_CHECK(DMSetGlobalSection(get_dm(), section));
-}
-
-void
-Problem::set_default_output_on(ExecuteOnFlags flags)
-{
-    this->default_output_on = flags;
-}
-
-ExecuteOnFlags
-Problem::get_default_output_on() const
-{
-    return this->default_output_on;
 }
 
 Problem::FieldDecomposition

--- a/test/src/CSVOutput_test.cpp
+++ b/test/src/CSVOutput_test.cpp
@@ -4,6 +4,7 @@
 #include "godzilla/Problem.h"
 #include "godzilla/CSVOutput.h"
 #include "godzilla/Postprocessor.h"
+#include "godzilla/Types.h"
 
 using namespace godzilla;
 
@@ -30,6 +31,7 @@ TEST_F(CSVOutputTest, get_file_ext)
     auto params = this->app->make_parameters<CSVOutput>();
     params.set<Ref<Problem>>("_problem", prob);
     params.set<fs::path>("file", "asdf");
+    params.set<ExecuteOnFlags>("on", ExecuteOn::NONE);
     CSVOutput out(params);
     out.create();
 
@@ -106,6 +108,7 @@ TEST_F(CSVOutputTest, set_file_name)
     auto params = this->app->make_parameters<CSVOutput>();
     params.set<Ref<Problem>>("_problem", prob);
     params.set<fs::path>("file", "asdf");
+    params.set<ExecuteOnFlags>("on", ExecuteOn::NONE);
     CSVOutput out(params);
 
     prob->create();

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -4,6 +4,7 @@
 #include "godzilla/ExodusIIOutput.h"
 #include "godzilla/MeshFactory.h"
 #include "godzilla/LineMesh.h"
+#include "godzilla/Types.h"
 
 using namespace godzilla;
 
@@ -25,6 +26,7 @@ TEST(ExodusIIOutputTest, get_file_ext)
     params.set<Ref<App>>("app", ref(app));
     params.set<Ref<Problem>>("_problem", ref(prob));
     params.set<fs::path>("file", "out");
+    params.set<ExecuteOnFlags>("on", ExecuteOn::NONE);
     ExodusIIOutput out(params);
     out.create();
 

--- a/test/src/MeshPartitioningOutput_test.cpp
+++ b/test/src/MeshPartitioningOutput_test.cpp
@@ -54,6 +54,7 @@ TEST(MeshPartitioningOutputTest, get_file_ext)
     params.set<Ref<App>>("app", ref(app));
     params.set<Ref<Problem>>("_problem", ref(prob));
     params.set<fs::path>("file", "part");
+    params.set<ExecuteOnFlags>("on", ExecuteOn::NONE);
     MeshPartitioningOutput out(params);
     out.create();
 

--- a/test/src/Output_test.cpp
+++ b/test/src/Output_test.cpp
@@ -126,3 +126,17 @@ TEST_F(OutputTest, interval_with_no_timestep_output)
         testing::internal::GetCapturedStdout(),
         testing::HasSubstr("Parameter 'interval' was specified, but 'on' is missing 'timestep'."));
 }
+
+TEST_F(OutputTest, default_execute_on_mask)
+{
+    auto prob = this->app->get_problem<GTestImplicitFENonlinearProblem>();
+
+    auto pars = Postprocessor::parameters();
+    pars.set<Ref<App>>("app", ref(*this->app));
+    pars.set<Ref<Problem>>("_problem", prob);
+    auto out = prob->add_output<MockOutput>(pars);
+
+    EXPECT_FALSE(out->execute_on() & ExecuteOn::FINAL);
+    EXPECT_TRUE(out->execute_on() & ExecuteOn::INITIAL);
+    EXPECT_TRUE(out->execute_on() & ExecuteOn::TIMESTEP);
+}

--- a/test/src/TecplotOutput_test.cpp
+++ b/test/src/TecplotOutput_test.cpp
@@ -27,6 +27,7 @@ TEST(TecplotOutputTest, get_file_ext)
     params.set<Ref<App>>("app", ref(app));
     params.set<Ref<Problem>>("_problem", ref(prob));
     params.set<fs::path>("file", "out");
+    params.set<ExecuteOnFlags>("on", ExecuteOn::NONE);
     TecplotOutput out(params);
 
     prob.create();


### PR DESCRIPTION
- we have a category type in the base class
- we have a virtual method on problem that supplies the flags
  rather than storing it in a member variable
- `Problem::add_output` makes sure we supply "on" flags with the
  defaults
