### PR TITLE
Removing deprecated API from `Assert.h`

### DIFF
--- a/include/godzilla/Assert.h
+++ b/include/godzilla/Assert.h
@@ -42,11 +42,6 @@ assert_true(bool cond,
 
 #else
 
-[[deprecated]] inline void
-assert_true(bool, fmt::string_view, std::source_location = std::source_location::current())
-{
-}
-
     #define GODZILLA_ASSERT_TRUE(cond, msg)
 
 #endif


### PR DESCRIPTION
Closes #1090 