### PR TITLE
Renaming methods in `NetworkMesh` to match PETSc API

### DIFF
--- a/include/godzilla/NetworkMesh.h
+++ b/include/godzilla/NetworkMesh.h
@@ -24,7 +24,7 @@ public:
     /// Gets the number of subnetworks
     ///
     /// @return local and global number of subnetworks
-    std::tuple<Int, Int> num_sub_networks() const;
+    std::tuple<Int, Int> get_num_sub_networks() const;
 
     /// Sets the number of subnetworks
     ///
@@ -44,28 +44,28 @@ public:
     void create();
 
     /// Get the number of components at a vertex/edge
-    Int num_components(Int p) const;
+    Int get_num_components(Int p) const;
 
     /// Get the local and global number of vertices for the entire network.
-    std::tuple<Int, Int> num_vertices() const;
+    std::tuple<Int, Int> get_num_vertices() const;
 
     /// Get the bounds [start, end) for the local vertices
-    Range vertex_range() const;
+    Range get_vertex_range() const;
 
     /// Return the supporting edges for this vertex point
-    std::vector<Int> supporting_edges(Int vertex) const;
+    std::vector<Int> get_supporting_edges(Int vertex) const;
 
     /// Returns `true` if the vertex is a ghost vertex
     bool is_ghost_vertex(Int p) const;
 
     /// Get the local and global number of edges for the entire network.
-    std::tuple<Int, Int> num_edges() const;
+    std::tuple<Int, Int> get_num_edges() const;
 
     /// Get the bounds [start, end) for the local edges
-    Range edge_range() const;
+    Range get_edge_range() const;
 
     /// Return the connected vertices for this edge point
-    std::array<Int, 2> connected_vertices(Int edge) const;
+    std::array<Int, 2> get_connected_vertices(Int edge) const;
 
     /// Sets up the bare layout (graph) for the network
     void layout_set_up();
@@ -77,13 +77,13 @@ public:
 
     /// Get the offset for accessing the variables associated with the given edge from the local
     /// subvector
-    Int edge_offset(Int p) const;
+    Int get_edge_offset(Int p) const;
 
     /// Get the global numbering for the edge on the network
     ///
     /// @param p Edge point
     /// @return the global numbering for the edge
-    Int global_edge_index(Int p) const;
+    Int get_global_edge_index(Int p) const;
 
     /// Get the global offset for accessing the variables associated with a component for the given
     /// vertex/edge from the global vector
@@ -91,13 +91,13 @@ public:
     /// @param p The edge or vertex point
     /// @param comp_num component number; use ALL_COMPONENTS if no specific component is requested
     /// @return The global offset
-    Int global_vec_offset(Int p, Int comp_num) const;
+    Int get_global_vec_offset(Int p, Int comp_num) const;
 
     /// Get the global numbering for the vertex on the network
     ///
     /// @param p Vertex point
     /// @return The global numbering for the vertex
-    Int global_vertex_index(Int p) const;
+    Int get_global_vertex_index(Int p) const;
 
     /// Get the offset for accessing the variables associated with a component at the given
     /// vertex/edge from the local vector
@@ -105,14 +105,14 @@ public:
     /// @param p The edge or vertex point
     /// @param comp_num Component number; use ALL_COMPONENTS if no specific component is requested
     /// @return The local offset
-    Int local_vec_offset(Int p, Int comp_num) const;
+    Int get_local_vec_offset(Int p, Int comp_num) const;
 
     /// Get the offset for accessing the variables associated with the given vertex from the local
     /// subvector
     ///
     /// @param p The vertex point
     /// @return The offset
-    Int vertex_offset(Int p) const;
+    Int get_vertex_offset(Int p) const;
 
     /// Sets user-provided Jacobian matrices for this edge to the network
     ///

--- a/src/NetworkMesh.cpp
+++ b/src/NetworkMesh.cpp
@@ -48,7 +48,7 @@ NetworkMesh::get_component(Int p) const
 }
 
 std::tuple<Int, Int>
-NetworkMesh::num_sub_networks() const
+NetworkMesh::get_num_sub_networks() const
 {
     CALL_STACK_MSG();
     Int l, g;
@@ -86,7 +86,7 @@ NetworkMesh::create()
 }
 
 Int
-NetworkMesh::num_components(Int p) const
+NetworkMesh::get_num_components(Int p) const
 {
     CALL_STACK_MSG();
     Int n;
@@ -95,7 +95,7 @@ NetworkMesh::num_components(Int p) const
 }
 
 std::tuple<Int, Int>
-NetworkMesh::num_vertices() const
+NetworkMesh::get_num_vertices() const
 {
     CALL_STACK_MSG();
     Int loc, glob;
@@ -104,7 +104,7 @@ NetworkMesh::num_vertices() const
 }
 
 Range
-NetworkMesh::vertex_range() const
+NetworkMesh::get_vertex_range() const
 {
     CALL_STACK_MSG();
     Int start, end;
@@ -113,7 +113,7 @@ NetworkMesh::vertex_range() const
 }
 
 std::vector<Int>
-NetworkMesh::supporting_edges(Int vertex) const
+NetworkMesh::get_supporting_edges(Int vertex) const
 {
     CALL_STACK_MSG();
     Int n_edges;
@@ -132,7 +132,7 @@ NetworkMesh::is_ghost_vertex(Int p) const
 }
 
 std::tuple<Int, Int>
-NetworkMesh::num_edges() const
+NetworkMesh::get_num_edges() const
 {
     CALL_STACK_MSG();
     Int loc, glob;
@@ -141,7 +141,7 @@ NetworkMesh::num_edges() const
 }
 
 Range
-NetworkMesh::edge_range() const
+NetworkMesh::get_edge_range() const
 {
     CALL_STACK_MSG();
     Int start, end;
@@ -150,7 +150,7 @@ NetworkMesh::edge_range() const
 }
 
 std::array<Int, 2>
-NetworkMesh::connected_vertices(Int edge) const
+NetworkMesh::get_connected_vertices(Int edge) const
 {
     CALL_STACK_MSG();
     const Int * verts;
@@ -180,7 +180,7 @@ NetworkMesh::finalize_components()
 }
 
 Int
-NetworkMesh::edge_offset(Int p) const
+NetworkMesh::get_edge_offset(Int p) const
 {
     CALL_STACK_MSG();
     Int offset;
@@ -189,7 +189,7 @@ NetworkMesh::edge_offset(Int p) const
 }
 
 Int
-NetworkMesh::global_edge_index(Int p) const
+NetworkMesh::get_global_edge_index(Int p) const
 {
     CALL_STACK_MSG();
     Int idx;
@@ -198,7 +198,7 @@ NetworkMesh::global_edge_index(Int p) const
 }
 
 Int
-NetworkMesh::global_vec_offset(Int p, Int comp_num) const
+NetworkMesh::get_global_vec_offset(Int p, Int comp_num) const
 {
     CALL_STACK_MSG();
     Int offset;
@@ -207,7 +207,7 @@ NetworkMesh::global_vec_offset(Int p, Int comp_num) const
 }
 
 Int
-NetworkMesh::global_vertex_index(Int p) const
+NetworkMesh::get_global_vertex_index(Int p) const
 {
     CALL_STACK_MSG();
     Int idx;
@@ -216,7 +216,7 @@ NetworkMesh::global_vertex_index(Int p) const
 }
 
 Int
-NetworkMesh::local_vec_offset(Int p, Int comp_num) const
+NetworkMesh::get_local_vec_offset(Int p, Int comp_num) const
 {
     CALL_STACK_MSG();
     Int offset;
@@ -225,7 +225,7 @@ NetworkMesh::local_vec_offset(Int p, Int comp_num) const
 }
 
 Int
-NetworkMesh::vertex_offset(Int p) const
+NetworkMesh::get_vertex_offset(Int p) const
 {
     CALL_STACK_MSG();
     Int offset;


### PR DESCRIPTION
This is for consistency withing the library
