### PR TITLE
Renaming `NetworkMesh::component` to `NetworkMesh::get_component`

### DIFF
--- a/include/godzilla/NetworkMesh.h
+++ b/include/godzilla/NetworkMesh.h
@@ -19,7 +19,7 @@ public:
 
     void add_component(Int p, ClassID key, void * comp, Int n_vars);
 
-    void * component(Int p);
+    void * get_component(Int p) const;
 
     /// Gets the number of subnetworks
     ///

--- a/src/NetworkMesh.cpp
+++ b/src/NetworkMesh.cpp
@@ -39,7 +39,7 @@ NetworkMesh::add_component(Int p, ClassID key, void * comp, Int n_vars)
 }
 
 void *
-NetworkMesh::component(Int p)
+NetworkMesh::get_component(Int p) const
 {
     CALL_STACK_MSG();
     void * ptr;


### PR DESCRIPTION
- matches PETSc API
- allows child classes to use the better verison `component` and
  possible template it to avoid casting
