### PR TITLE
Moving convergence check in LinearProblem/NonlinearProblem

### DIFF
--- a/src/LinearProblem.cpp
+++ b/src/LinearProblem.cpp
@@ -179,6 +179,8 @@ LinearProblem::run()
     pre_solve();
     solve();
     post_solve();
+    if (converged())
+        on_final();
 }
 
 void
@@ -204,8 +206,6 @@ void
 LinearProblem::post_solve()
 {
     CALL_STACK_MSG();
-    if (converged())
-        on_final();
 }
 
 void

--- a/src/NonlinearProblem.cpp
+++ b/src/NonlinearProblem.cpp
@@ -332,6 +332,8 @@ NonlinearProblem::run()
     pre_solve();
     solve();
     post_solve();
+    if (converged())
+        on_final();
 }
 
 void
@@ -359,8 +361,6 @@ void
 NonlinearProblem::post_solve()
 {
     CALL_STACK_MSG();
-    if (converged())
-        on_final();
 }
 
 void


### PR DESCRIPTION
- moved into `run`
- as a side effect this removes the double call to
  output on final
