### PR TITLE
Removing deprecated API from `Math`

### DIFF
--- a/include/godzilla/Math.h
+++ b/include/godzilla/Math.h
@@ -71,18 +71,6 @@ sign(T val)
     return (T(0) < val) - (val < T(0));
 }
 
-/// Square of the argument
-///
-/// @tparam T Type
-/// @param val Value to be squared
-/// @return Square of the value, i.e. `val * val`
-template <typename T>
-[[deprecated("Use math::pow<2>() instead")]] T
-sqr(T val)
-{
-    return val * val;
-}
-
 /// Compute the square root of a number.
 ///
 /// @param arg The number to compute the square root of.


### PR DESCRIPTION
Closes #1088 