### PR TITLE
Check that objects are constructed from correct `Parameters`

### DIFF
--- a/include/godzilla/App.h
+++ b/include/godzilla/App.h
@@ -138,6 +138,7 @@ public:
                       "T must be constructible from `const Parameters &`");
 
         auto pars = T::parameters();
+        pars.template set<String>("_type", utils::type_name<T>());
         pars.template set<Ref<App>>("app", ref(*this));
         return pars;
     }

--- a/include/godzilla/DiscreteProblemInterface.h
+++ b/include/godzilla/DiscreteProblemInterface.h
@@ -183,7 +183,8 @@ public:
     /// @param pars Parameters used to construct InitialCondition object
     /// @return Built InitialCondition object
     template <InitialConditionDerived OBJECT>
-    Ref<OBJECT> add_initial_condition(Parameters & pars);
+    Ref<OBJECT> add_initial_condition(Parameters & pars,
+                                      std::source_location loc = std::source_location::current());
 
     /// Check if we have an initial condition object with a specified name
     ///
@@ -202,14 +203,16 @@ public:
     /// @param pars Paremeters used to construct BoundaryCondition object
     /// @return Built BoundaryCondition object
     template <BoundaryConditionDerived OBJECT>
-    Ref<OBJECT> add_boundary_condition(Parameters & pars);
+    Ref<OBJECT> add_boundary_condition(Parameters & pars,
+                                       std::source_location loc = std::source_location::current());
 
     /// Add auxiliary field
     ///
     /// @param pars Parameters used to construct the AuxiliaryField object
     /// @return Built AuxiliaryField object
     template <AuxiliaryFieldDerived OBJECT>
-    Ref<OBJECT> add_auxiliary_field(Parameters & pars);
+    Ref<OBJECT> add_auxiliary_field(Parameters & pars,
+                                    std::source_location loc = std::source_location::current());
 
     /// Get auxiliary object with a specified name
     ///
@@ -510,9 +513,14 @@ DiscreteProblemInterface::get_point_local_field_ref(Int point, FieldID field, Sc
 
 template <BoundaryConditionDerived T>
 Ref<T>
-DiscreteProblemInterface::add_boundary_condition(Parameters & pars)
+DiscreteProblemInterface::add_boundary_condition(Parameters & pars, std::source_location loc)
 {
-    CALL_STACK_MSG();
+    expect_true(
+        pars.get<String>("_type") == utils::type_name<T>(),
+        fmt::format("Mismatch in the type of object ({}) and parameters used for construction ({})",
+                    utils::demangle(utils::type_name<T>()),
+                    utils::demangle(pars.get<String>("_type"))),
+        loc);
     pars.set<Ref<DiscreteProblemInterface>>("_dpi", ref(*this));
     auto obj = Qtr<T>::alloc(pars);
     auto ptr = obj.get();
@@ -526,15 +534,21 @@ DiscreteProblemInterface::add_boundary_condition(Parameters & pars)
 
 template <InitialConditionDerived T>
 Ref<T>
-DiscreteProblemInterface::add_initial_condition(Parameters & pars)
+DiscreteProblemInterface::add_initial_condition(Parameters & pars, std::source_location loc)
 {
-    CALL_STACK_MSG();
+    expect_true(
+        pars.get<String>("_type") == utils::type_name<T>(),
+        fmt::format("Mismatch in the type of object ({}) and parameters used for construction ({})",
+                    utils::demangle(utils::type_name<T>()),
+                    utils::demangle(pars.get<String>("_type"))),
+        loc);
     pars.set<Ref<DiscreteProblemInterface>>("_dpi", ref(*this));
     auto obj = Qtr<T>::alloc(pars);
     auto name = obj->get_name();
     auto it = this->ics_by_name.find(name);
     expect_true(it == this->ics_by_name.end(),
-                fmt::format("Cannot add initial condition object '{}'. Name already taken.", name));
+                fmt::format("Cannot add initial condition object '{}'. Name already taken.", name),
+                loc);
     auto ic = obj.get();
     this->ics_by_name.emplace(name, Ref<InitialCondition>(*ic));
     this->all_ics.push_back(std::move(obj));
@@ -543,15 +557,21 @@ DiscreteProblemInterface::add_initial_condition(Parameters & pars)
 
 template <AuxiliaryFieldDerived T>
 Ref<T>
-DiscreteProblemInterface::add_auxiliary_field(Parameters & pars)
+DiscreteProblemInterface::add_auxiliary_field(Parameters & pars, std::source_location loc)
 {
-    CALL_STACK_MSG();
+    expect_true(
+        pars.get<String>("_type") == utils::type_name<T>(),
+        fmt::format("Mismatch in the type of object ({}) and parameters used for construction ({})",
+                    utils::demangle(utils::type_name<T>()),
+                    utils::demangle(pars.get<String>("_type"))),
+        loc);
     pars.set<Ref<DiscreteProblemInterface>>("_dpi", ref(*this));
     auto obj = Qtr<T>::alloc(pars);
     auto name = obj->get_name();
     auto it = this->auxs_by_name.find(name);
     expect_true(it == this->auxs_by_name.end(),
-                fmt::format("Cannot add auxiliary object '{}'. Name already taken.", name));
+                fmt::format("Cannot add auxiliary object '{}'. Name already taken.", name),
+                loc);
     auto aux = obj.get();
     this->auxs_by_name.emplace(name, Ref<AuxiliaryField>(*aux));
     this->auxs.push_back(std::move(obj));

--- a/include/godzilla/FVProblemInterface.h
+++ b/include/godzilla/FVProblemInterface.h
@@ -77,7 +77,8 @@ public:
     ///
     /// @param bc Boundary condition object parameters to add/create
     template <NaturalRiemannBCDerived OBJECT>
-    Ref<OBJECT> add_boundary_condition(Parameters & pars);
+    Ref<OBJECT> add_boundary_condition(Parameters & pars,
+                                       std::source_location loc = std::source_location::current());
 
 protected:
     void init() override;
@@ -178,9 +179,14 @@ private:
 
 template <NaturalRiemannBCDerived T>
 Ref<T>
-FVProblemInterface::add_boundary_condition(Parameters & pars)
+FVProblemInterface::add_boundary_condition(Parameters & pars, std::source_location loc)
 {
-    CALL_STACK_MSG();
+    expect_true(
+        pars.get<String>("_type") == utils::type_name<T>(),
+        fmt::format("Mismatch in the type of object ({}) and parameters used for construction ({})",
+                    utils::demangle(utils::type_name<T>()),
+                    utils::demangle(pars.get<String>("_type"))),
+        loc);
     pars.set<Ref<DiscreteProblemInterface>>("_dpi", ref(*this));
     auto obj = Qtr<T>::alloc(pars);
     auto ptr = obj.get();

--- a/include/godzilla/Problem.h
+++ b/include/godzilla/Problem.h
@@ -81,14 +81,16 @@ public:
     /// @param pars Parameters used to construct the Output object
     /// @return Built Output object
     template <OutputDerived T>
-    Ref<T> add_output(Parameters & pars);
+    Ref<T> add_output(Parameters & pars,
+                      std::source_location loc = std::source_location::current());
 
     /// Add a postprocessor object
     ///
     /// @param pars Postprocessor object parameters
     /// @return Newly created postprocessor
     template <PostprocessorDerived T>
-    Ref<T> add_postprocessor(Parameters & pars);
+    Ref<T> add_postprocessor(Parameters & pars,
+                             std::source_location loc = std::source_location::current());
 
     /// Get postprocessor by name
     ///
@@ -364,9 +366,14 @@ public:
 
 template <OutputDerived T>
 Ref<T>
-Problem::add_output(Parameters & pars)
+Problem::add_output(Parameters & pars, std::source_location loc)
 {
-    CALL_STACK_MSG();
+    expect_true(
+        pars.get<String>("_type") == utils::type_name<T>(),
+        fmt::format("Mismatch in the type of object ({}) and parameters used for construction ({})",
+                    utils::demangle(utils::type_name<T>()),
+                    utils::demangle(pars.get<String>("_type"))),
+        loc);
     pars.set<Ref<Problem>>("_problem", ref(*this));
     if (!pars.is_param_valid("on")) {
         pars.set<ExecuteOnFlags>("on", default_execute_on<T>());
@@ -383,9 +390,14 @@ Problem::add_output(Parameters & pars)
 
 template <PostprocessorDerived T>
 Ref<T>
-Problem::add_postprocessor(Parameters & pars)
+Problem::add_postprocessor(Parameters & pars, std::source_location loc)
 {
-    CALL_STACK_MSG();
+    expect_true(
+        pars.get<String>("_type") == utils::type_name<T>(),
+        fmt::format("Mismatch in the type of object ({}) and parameters used for construction ({})",
+                    utils::demangle(utils::type_name<T>()),
+                    utils::demangle(pars.get<String>("_type"))),
+        loc);
     pars.set<Ref<Problem>>("_problem", ref(*this));
     if (!pars.is_param_valid("on")) {
         pars.set<ExecuteOnFlags>("on", default_execute_on<T>());
@@ -395,7 +407,8 @@ Problem::add_postprocessor(Parameters & pars)
     auto pp = obj.get();
     auto name = pp->get_name();
     expect_true(this->pps.count(name) == 0,
-                fmt::format("Postprocessors with name '{}' already exists.", name));
+                fmt::format("Postprocessors with name '{}' already exists.", name),
+                loc);
     this->pps_names.push_back(name);
     this->pps[name] = std::move(obj);
     return Ref<T>(*pp);

--- a/test/src/AuxiliaryField_test.cpp
+++ b/test/src/AuxiliaryField_test.cpp
@@ -49,8 +49,8 @@ TEST_F(AuxiliaryFieldTest, api)
 
     prob->set_aux_field(FieldID(0), "fld", 1, Order(1));
 
-    auto params = AuxiliaryField::parameters();
-    params.set<Ref<App>>("app", ref(*app)).set<String>("name", "aux").set<String>("field", "fld");
+    auto params = this->app->make_parameters<TestAuxFld>();
+    params.set<String>("name", "aux").set<String>("field", "fld");
     auto aux = prob->add_auxiliary_field<TestAuxFld>(params);
     prob->create();
 
@@ -87,8 +87,7 @@ TEST_F(AuxiliaryFieldTest, non_existent_field)
 
     prob->set_aux_field(FieldID(0), "aux1", 1, Order(1));
 
-    auto params = AuxiliaryField::parameters();
-    params.set<Ref<App>>("app", ref(*app));
+    auto params = this->app->make_parameters<TestAuxFld>();
     params.set<String>("name", "aux");
     prob->add_auxiliary_field<TestAuxFld>(params);
 
@@ -115,8 +114,7 @@ TEST_F(AuxiliaryFieldTest, inconsistent_comp_number)
 
     prob->set_aux_field(FieldID(0), "aux", 1, Order(1));
 
-    auto params = AuxiliaryField::parameters();
-    params.set<Ref<App>>("app", ref(*app));
+    auto params = this->app->make_parameters<TestAuxFld>();
     params.set<String>("name", "aux");
     prob->add_auxiliary_field<TestAuxFld>(params);
 
@@ -145,8 +143,8 @@ TEST_F(AuxiliaryFieldTest, non_existent_region)
 
     prob->set_aux_field(FieldID(0), "aux", 1, Order(1));
 
-    auto params = AuxiliaryField::parameters();
-    params.set<Ref<App>>("app", ref(*app)).set<String>("name", "aux").set<String>("region", "asdf");
+    auto params = this->app->make_parameters<TestAuxFld>();
+    params.set<String>("name", "aux").set<String>("region", "asdf");
     prob->add_auxiliary_field<TestAuxFld>(params);
 
     EXPECT_DEATH(prob->create(), "Region 'asdf' does not exists. Typo?");
@@ -158,10 +156,8 @@ TEST_F(AuxiliaryFieldTest, name_already_taken)
 
     prob->set_aux_field(FieldID(0), "fld", 1, Order(1));
 
-    auto params = ConstantAuxiliaryField::parameters();
-    params.set<Ref<App>>("app", ref(*app))
-        .set<String>("name", "aux")
-        .set<std::vector<Real>>("value", { 1 });
+    auto params = this->app->make_parameters<ConstantAuxiliaryField>();
+    params.set<String>("name", "aux").set<std::vector<Real>>("value", { 1 });
     prob->add_auxiliary_field<ConstantAuxiliaryField>(params);
 
     EXPECT_DEATH(prob->add_auxiliary_field<ConstantAuxiliaryField>(params),
@@ -189,8 +185,8 @@ TEST_F(AuxiliaryFieldTest, get_value)
 
     prob->set_aux_field(FieldID(0), "aux", 1, Order(1));
 
-    auto params = AuxiliaryField::parameters();
-    params.set<Ref<App>>("app", ref(*app)).set<String>("name", "aux");
+    auto params = this->app->make_parameters<TestAuxFld>();
+    params.set<String>("name", "aux");
     auto aux = prob->add_auxiliary_field<TestAuxFld>(params);
 
     prob->create();
@@ -223,8 +219,8 @@ TEST_F(AuxiliaryFieldTest, get_vector_value)
 
     prob->set_aux_field(FieldID(0), "aux", 3, Order(1));
 
-    auto params = AuxiliaryField::parameters();
-    params.set<Ref<App>>("app", ref(*app)).set<String>("name", "aux");
+    auto params = this->app->make_parameters<TestAuxFld>();
+    params.set<String>("name", "aux");
     auto aux = prob->add_auxiliary_field<TestAuxFld>(params);
 
     prob->create();

--- a/test/src/CSVOutput_test.cpp
+++ b/test/src/CSVOutput_test.cpp
@@ -42,7 +42,7 @@ TEST_F(CSVOutputTest, create)
 {
     auto prob = this->app->get_problem<GTestFENonlinearProblem>();
 
-    auto params = this->app->make_parameters<CSVOutput>();
+    auto params = this->app->make_parameters<TestCSVOutput>();
     params.set<fs::path>("file", "asdf");
     auto out = prob->add_output<TestCSVOutput>(params);
 
@@ -73,7 +73,7 @@ TEST_F(CSVOutputTest, output)
     pp_params.set<String>("name", "pp");
     prob->add_postprocessor<TestPostprocessor>(pp_params);
 
-    auto params = this->app->make_parameters<CSVOutput>();
+    auto params = this->app->make_parameters<TestCSVOutput>();
     params.set<fs::path>("file", "out");
     auto out = prob->add_output<TestCSVOutput>(params);
 

--- a/test/src/ConstantAuxiliaryField_test.cpp
+++ b/test/src/ConstantAuxiliaryField_test.cpp
@@ -23,9 +23,8 @@ TEST(ConstantAuxiliaryFieldTest, create)
     GTestFENonlinearProblem prob(prob_params);
 
     prob.set_aux_field(FieldID(0), "aux1", 1, Order(1));
-    auto aux_params = ConstantAuxiliaryField::parameters();
-    aux_params.set<Ref<App>>("app", ref(app))
-        .set<String>("name", "aux1")
+    auto aux_params = app.make_parameters<ConstantAuxiliaryField>();
+    aux_params.set<String>("name", "aux1")
         .set<Ref<DiscreteProblemInterface>>("_dpi", ref(prob))
         .set<std::vector<Real>>("value", { 1234 });
     auto aux = prob.add_auxiliary_field<ConstantAuxiliaryField>(aux_params);

--- a/test/src/ExodusIIOutput_test.cpp
+++ b/test/src/ExodusIIOutput_test.cpp
@@ -47,8 +47,7 @@ TEST(ExodusIIOutputTest, create)
     prob_pars.set<Ref<Mesh>>("mesh", ref(*mesh));
     GTestFENonlinearProblem prob(prob_pars);
 
-    auto params = ExodusIIOutput::parameters();
-    params.set<Ref<App>>("app", ref(app));
+    auto params = app.make_parameters<ExodusIIOutput>();
     params.set<fs::path>("file", "out");
     auto out = prob.add_output<ExodusIIOutput>(params);
 
@@ -69,8 +68,7 @@ TEST(ExodusIIOutputTest, non_existent_var)
     prob_pars.set<Ref<Mesh>>("mesh", ref(*mesh));
     GTestFENonlinearProblem prob(prob_pars);
 
-    auto params = ExodusIIOutput::parameters();
-    params.set<Ref<App>>("app", ref(app));
+    auto params = app.make_parameters<ExodusIIOutput>();
     params.set<fs::path>("file", "out");
     params.set<std::vector<String>>("variables", { "asdf" });
     prob.add_output<ExodusIIOutput>(params);
@@ -93,8 +91,7 @@ TEST(ExodusIIOutputTest, output)
     prob_pars.set<Ref<Mesh>>("mesh", ref(*mesh));
     GTestFENonlinearProblem prob(prob_pars);
 
-    auto params = ExodusIIOutput::parameters();
-    params.set<Ref<App>>("app", ref(app));
+    auto params = app.make_parameters<ExodusIIOutput>();
     params.set<fs::path>("file", "out");
     auto out = prob.add_output<ExodusIIOutput>(params);
 
@@ -117,8 +114,8 @@ TEST(ExodusIIOutputTest, set_file_name)
     prob_pars.set<Ref<Mesh>>("mesh", ref(*mesh));
     GTestFENonlinearProblem prob(prob_pars);
 
-    auto params = ExodusIIOutput::parameters();
-    params.set<Ref<App>>("app", ref(app)).set<fs::path>("file", "out");
+    auto params = app.make_parameters<ExodusIIOutput>();
+    params.set<fs::path>("file", "out");
     auto out = prob.add_output<ExodusIIOutput>(params);
 
     out->create();
@@ -140,8 +137,8 @@ TEST(ExodusIIOutputTest, set_seq_file_name)
     prob_pars.set<Ref<Mesh>>("mesh", ref(*mesh));
     GTestFENonlinearProblem prob(prob_pars);
 
-    auto params = ExodusIIOutput::parameters();
-    params.set<Ref<App>>("app", ref(app)).set<fs::path>("file", "out");
+    auto params = app.make_parameters<ExodusIIOutput>();
+    params.set<fs::path>("file", "out");
     auto out = prob.add_output<ExodusIIOutput>(params);
 
     out->create();

--- a/test/src/FENonlinearProblemJFNK_test.cpp
+++ b/test/src/FENonlinearProblemJFNK_test.cpp
@@ -146,15 +146,12 @@ TEST(FENonlinearProblemJFNKTest, solve)
     prob_params.set<Ref<Mesh>>("mesh", ref(*mesh));
     auto prob = app.make_problem<GTestFENonlinearProblemJFNK>(prob_params);
 
-    auto ic_params = ConstantInitialCondition::parameters();
-    ic_params.set<Ref<godzilla::App>>("app", ref(app));
+    auto ic_params = app.make_parameters<ConstantInitialCondition>();
     ic_params.set<std::vector<Real>>("value", { 0.1 });
     prob->add_initial_condition<ConstantInitialCondition>(ic_params);
 
-    auto bc_params = DirichletBC::parameters();
-    bc_params.set<Ref<godzilla::App>>("app", ref(app))
-        .set<Ref<App>>("app", ref(app))
-        .set<std::vector<String>>("boundary", { "left", "right" });
+    auto bc_params = app.make_parameters<DirichletBC>();
+    bc_params.set<std::vector<String>>("boundary", { "left", "right" });
     prob->add_boundary_condition<DirichletBC>(bc_params);
 
     prob->create();

--- a/test/src/FENonlinearProblem_test.cpp
+++ b/test/src/FENonlinearProblem_test.cpp
@@ -166,8 +166,7 @@ TEST_F(FENonlinearProblemTest, set_up_initial_guess)
 {
     auto prob = this->app->get_problem<GTestFENonlinearProblem>();
 
-    auto ic_pars = ConstantInitialCondition::parameters();
-    ic_pars.set<Ref<App>>("app", ref(*app));
+    auto ic_pars = this->app->make_parameters<ConstantInitialCondition>();
     ic_pars.set<std::vector<Real>>("value", { 0 });
     prob->add_initial_condition<ConstantInitialCondition>(ic_pars);
 
@@ -198,13 +197,11 @@ TEST_F(FENonlinearProblemTest, solve)
 {
     auto prob = this->app->get_problem<GTestFENonlinearProblem>();
 
-    auto ic_pars = ConstantInitialCondition::parameters();
-    ic_pars.set<Ref<App>>("app", ref(*this->app));
+    auto ic_pars = this->app->make_parameters<ConstantInitialCondition>();
     ic_pars.set<std::vector<Real>>("value", { 0.1 });
     prob->add_initial_condition<ConstantInitialCondition>(ic_pars);
 
-    auto params = DirichletBC::parameters();
-    params.set<Ref<App>>("app", ref(*this->app));
+    auto params = this->app->make_parameters<DirichletBC>();
     params.set<std::vector<String>>("boundary", { "left", "right" });
     auto bc = prob->add_boundary_condition<DirichletBC>(params);
     prob->create();
@@ -230,8 +227,7 @@ TEST_F(FENonlinearProblemTest, solve_no_ic)
 {
     auto prob = this->app->get_problem<GTestFENonlinearProblem>();
 
-    auto params = DirichletBC::parameters();
-    params.set<Ref<App>>("app", ref(*this->app));
+    auto params = this->app->make_parameters<DirichletBC>();
     params.set<std::vector<String>>("boundary", { "left" });
     prob->add_boundary_condition<DirichletBC>(params);
     prob->create();
@@ -244,9 +240,8 @@ TEST_F(FENonlinearProblemTest, err_ic_comp_mismatch)
 {
     auto prob = this->app->get_problem<GTestFENonlinearProblem>();
 
-    auto params = GTest2CompIC::parameters();
+    auto params = this->app->make_parameters<GTest2CompIC>();
     params.set<String>("name", "ic");
-    params.set<Ref<App>>("app", ref(*this->app));
     prob->add_initial_condition<GTest2CompIC>(params);
 
     EXPECT_DEATH(prob->create(),
@@ -268,16 +263,14 @@ TEST(TwoFieldFENonlinearProblemTest, err_duplicate_ics)
     prob_params.set<Ref<Mesh>>("mesh", ref(*mesh));
     GTest2FieldsFENonlinearProblem prob(prob_params);
 
-    auto ic1_params = ConstantInitialCondition::parameters();
+    auto ic1_params = app.make_parameters<ConstantInitialCondition>();
     ic1_params.set<String>("name", "ic1")
-        .set<Ref<App>>("app", ref(app))
         .set<String>("field", "u")
         .set<std::vector<Real>>("value", { 0.1 });
     prob.add_initial_condition<ConstantInitialCondition>(ic1_params);
 
-    auto ic2_params = ConstantInitialCondition::parameters();
+    auto ic2_params = app.make_parameters<ConstantInitialCondition>();
     ic2_params.set<String>("name", "ic2")
-        .set<Ref<App>>("app", ref(app))
         .set<String>("field", "u")
         .set<std::vector<Real>>("value", { 0.2 });
     prob.add_initial_condition<ConstantInitialCondition>(ic2_params);
@@ -296,13 +289,11 @@ TEST(TwoFieldFENonlinearProblemTest, err_not_enough_ics)
     mesh_pars.set<Int>("nx", 2);
     auto mesh = MeshFactory::create<LineMesh>(mesh_pars);
 
-    auto prob_params = GTest2FieldsFENonlinearProblem::parameters();
-    prob_params.set<Ref<App>>("app", ref(app));
+    auto prob_params = app.make_parameters<GTest2FieldsFENonlinearProblem>();
     prob_params.set<Ref<Mesh>>("mesh", ref(*mesh));
     GTest2FieldsFENonlinearProblem prob(prob_params);
 
-    auto ic_params = ConstantInitialCondition::parameters();
-    ic_params.set<Ref<App>>("app", ref(app));
+    auto ic_params = app.make_parameters<ConstantInitialCondition>();
     ic_params.set<String>("name", "ic1");
     ic_params.set<std::vector<Real>>("value", { 0.1 });
     ic_params.set<String>("field", "u");
@@ -315,9 +306,8 @@ TEST_F(FENonlinearProblemTest, err_nonexisting_bc_bnd)
 {
     auto prob = this->app->get_problem<GTestFENonlinearProblem>();
 
-    auto params = DirichletBC::parameters();
+    auto params = this->app->make_parameters<DirichletBC>();
     params.set<String>("name", "bc1");
-    params.set<Ref<App>>("app", ref(*this->app));
     params.set<std::vector<String>>("boundary", { "asdf" });
     prob->add_boundary_condition<DirichletBC>(params);
 
@@ -335,8 +325,7 @@ TEST(TwoFieldFENonlinearProblemTest, field_decomposition)
     mesh_pars.set<Int>("nx", 2);
     auto mesh = MeshFactory::create<LineMesh>(mesh_pars);
 
-    auto prob_params = GTest2FieldsFENonlinearProblem::parameters();
-    prob_params.set<Ref<App>>("app", ref(app));
+    auto prob_params = app.make_parameters<GTest2FieldsFENonlinearProblem>();
     prob_params.set<Ref<Mesh>>("mesh", ref(*mesh));
     GTest2FieldsFENonlinearProblem prob(prob_params);
 
@@ -369,8 +358,7 @@ TEST_F(FENonlinearProblemTest, steady_state_output)
 {
     auto prob = this->app->get_problem<GTestFENonlinearProblem>();
 
-    auto params = DirichletBC::parameters();
-    params.set<Ref<App>>("app", ref(*this->app));
+    auto params = this->app->make_parameters<DirichletBC>();
     params.set<std::vector<String>>("boundary", { "left", "right" });
     prob->add_boundary_condition<DirichletBC>(params);
 

--- a/test/src/ImplicitFENonlinearProblem_test.cpp
+++ b/test/src/ImplicitFENonlinearProblem_test.cpp
@@ -28,14 +28,12 @@ TEST_F(ImplicitFENonlinearProblemTest, run)
 {
     auto prob = this->app->get_problem<GTestImplicitFENonlinearProblem>();
 
-    auto ic_params = ConstantInitialCondition::parameters();
-    ic_params.set<Ref<godzilla::App>>("app", ref(*this->app));
+    auto ic_params = this->app->make_parameters<ConstantInitialCondition>();
     ic_params.set<String>("name", "ic");
     ic_params.set<std::vector<Real>>("value", { 0 });
     prob->add_initial_condition<ConstantInitialCondition>(ic_params);
 
-    auto bc_params = DirichletBC::parameters();
-    bc_params.set<Ref<godzilla::App>>("app", ref(*this->app));
+    auto bc_params = this->app->make_parameters<DirichletBC>();
     bc_params.set<std::vector<String>>("boundary", { "left", "right" });
     prob->add_boundary_condition<DirichletBC>(bc_params);
 
@@ -115,14 +113,12 @@ TEST_F(ImplicitFENonlinearProblemTest, set_schemes)
 {
     auto prob = this->app->get_problem<GTestImplicitFENonlinearProblem>();
 
-    auto ic_params = ConstantInitialCondition::parameters();
-    ic_params.set<Ref<godzilla::App>>("app", ref(*this->app));
+    auto ic_params = this->app->make_parameters<ConstantInitialCondition>();
     ic_params.set<String>("name", "ic");
     ic_params.set<std::vector<Real>>("value", { 0 });
     prob->add_initial_condition<ConstantInitialCondition>(ic_params);
 
-    auto bc_params = DirichletBC::parameters();
-    bc_params.set<Ref<godzilla::App>>("app", ref(*this->app));
+    auto bc_params = this->app->make_parameters<DirichletBC>();
     bc_params.set<std::vector<String>>("boundary", { "left", "right" });
     prob->add_boundary_condition<DirichletBC>(bc_params);
 
@@ -143,14 +139,12 @@ TEST_F(ImplicitFENonlinearProblemTest, converged_reason)
 {
     auto prob = this->app->get_problem<GTestImplicitFENonlinearProblem>();
 
-    auto ic_params = ConstantInitialCondition::parameters();
-    ic_params.set<Ref<godzilla::App>>("app", ref(*this->app));
+    auto ic_params = this->app->make_parameters<ConstantInitialCondition>();
     ic_params.set<String>("name", "ic");
     ic_params.set<std::vector<Real>>("value", { 0 });
     prob->add_initial_condition<ConstantInitialCondition>(ic_params);
 
-    auto bc_params = DirichletBC::parameters();
-    bc_params.set<Ref<godzilla::App>>("app", ref(*this->app));
+    auto bc_params = this->app->make_parameters<DirichletBC>();
     bc_params.set<std::vector<String>>("boundary", { "left", "right" });
     prob->add_boundary_condition<DirichletBC>(bc_params);
 

--- a/test/src/InitialCondition_test.cpp
+++ b/test/src/InitialCondition_test.cpp
@@ -81,14 +81,12 @@ TEST_F(InitialConditionTest, test)
 
     prob->add_aux_field("a", 1, Order(1));
 
-    auto params = InitialCondition::parameters();
-    params.set<Ref<App>>("app", ref(*this->app));
+    auto params = this->app->make_parameters<MockInitialCondition>();
     params.set<String>("name", "obj");
     params.set<String>("field", "u");
     auto ic = prob->add_initial_condition<MockInitialCondition>(params);
 
-    auto aux_ic_pars = InitialCondition::parameters();
-    aux_ic_pars.set<Ref<App>>("app", ref(*this->app));
+    auto aux_ic_pars = this->app->make_parameters<MockInitialCondition>();
     aux_ic_pars.set<String>("name", "a_ic");
     aux_ic_pars.set<String>("field", "a");
     auto aux_ic = prob->add_initial_condition<MockInitialCondition>(aux_ic_pars);
@@ -149,8 +147,7 @@ TEST_F(InitialConditionTest, duplicate_ic_name)
 {
     auto prob = this->app->get_problem<GTestFENonlinearProblem>();
 
-    auto params = TestInitialCondition::parameters();
-    params.set<Ref<App>>("app", ref(*this->app));
+    auto params = this->app->make_parameters<TestInitialCondition>();
     params.set<String>("name", "obj");
 
     prob->add_initial_condition<TestInitialCondition>(params);
@@ -163,8 +160,7 @@ TEST_F(InitialConditionTest, constant_ic)
 {
     auto prob = this->app->get_problem<GTestFENonlinearProblem>();
 
-    auto params = ConstantInitialCondition::parameters();
-    params.set<Ref<App>>("app", ref(*this->app));
+    auto params = this->app->make_parameters<ConstantInitialCondition>();
     params.set<std::vector<Real>>("value", { 5 });
     auto ic = prob->add_initial_condition<ConstantInitialCondition>(params);
     prob->create();
@@ -183,8 +179,7 @@ TEST_F(InitialCondition2FieldTest, no_field_param)
 {
     auto prob = this->app->get_problem<GTestFENonlinearProblem>();
 
-    auto params = InitialCondition::parameters();
-    params.set<Ref<App>>("app", ref(*this->app));
+    auto params = this->app->make_parameters<MockInitialCondition>();
     params.set<String>("name", "obj");
     prob->add_initial_condition<MockInitialCondition>(params);
 
@@ -195,8 +190,7 @@ TEST_F(InitialCondition2FieldTest, non_existing_field)
 {
     auto prob = this->app->get_problem<GTestFENonlinearProblem>();
 
-    auto params = InitialCondition::parameters();
-    params.set<Ref<App>>("app", ref(*this->app));
+    auto params = this->app->make_parameters<MockInitialCondition>();
     params.set<String>("name", "obj");
     params.set<String>("field", "asdf");
     prob->add_initial_condition<MockInitialCondition>(params);

--- a/test/src/L2Diff_test.cpp
+++ b/test/src/L2Diff_test.cpp
@@ -46,18 +46,15 @@ TEST(L2DiffTest, compute)
     prob_params.set<Ref<Mesh>>("mesh", ref(*mesh));
     auto prob = app.make_problem<GTestFENonlinearProblem>(prob_params);
 
-    auto bc_left_params = DirichletBC::parameters();
-    bc_left_params.set<Ref<App>>("app", ref(app));
+    auto bc_left_params = app.make_parameters<DirichletBC>();
     bc_left_params.set<std::vector<String>>("boundary", { "left" });
     prob->add_boundary_condition<DirichletBC>(bc_left_params);
 
-    auto bc_right_params = DirichletBC::parameters();
-    bc_right_params.set<Ref<App>>("app", ref(app));
+    auto bc_right_params = app.make_parameters<DirichletBC>();
     bc_right_params.set<std::vector<String>>("boundary", { "right" });
     prob->add_boundary_condition<DirichletBC>(bc_right_params);
 
-    auto ps_params = L2Error::parameters();
-    ps_params.set<Ref<App>>("app", ref(app));
+    auto ps_params = app.make_parameters<L2Error>();
     ps_params.set<String>("name", "l2err");
     auto ps = prob->add_postprocessor<L2Error>(ps_params);
 

--- a/test/src/LinearProblem_test.cpp
+++ b/test/src/LinearProblem_test.cpp
@@ -99,8 +99,7 @@ TEST(LinearProblemTest, restart_file)
     prob_pars.set<String>("ksp_type", KSPCG);
     CustomLinearProblem prob(prob_pars);
 
-    auto ro_pars = RestartOutput::parameters();
-    ro_pars.set<Ref<App>>("app", ref(app));
+    auto ro_pars = app.make_parameters<RestartOutput>();
     ro_pars.set<fs::path>("file", "lp");
     prob.add_output<RestartOutput>(ro_pars);
 

--- a/test/src/MeshPartitioningOutput_test.cpp
+++ b/test/src/MeshPartitioningOutput_test.cpp
@@ -77,8 +77,7 @@ TEST(MeshPartitioningOutputTest, output)
     prob_params.set<Ref<Mesh>>("mesh", ref(*mesh));
     TestProblem prob(prob_params);
 
-    auto params = MeshPartitioningOutput::parameters();
-    params.set<Ref<App>>("app", ref(app));
+    auto params = app.make_parameters<MeshPartitioningOutput>();
     params.set<fs::path>("file", "part");
     auto out = prob.add_output<MeshPartitioningOutput>(params);
 

--- a/test/src/NaturalBC_test.cpp
+++ b/test/src/NaturalBC_test.cpp
@@ -113,8 +113,7 @@ TEST(NaturalBCTest, fe)
     prob_params.set<Ref<Mesh>>("mesh", ref(*mesh));
     auto prob = app.make_problem<GTest2FieldsFENonlinearProblem>(prob_params);
 
-    auto bc_params = TestNaturalBC::parameters();
-    bc_params.set<Ref<App>>("app", ref(app));
+    auto bc_params = app.make_parameters<TestNaturalBC>();
     bc_params.set<String>("name", "bc1");
     bc_params.set<std::vector<String>>("boundary", { "left" });
     bc_params.set<String>("field", "u");
@@ -156,8 +155,7 @@ TEST(NaturalBCTest, non_existing_field)
     prob_pars.set<Ref<Mesh>>("mesh", ref(*mesh));
     auto problem = app.make_problem<GTest2FieldsFENonlinearProblem>(prob_pars);
 
-    auto params = TestNaturalBC::parameters();
-    params.set<Ref<App>>("app", ref(app));
+    auto params = app.make_parameters<TestNaturalBC>();
     params.set<std::vector<String>>("boundary", { "left" });
     params.set<String>("field", "asdf");
     problem->add_boundary_condition<TestNaturalBC>(params);

--- a/test/src/NaturalRiemannBC_test.cpp
+++ b/test/src/NaturalRiemannBC_test.cpp
@@ -81,8 +81,7 @@ TEST(NaturalRiemannBCTest, api)
     prob_pars.set<Real>("dt", 1e-3);
     auto prob = app.make_problem<TestExplicitFVLinearProblem>(prob_pars);
 
-    auto bc_pars = TestBC::parameters();
-    bc_pars.set<Ref<App>>("app", ref(app));
+    auto bc_pars = app.make_parameters<TestBC>();
     bc_pars.set<std::vector<String>>("boundary", { "left" });
     prob->add_boundary_condition<TestBC>(bc_pars);
 

--- a/test/src/NeumannProblem_test.cpp
+++ b/test/src/NeumannProblem_test.cpp
@@ -172,14 +172,12 @@ TEST(NeumannProblemTest, solve)
     prob_params.set<Ref<Mesh>>("mesh", ref(*mesh));
     auto prob = app.make_problem<TestNeumannProblem>(prob_params);
 
-    auto bc_left_pars = TestNeumannBC::parameters();
-    bc_left_pars.set<Ref<App>>("app", ref(app));
+    auto bc_left_pars = app.make_parameters<TestNeumannBC>();
     bc_left_pars.set<String>("name", "bc1");
     bc_left_pars.set<std::vector<String>>("boundary", { "left" });
     prob->add_boundary_condition<TestNeumannBC>(bc_left_pars);
 
-    auto bc_right_pars = TestNeumannBC::parameters();
-    bc_right_pars.set<Ref<App>>("app", ref(app));
+    auto bc_right_pars = app.make_parameters<TestNeumannBC>();
     bc_right_pars.set<String>("name", "bc2");
     bc_right_pars.set<std::vector<String>>("boundary", { "right" });
     prob->add_boundary_condition<TestNeumannBC>(bc_right_pars);

--- a/test/src/NonlinearProblem_test.cpp
+++ b/test/src/NonlinearProblem_test.cpp
@@ -270,8 +270,7 @@ TEST(NonlinearProblemTest, restart_file)
     prob_pars.set<Ref<Mesh>>("mesh", ref(*mesh));
     G1DTestNonlinearProblem prob(prob_pars);
 
-    auto ro_pars = RestartOutput::parameters();
-    ro_pars.set<Ref<App>>("app", ref(app));
+    auto ro_pars = app.make_parameters<RestartOutput>();
     ro_pars.set<fs::path>("file", "nl");
     prob.add_output<RestartOutput>(ro_pars);
 

--- a/test/src/Output_test.cpp
+++ b/test/src/Output_test.cpp
@@ -131,8 +131,7 @@ TEST_F(OutputTest, default_execute_on_mask)
 {
     auto prob = this->app->get_problem<GTestImplicitFENonlinearProblem>();
 
-    auto pars = Output::parameters();
-    pars.set<Ref<App>>("app", ref(*this->app));
+    auto pars = this->app->make_parameters<MockOutput>();
     pars.set<Ref<Problem>>("_problem", prob);
     auto out = prob->add_output<MockOutput>(pars);
 

--- a/test/src/Postprocessor_test.cpp
+++ b/test/src/Postprocessor_test.cpp
@@ -36,8 +36,7 @@ TEST_F(PostprocessorTest, exec_masks_1)
 {
     auto prob = this->app->get_problem<GTestImplicitFENonlinearProblem>();
 
-    auto pars = Postprocessor::parameters();
-    pars.set<Ref<App>>("app", ref(*this->app));
+    auto pars = this->app->make_parameters<MockPostprocessor>();
     pars.set<Ref<Problem>>("_problem", prob);
     pars.set<String>("name", "pps");
     pars.set<ExecuteOnFlags>("on", ExecuteOn::NONE);
@@ -52,8 +51,7 @@ TEST_F(PostprocessorTest, exec_masks_2)
 {
     auto prob = this->app->get_problem<GTestImplicitFENonlinearProblem>();
 
-    auto pars = Postprocessor::parameters();
-    pars.set<Ref<App>>("app", ref(*this->app));
+    auto pars = this->app->make_parameters<MockPostprocessor>();
     pars.set<Ref<Problem>>("_problem", prob);
     pars.set<String>("name", "pps");
     pars.set<ExecuteOnFlags>("on", ExecuteOn::FINAL);
@@ -69,8 +67,7 @@ TEST_F(PostprocessorTest, exec_masks_3)
 {
     auto prob = this->app->get_problem<GTestImplicitFENonlinearProblem>();
 
-    auto pars = Postprocessor::parameters();
-    pars.set<Ref<App>>("app", ref(*this->app));
+    auto pars = this->app->make_parameters<MockPostprocessor>();
     pars.set<Ref<Problem>>("_problem", prob);
     pars.set<String>("name", "pps");
     pars.set<ExecuteOnFlags>("on", ExecuteOn::FINAL | ExecuteOn::INITIAL | ExecuteOn::TIMESTEP);
@@ -93,8 +90,7 @@ TEST_F(PostprocessorTest, empty_on)
 {
     auto prob = this->app->get_problem<GTestImplicitFENonlinearProblem>();
 
-    auto pars = Postprocessor::parameters();
-    pars.set<Ref<App>>("app", ref(*app));
+    auto pars = this->app->make_parameters<MockPostprocessor>();
     pars.set<Ref<Problem>>("_problem", prob);
     pars.set<String>("name", "pps");
     pars.set<ExecuteOnFlags>("on", 0);
@@ -108,8 +104,7 @@ TEST_F(PostprocessorTest, none_plus_mask)
 {
     auto prob = this->app->get_problem<GTestImplicitFENonlinearProblem>();
 
-    auto pars = Postprocessor::parameters();
-    pars.set<Ref<App>>("app", ref(*this->app));
+    auto pars = this->app->make_parameters<MockPostprocessor>();
     pars.set<Ref<Problem>>("_problem", prob);
     pars.set<String>("name", "pps");
     pars.set<ExecuteOnFlags>("on", ExecuteOn::NONE | ExecuteOn::FINAL | ExecuteOn::TIMESTEP);
@@ -122,8 +117,7 @@ TEST_F(PostprocessorTest, default_execute_on_mask)
 {
     auto prob = this->app->get_problem<GTestImplicitFENonlinearProblem>();
 
-    auto pars = Postprocessor::parameters();
-    pars.set<Ref<App>>("app", ref(*this->app));
+    auto pars = this->app->make_parameters<MockPostprocessor>();
     pars.set<Ref<Problem>>("_problem", prob);
     pars.set<String>("name", "pps");
     auto pp = prob->add_postprocessor<MockPostprocessor>(pars);

--- a/test/src/TecplotOutput_test.cpp
+++ b/test/src/TecplotOutput_test.cpp
@@ -50,7 +50,7 @@ TEST(TecplotOutputTest, output)
     prob_pars.set<Ref<Mesh>>("mesh", ref(*mesh));
     GTestFENonlinearProblem prob(prob_pars);
 
-    auto params = TecplotOutput::parameters();
+    auto params = app.make_parameters<TecplotOutput>();
     params.set<Ref<App>>("app", ref(app));
     params.set<fs::path>("file", "out");
     auto out = prob.add_output<TecplotOutput>(params);
@@ -76,8 +76,7 @@ TEST(TecplotOutputTest, test)
     prob_pars.set<Ref<Mesh>>("mesh", ref(*mesh));
     GTestFENonlinearProblem prob(prob_pars);
 
-    auto params = TecplotOutput::parameters();
-    params.set<Ref<App>>("app", ref(app));
+    auto params = app.make_parameters<TecplotOutput>();
     params.set<fs::path>("file", "out");
 
     EXPECT_DEATH(prob.add_output<TecplotOutput>(params),

--- a/test/src/VTKOutput_test.cpp
+++ b/test/src/VTKOutput_test.cpp
@@ -48,8 +48,7 @@ TEST(VTKOutputTest, test)
     prob_pars.set<Ref<Mesh>>("mesh", ref(*mesh));
     TestProblem prob(prob_pars);
 
-    auto pars = VTKOutput::parameters();
-    pars.set<Ref<App>>("app", ref(app));
+    auto pars = app.make_parameters<VTKOutput>();
     pars.set<fs::path>("file", "file");
     auto out = prob.add_output<VTKOutput>(pars);
 

--- a/test/src/WeakForm_test.cpp
+++ b/test/src/WeakForm_test.cpp
@@ -91,8 +91,7 @@ TEST(WeakFormTest, test)
     prob_pars.set<Ref<Mesh>>("mesh", ref(*mesh));
     GTestFENonlinearProblem prob(prob_pars);
 
-    auto bc_pars = TestBC::parameters();
-    bc_pars.set<Ref<App>>("app", ref(app));
+    auto bc_pars = app.make_parameters<TestBC>();
     bc_pars.set<std::vector<String>>("boundary", { "left" });
     auto bc = prob.add_boundary_condition<TestBC>(bc_pars);
 


### PR DESCRIPTION
Object parameters that are created via `App::make_parameters` have
`_type` parameter set. It carries the type used in the `make_parameters`
call. When users call `add_XYZ` we check that the `_type` parameter
matches the type of the constructed object
