### PR TITLE
FindPETSc.cmake: do not include compile flags

### DIFF
--- a/cmake/FindPETSc.cmake
+++ b/cmake/FindPETSc.cmake
@@ -59,7 +59,6 @@ if (PETSC_FOUND AND NOT TARGET PETSc::petsc)
     set_target_properties(PETSc::petsc
         PROPERTIES
             IMPORTED_LOCATION "${PETSC_LIBRARY}"
-            INTERFACE_COMPILE_OPTIONS "${PC_PETSC_CFLAGS_OTHER}"
             INTERFACE_INCLUDE_DIRECTORIES "${PETSC_INCLUDE_DIR}"
     )
 endif()


### PR DESCRIPTION
This can destroy the build of apps on macOS when something cheekily
includes compile flags that swaps the SDK version and then
we get no C++20 build
