### PR TITLE
Logger name uses App name

### DIFF
--- a/include/godzilla/Logger.h
+++ b/include/godzilla/Logger.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "godzilla/String.h"
 #include "spdlog/spdlog.h"
 #include "spdlog/details/periodic_worker.h"
 #include <filesystem>
@@ -15,6 +16,7 @@ namespace godzilla {
 class Logger {
 public:
     Logger();
+    Logger(String name);
     ~Logger();
 
     /// Set log file name
@@ -52,6 +54,7 @@ public:
     }
 
 private:
+    std::string logger_name;
     std::shared_ptr<spdlog::logger> spdlgr;
     std::mutex flusher_mutex;
     std::unique_ptr<spdlog::details::periodic_worker> periodic_flusher;

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -65,7 +65,7 @@ App::App(mpi::Communicator comm, Registry & registry, String name) :
     name(name),
     mpi_comm(comm),
     registry(registry),
-    logger(Qtr<Logger>::alloc()),
+    logger(Qtr<Logger>::alloc(name)),
     verbosity_level(1),
     cout_buf_(nullptr),
     cerr_buf_(nullptr),

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -8,23 +8,29 @@
 
 namespace godzilla {
 
-Logger::Logger()
+Logger::Logger() : logger_name("file_logger")
 {
     CALL_STACK_MSG();
-    this->spdlgr = spdlog::null_logger_mt("file_logger");
+    this->spdlgr = spdlog::null_logger_mt(this->logger_name);
+}
+
+Logger::Logger(String name) : logger_name(fmt::format("file_logger:{}", name))
+{
+    CALL_STACK_MSG();
+    this->spdlgr = spdlog::null_logger_mt(logger_name);
 }
 
 Logger::~Logger()
 {
-    spdlog::drop("file_logger");
+    spdlog::drop(this->logger_name);
 }
 
 void
 Logger::set_log_file_name(fs::path file_name)
 {
     CALL_STACK_MSG();
-    spdlog::drop("file_logger");
-    this->spdlgr = spdlog::basic_logger_mt("file_logger", file_name, true);
+    spdlog::drop(this->logger_name);
+    this->spdlgr = spdlog::basic_logger_mt(this->logger_name, file_name, true);
     this->spdlgr->set_pattern("[%Y %b %d %H:%M:%S.%e] [%l] %v");
 }
 


### PR DESCRIPTION
Logger name must be globally unique. Thus if we have multiple App instances, the construction would fail. Logger uses app name it its name to make it unique enough (as long as app names are unique).

This improves cooexistence of multiple App instances